### PR TITLE
EgovAbstractServiceImpl 에 Exception 을 EgovBizException 으로 수정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,5 @@ target/
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml #
 hs_err_pid*
+
+.factorypath

--- a/Foundation/org.egovframe.rte.fdl.cmmn/src/main/java/org/egovframe/rte/fdl/cmmn/EgovAbstractServiceImpl.java
+++ b/Foundation/org.egovframe.rte.fdl.cmmn/src/main/java/org/egovframe/rte/fdl/cmmn/EgovAbstractServiceImpl.java
@@ -15,6 +15,10 @@
  */
 package org.egovframe.rte.fdl.cmmn;
 
+import java.util.Locale;
+
+import javax.annotation.Resource;
+
 import org.egovframe.rte.fdl.cmmn.exception.EgovBizException;
 import org.egovframe.rte.fdl.cmmn.trace.LeaveaTrace;
 import org.slf4j.Logger;
@@ -22,26 +26,27 @@ import org.slf4j.LoggerFactory;
 import org.springframework.context.MessageSource;
 import org.springframework.context.i18n.LocaleContextHolder;
 
-import javax.annotation.Resource;
-import java.util.Locale;
-
 /**
  * 비즈니스 서비스 구현체가 상속받는 추상클래스
- * <p><b>NOTE:</b> 비즈니스 서비스 구현시 디폴드로 Exception 발생을 위한 processException 메소드와
- * leaveaTrace 메소드를 가지고 있다. processException / leaveaTrace 를 여러스타일의 파라미터를 취할 수 있도록 제공하고 있다.
- * 또한 EgovAbstractServiceImpl을 상속하는 클래스는 직접 Logger 생성없이
- * protected로 선언된 egovLogger를 사용할 수 있다.</p>
+ * <p>
+ * <b>NOTE:</b> 비즈니스 서비스 구현시 디폴드로 Exception 발생을 위한 processException 메소드와
+ * leaveaTrace 메소드를 가지고 있다. processException / leaveaTrace 를 여러스타일의 파라미터를 취할 수
+ * 있도록 제공하고 있다. 또한 EgovAbstractServiceImpl을 상속하는 클래스는 직접 Logger 생성없이 protected로
+ * 선언된 egovLogger를 사용할 수 있다.
+ * </p>
  * 
  * @author Daniela Kwon
  * @since 2014.06.01
  * @version 3.0
- * <pre>
+ * 
+ *          <pre>
  * 개정이력(Modification Information)
  *
  * 수정일		수정자				수정내용
  * ----------------------------------------------
- * 2014.06.01	Daniela Kwon		최초생성
- * </pre>
+ *   2014.06.01  Daniela Kwon  최초생성
+ *   2024.08.15  이백행          Exception 을 EgovBizException 으로 수정
+ *          </pre>
  */
 public abstract class EgovAbstractServiceImpl {
 
@@ -55,70 +60,80 @@ public abstract class EgovAbstractServiceImpl {
 
 	/**
 	 * EgovBizException 발생을 위한 메소드.
+	 * 
 	 * @param msgKey 메세지리소스에서 제공되는 메세지의 키값
-	 * @return Exception EgovBizException 객체
+	 * @return EgovBizException EgovBizException 객체
 	 */
-	protected Exception processException(final String msgKey) {
+	protected EgovBizException processException(final String msgKey) {
 		return processException(msgKey, new String[] {});
 	}
 
 	/**
 	 * EgovBizException 발생을 위한 메소드.
-	 * @param msgKey 메세지리소스에서 제공되는 메세지의 키값
+	 * 
+	 * @param msgKey    메세지리소스에서 제공되는 메세지의 키값
 	 * @param exception 발생한 Exception(내부적으로 취하고 있다가 에러핸들링시 사용)
-	 * @return Exception EgovBizException 객체
+	 * @return EgovBizException EgovBizException 객체
 	 */
-	protected Exception processException(final String msgKey, Exception exception) {
+	protected EgovBizException processException(final String msgKey, Exception exception) {
 		return processException(msgKey, new String[] {}, exception);
 	}
 
 	/**
 	 * EgovBizException 발생을 위한 메소드.
-	 * @param msgKey 메세지리소스에서 제공되는 메세지의 키값
+	 * 
+	 * @param msgKey  메세지리소스에서 제공되는 메세지의 키값
 	 * @param msgArgs msgKey의 메세지에서 변수에 취환되는 값들
-	 * @return Exception EgovBizException 객체
+	 * @return EgovBizException EgovBizException 객체
 	 */
-	protected Exception processException(final String msgKey, final String[] msgArgs) {
+	protected EgovBizException processException(final String msgKey, final String[] msgArgs) {
 		return processException(msgKey, msgArgs, null);
 	}
 
 	/**
 	 * EgovBizException 발생을 위한 메소드.
-	 * @param msgKey 메세지리소스에서 제공되는 메세지의 키값
-	 * @param msgArgs msgKey의 메세지에서 변수에 취환되는 값들
+	 * 
+	 * @param msgKey    메세지리소스에서 제공되는 메세지의 키값
+	 * @param msgArgs   msgKey의 메세지에서 변수에 취환되는 값들
 	 * @param exception 발생한 Exception(내부적으로 취하고 있다가 에러핸들링시 사용)
-	 * @return Exception EgovBizException 객체
+	 * @return EgovBizException EgovBizException 객체
 	 */
-	protected Exception processException(final String msgKey, final String[] msgArgs, final Exception exception) {
+	protected EgovBizException processException(final String msgKey, final String[] msgArgs,
+			final Exception exception) {
 		return processException(msgKey, msgArgs, exception, LocaleContextHolder.getLocale());
 	}
 
 	/**
 	 * EgovBizException 발생을 위한 메소드.
-	 * @param msgKey 메세지리소스에서 제공되는 메세지의 키값
-	 * @param msgArgs msgKey의 메세지에서 변수에 취환되는 값들
+	 * 
+	 * @param msgKey    메세지리소스에서 제공되는 메세지의 키값
+	 * @param msgArgs   msgKey의 메세지에서 변수에 취환되는 값들
 	 * @param exception 발생한 Exception(내부적으로 취하고 있다가 에러핸들링시 사용)
-	 * @param locale 명시적 국가/언어지정
-	 * @return Exception EgovBizException 객체
+	 * @param locale    명시적 국가/언어지정
+	 * @return EgovBizException EgovBizException 객체
 	 */
-	protected Exception processException(final String msgKey, final String[] msgArgs, final Exception exception, Locale locale) {
+	protected EgovBizException processException(final String msgKey, final String[] msgArgs, final Exception exception,
+			Locale locale) {
 		return processException(msgKey, msgArgs, exception, locale, null);
 	}
 
 	/**
 	 * EgovBizException 발생을 위한 메소드.
-	 * @param msgKey 메세지리소스에서 제공되는 메세지의 키값
-	 * @param msgArgs msgKey의 메세지에서 변수에 취환되는 값들
-	 * @param exception 발생한 Exception(내부적으로 취하고 있다가 에러핸들링시 사용)
-	 * @param locale 명시적 국가/언어지정
+	 * 
+	 * @param msgKey           메세지리소스에서 제공되는 메세지의 키값
+	 * @param msgArgs          msgKey의 메세지에서 변수에 취환되는 값들
+	 * @param exception        발생한 Exception(내부적으로 취하고 있다가 에러핸들링시 사용)
+	 * @param locale           명시적 국가/언어지정
 	 * @param exceptionCreator 외부에서 별도의 Exception 생성기 지정
-	 * @return Exception EgovBizException 객체
+	 * @return EgovBizException EgovBizException 객체
 	 */
-	protected Exception processException(final String msgKey, final String[] msgArgs, final Exception exception, final Locale locale, ExceptionCreator exceptionCreator) {
+	protected EgovBizException processException(final String msgKey, final String[] msgArgs, final Exception exception,
+			final Locale locale, ExceptionCreator exceptionCreator) {
 		ExceptionCreator eC = null;
 		if (exceptionCreator == null) {
 			eC = new ExceptionCreator() {
-				public Exception createBizException(MessageSource messageSource) {
+				@Override
+				public EgovBizException createBizException(MessageSource messageSource) {
 					return new EgovBizException(messageSource, msgKey, msgArgs, locale, exception);
 				}
 			};
@@ -129,11 +144,12 @@ public abstract class EgovAbstractServiceImpl {
 	}
 
 	protected interface ExceptionCreator {
-		Exception createBizException(MessageSource messageSource);
+		EgovBizException createBizException(MessageSource messageSource);
 	}
 
 	/**
 	 * Exception 발생없이 후처리로직 실행을 위한 메소드.
+	 * 
 	 * @param msgKey 메세지리소스에서 제공되는 메세지의 키값
 	 */
 	protected void leaveaTrace(String msgKey) {
@@ -142,7 +158,8 @@ public abstract class EgovAbstractServiceImpl {
 
 	/**
 	 * Exception 발생없이 후처리로직 실행을 위한 메소드.
-	 * @param msgKey 메세지리소스에서 제공되는 메세지의 키값
+	 * 
+	 * @param msgKey  메세지리소스에서 제공되는 메세지의 키값
 	 * @param msgArgs msgKey의 메세지에서 변수에 취환되는 값들
 	 */
 	protected void leaveaTrace(String msgKey, String[] msgArgs) {
@@ -151,9 +168,10 @@ public abstract class EgovAbstractServiceImpl {
 
 	/**
 	 * Exception 발생없이 후처리로직 실행을 위한 메소드.
-	 * @param msgKey 메세지리소스에서 제공되는 메세지의 키값
+	 * 
+	 * @param msgKey  메세지리소스에서 제공되는 메세지의 키값
 	 * @param msgArgs msgKey의 메세지에서 변수에 취환되는 값들
-	 * @param locale 명시적 국가/언어지정
+	 * @param locale  명시적 국가/언어지정
 	 */
 	protected void leaveaTrace(String msgKey, String[] msgArgs, Locale locale) {
 		traceObj.trace(this.getClass(), messageSource, msgKey, msgArgs, locale, egovLogger);


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [x] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

검토자를 위해 수정된 소스 내용을 설명해 주세요. Please describe the modified source for reviewers.

EgovAbstractServiceImpl 에 Exception 을 EgovBizException 으로 수정
- throws Exception 을 제거하기 위함
- Exception 을 EgovBizException 으로 수정
- Exception 을 BaseRuntimeException 으로 수정하면?
- ` *   2024.08.17  이백행          Exception 을 EgovBizException 으로 수정` 개정이력 수정
- ` *   2024.08.18  이백행          processRuntimeException 추가` 개정이력 수정
- .gitignore 에 .factorypath 를 추가
- processRuntimeException 추가

## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [ ] JUnit 테스트 JUnit tests
- [x] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

테스트 전과 후의 스크린샷 또는 캡처 영상을 이곳에 첨부해 주세요. Please attach screenshots or video captures of your before and after tests here.

**throw processException("info.nodata.msg");**
테스트 전
![image](https://github.com/user-attachments/assets/6f114fdd-8ae6-4139-9806-1d67ec3e6501)

테스트 후
![image](https://github.com/user-attachments/assets/216fd23f-da8b-4dea-8566-3ed445e96ec5)

**throw processRuntimeException("info.nodata.msg");**
테스트 후
![image](https://github.com/user-attachments/assets/3918ac08-0a94-4268-bdaf-35d710ed6b64)
