### PR TITLE
remove equals for comparing Object to null

### DIFF
--- a/Foundation/org.egovframe.rte.fdl.excel/src/main/java/org/egovframe/rte/fdl/excel/util/EgovExcelUtil.java
+++ b/Foundation/org.egovframe.rte.fdl.excel/src/main/java/org/egovframe/rte/fdl/excel/util/EgovExcelUtil.java
@@ -56,7 +56,7 @@ public final class EgovExcelUtil {
      */
     public static String getValue(Cell cell) {
         String result = "";
-        if (null == cell || cell.equals(null)) {
+        if (null == cell) {
             return "";
         }
 


### PR DESCRIPTION
Don't use equals method to compare for object which is null or not