### PR TITLE
문자열 비교 시 대소문자 구분

### DIFF
--- a/Batch/org.egovframe.rte.bat.core/src/main/java/org/egovframe/rte/bat/core/item/file/EgovFlatFileByteReader.java
+++ b/Batch/org.egovframe.rte.bat.core/src/main/java/org/egovframe/rte/bat/core/item/file/EgovFlatFileByteReader.java
@@ -114,7 +114,7 @@ public class EgovFlatFileByteReader<T> extends AbstractItemCountingItemStreamIte
 	 * osType
 	 */
 	public void setOsType(String osType) {
-		if (!osType.toUpperCase().equals("WINDOWS")) {
+		if (!osType.equalsIgnoreCase("WINDOWS")) {
 			LINE_CRLF = UNIX_CRLF;
 		} else {
 			LINE_CRLF = WINDOWS_CRLF;


### PR DESCRIPTION
대/소문자 구분 시 UpperCase / LowerCase는 임시 중간 객체를 사용하므로,
equalsIgnoreCase 변경을 권장합니다.