### PR TITLE
불필요한 라이브러리 참조 제거

### DIFF
--- a/Persistence/org.egovframe.rte.psl.dataaccess/pom.xml
+++ b/Persistence/org.egovframe.rte.psl.dataaccess/pom.xml
@@ -60,12 +60,6 @@
                 </exclusion>
             </exclusions>
         </dependency>
-        <!-- org.egovframe.rte.psl.jdbc의 LobCreatorUtils 참조로 추가(v3.7 작업) -->
-        <dependency>
-            <groupId>javax</groupId>
-            <artifactId>javaee-api</artifactId>
-            <version>7.0</version>
-        </dependency>
         <!-- iBatis -->
         <dependency>
             <groupId>org.apache.ibatis</groupId>


### PR DESCRIPTION
Java EE 라이브러리는 포함된 클래스 범위가 대단히 넓은데 사용하지 않으면서 포함돼 있었습니다. 사용한다고 하더라도 JEE 컨테이너의 경우 기본적으로 가지고 있는 라이브러리이므로 충돌이 발생할 수도 있으므로 provided scope로 지정하거나 필요한 개별 라이브러리만 지정하면 충분했을 것입니다.