### PR TITLE
remove unnecessary comments in pom.xml

### DIFF
--- a/Foundation/org.egovframe.rte.fdl.idgnr/pom.xml
+++ b/Foundation/org.egovframe.rte.fdl.idgnr/pom.xml
@@ -89,15 +89,6 @@
             <version>2.5.0</version>
             <scope>test</scope>
         </dependency>
-        <!-- for Table ID Generation Service -->
-        <!--
-        <dependency>
-            <groupId>ojdbc</groupId>
-            <artifactId>ojdbc</artifactId>
-            <version>14</version>
-            <scope>test</scope>
-        </dependency>
-        -->
     </dependencies>
 
     <build>


### PR DESCRIPTION
remove unnecessary comments in pom.xml

Unused code should be deleted and can be retrieved from source control history if required.