### PR TITLE
Changed Require Annotation, Deprecated. as of 5.1, in favor of using …

### DIFF
--- a/Foundation/org.egovframe.rte.fdl.crypto/src/main/java/org/egovframe/rte/fdl/cryptography/EgovPasswordEncoder.java
+++ b/Foundation/org.egovframe.rte.fdl.crypto/src/main/java/org/egovframe/rte/fdl/cryptography/EgovPasswordEncoder.java
@@ -33,7 +33,7 @@
 package org.egovframe.rte.fdl.cryptography;
 
 import org.jasypt.util.password.ConfigurablePasswordEncryptor;
-import org.springframework.beans.factory.annotation.Required;
+import org.springframework.beans.factory.annotation.Autowired;
 
 public class EgovPasswordEncoder {
 
@@ -49,7 +49,7 @@ public class EgovPasswordEncoder {
 		this.algorithm = algorithm;
 	}
 
-	@Required
+	@Autowired(required=true)
 	public void setHashedPassword(String hashedPassword) {
 		this.hashedPassword = hashedPassword;
 	}

--- a/Foundation/org.egovframe.rte.fdl.crypto/src/main/java/org/egovframe/rte/fdl/cryptography/impl/EgovARIACryptoServiceImpl.java
+++ b/Foundation/org.egovframe.rte.fdl.crypto/src/main/java/org/egovframe/rte/fdl/cryptography/impl/EgovARIACryptoServiceImpl.java
@@ -22,7 +22,7 @@ import org.egovframe.rte.fdl.cryptography.EgovPasswordEncoder;
 import org.egovframe.rte.fdl.logging.util.EgovResourceReleaser;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Required;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.util.ReflectionUtils;
 
 import java.io.ByteArrayOutputStream;
@@ -41,7 +41,7 @@ public class EgovARIACryptoServiceImpl implements EgovARIACryptoService {
 	private EgovPasswordEncoder passwordEncoder;
 	private int blockSize = DEFAULT_BLOCKSIZE;
 
-	@Required
+	@Autowired(required=true)
 	public void setPasswordEncoder(EgovPasswordEncoder passwordEncoder) {
 		this.passwordEncoder = passwordEncoder;
 		LOGGER.debug("passwordEncoder's algorithm : {}", passwordEncoder.getAlgorithm());

--- a/Foundation/org.egovframe.rte.fdl.crypto/src/main/java/org/egovframe/rte/fdl/cryptography/impl/EgovGeneralCryptoServiceImpl.java
+++ b/Foundation/org.egovframe.rte.fdl.crypto/src/main/java/org/egovframe/rte/fdl/cryptography/impl/EgovGeneralCryptoServiceImpl.java
@@ -23,7 +23,7 @@ import org.jasypt.encryption.pbe.StandardPBEBigDecimalEncryptor;
 import org.jasypt.encryption.pbe.StandardPBEByteEncryptor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Required;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.util.ReflectionUtils;
 
 import java.io.*;
@@ -48,7 +48,7 @@ public class EgovGeneralCryptoServiceImpl implements EgovGeneralCryptoService {
 		LOGGER.debug("General Crypto Service's algorithm : {}", algorithm);
 	}
 
-	@Required
+	@Autowired(required=true)
 	public void setPasswordEncoder(EgovPasswordEncoder passwordEncoder) {
 		this.passwordEncoder = passwordEncoder;
 		LOGGER.debug("passwordEncoder's algorithm : {}", passwordEncoder.getAlgorithm());


### PR DESCRIPTION
…constructor injection for required settings.

## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [X] 기타 Others

## 수정된 소스 내용 Modified source
Deprecated된 Require Annotation을 사용하고 있는 부분을 Autowired로 수정  하였습니다.

Deprecated. as of 5.1, in favor of using constructor injection for required settings (or a custom InitializingBean implementation)

검토자를 위해 수정된 소스 내용을 설명해 주세요. Please describe the modified source for reviewers.

## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [x] JUnit 테스트 JUnit tests
- [x] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡쳐 영상 Test screenshots or captured video

테스트 전과 후의 스크린샷 또는 캡쳐 영상을 이곳에 첨부해 주세요. Please attach screenshots or video captures of your before and after tests here.
![image](https://github.com/eGovFramework/egovframe-runtime/assets/38740832/7abf95ce-2ab3-43b6-b09c-50879c9dd63e)
