### PR TITLE
url safe 를 고려한 암복호화 로직 개선 

### DIFF
--- a/Foundation/org.egovframe.rte.fdl.crypto/src/main/java/org/egovframe/rte/fdl/cryptography/impl/EgovEnvCryptoServiceImpl.java
+++ b/Foundation/org.egovframe.rte.fdl.crypto/src/main/java/org/egovframe/rte/fdl/cryptography/impl/EgovEnvCryptoServiceImpl.java
@@ -23,9 +23,6 @@ import org.egovframe.rte.fdl.property.EgovPropertyService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.UnsupportedEncodingException;
-import java.net.URLDecoder;
-import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 
 /**
@@ -148,8 +145,8 @@ public class EgovEnvCryptoServiceImpl implements EgovEnvCryptoService {
 	 */
 	public String encrypt(String encrypt){
 		try {
-			return URLEncoder.encode(new String(new Base64().encode(cryptoService.encrypt( encrypt.getBytes(StandardCharsets.UTF_8), this.getCyptoAlgorithmKey()))), "UTF-8");
-		} catch(IllegalArgumentException | UnsupportedEncodingException e) {
+			return new String(Base64.encodeBase64(cryptoService.encrypt(encrypt.getBytes(StandardCharsets.UTF_8), this.getCyptoAlgorithmKey()), false, true));
+		} catch(IllegalArgumentException e) {
 			LOGGER.error("[IllegalArgumentException] Try/Catch...usingParameters Runing : "+ e.getMessage());
 		}
 		return encrypt;
@@ -162,8 +159,8 @@ public class EgovEnvCryptoServiceImpl implements EgovEnvCryptoService {
 	 */
 	public String decrypt(String decrypt){
 		try {
-			return new String(cryptoService.decrypt(new Base64().decode(URLDecoder.decode(decrypt,"UTF-8").getBytes(StandardCharsets.UTF_8)), this.cyptoAlgorithmKey));
-		} catch(IllegalArgumentException | UnsupportedEncodingException e) {
+			return new String(cryptoService.decrypt(Base64.decodeBase64(decrypt.getBytes(StandardCharsets.UTF_8)), this.cyptoAlgorithmKey));
+		} catch(IllegalArgumentException e) {
 			LOGGER.error("[IllegalArgumentException] Try/Catch...usingParameters Runing : "+ e.getMessage());
 		}
 		return decrypt;

--- a/Foundation/org.egovframe.rte.fdl.crypto/src/test/java/org/egovframe/rte/fdl/cryptography/EgovARIAErrorTest.java
+++ b/Foundation/org.egovframe.rte.fdl.crypto/src/test/java/org/egovframe/rte/fdl/cryptography/EgovARIAErrorTest.java
@@ -6,16 +6,28 @@ import org.slf4j.LoggerFactory;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 
+import java.net.URLEncoder;
+
 public class EgovARIAErrorTest {
 
 	private static final Logger LOGGER = LoggerFactory.getLogger(EgovARIAErrorTest.class);
 	
 	public static void main(String[] args) {
-		
-		
-		String[] arrCryptoString = { 
-                "ckimage/2018/12"
-              };
+
+
+		String[] givenStrs = {
+				"ckimage/2018/12",
+				"FILE_000000000000001",
+				"FILE_000000000000002",
+				"FILE_000000000000003",
+				"FILE_000000000000004",
+				"FILE_000000000000005",
+				"FILE_000000000000006",
+				"FILE_000000000000007",
+				"FILE_000000000000008",
+				"FILE_000000000000009",
+				"FILE_000000000000010",
+		};
 
 		
 		LOGGER.info("------------------------------------------------------");		
@@ -26,16 +38,25 @@ public class EgovARIAErrorTest {
 		
 		String label = "";
 		try {
-			for(int i=0; i < arrCryptoString.length; i++) {		
+            for (String str : givenStrs) {
 
-				LOGGER.info(label+" 원본(orignal):" + arrCryptoString[i]);
-				LOGGER.info(label+" 인코딩(encrypted):" + cryptoService.encrypt(arrCryptoString[i]) );
-				LOGGER.info(label+" 디코딩(decrypted):" + cryptoService.decrypt(cryptoService.encrypt(arrCryptoString[i])) );
-				if( cryptoService.decrypt(cryptoService.encrypt(arrCryptoString[i])).equals(arrCryptoString[i]) ) {
-					LOGGER.info(label+" 통과 !!!");
-				}
-				LOGGER.info("------------------------------------------------------");
-			}
+                String encrypt = cryptoService.encrypt(str);
+                LOGGER.info(label + " 원본(orignal):" + str);
+                LOGGER.info(label + " 인코딩(encrypted):" + encrypt);
+                LOGGER.info(label + " 디코딩(decrypted):" + cryptoService.decrypt(encrypt));
+                LOGGER.info(label + " URL인코딩(encrypted+url):" + URLEncoder.encode(encrypt, "UTF-8"));
+
+                if (!encrypt.equals(URLEncoder.encode(encrypt, "UTF-8"))) {
+                    LOGGER.error(label + " 실패 !!!(URL SAFE 실패)");
+                    return;
+                } else if (cryptoService.decrypt(encrypt).equals(str)) {
+                    LOGGER.info(label + " 통과 !!!");
+                } else {
+                    LOGGER.error(label + " 실패 !!!");
+                    return;
+                }
+                LOGGER.info("------------------------------------------------------");
+            }
 		} catch (IllegalArgumentException e) {
 			LOGGER.error("["+e.getClass()+"] IllegalArgumentException : " + e.getMessage());
 			//e.printStackTrace();


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [ ] 버그수정 Bug fixes
- [X] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

### 이슈
- 기존 **url safe** 를 고려한 암복호화 로직 개선 필요성
- URLEncoder 를 통해 나온 결과는 url 사용을 위함이고, 이 자체가 **url safe** 하지 못함(특수문자 존재)
- 복잡한 케이스 고려 필요(SSR 케이스, 스프링 자동 URL디코딩 케이스, 정상 케이스 등)

### 처리내용
- URLEncoder 제거 및 Base64 **url safe** 옵션 활성화
- 불필요한 인스턴스 생성 제거

## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [ ] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [X] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

테스트 전과 후의 스크린샷 또는 캡처 영상을 이곳에 첨부해 주세요. Please attach screenshots or video captures of your before and after tests here.

- 테스트 전
```text
2024-08-22 11:10:08,811  INFO [org.egovframe.rte.fdl.cryptography.EgovARIAErrorTest]  원본(orignal):ckimage/2018/12
2024-08-22 11:10:08,812  INFO [org.egovframe.rte.fdl.cryptography.EgovARIAErrorTest]  인코딩(encrypted):%2FITkIPGdXOGtfGQ7KO5n1A%3D%3D
2024-08-22 11:10:08,812  INFO [org.egovframe.rte.fdl.cryptography.EgovARIAErrorTest]  디코딩(decrypted):ckimage/2018/12
2024-08-22 11:10:08,812  INFO [org.egovframe.rte.fdl.cryptography.EgovARIAErrorTest]  URL인코딩(encrypted+url):%252FITkIPGdXOGtfGQ7KO5n1A%253D%253D
2024-08-22 11:10:08,812 ERROR [org.egovframe.rte.fdl.cryptography.EgovARIAErrorTest]  실패 !!!(URL SAFE 실패)
```

- 테스트 후
```text
2024-08-22 11:08:20,756  INFO [org.egovframe.rte.fdl.cryptography.EgovARIAErrorTest]  원본(orignal):ckimage/2018/12
2024-08-22 11:08:20,756  INFO [org.egovframe.rte.fdl.cryptography.EgovARIAErrorTest]  인코딩(encrypted):_ITkIPGdXOGtfGQ7KO5n1A
2024-08-22 11:08:20,757  INFO [org.egovframe.rte.fdl.cryptography.EgovARIAErrorTest]  디코딩(decrypted):ckimage/2018/12
2024-08-22 11:08:20,757  INFO [org.egovframe.rte.fdl.cryptography.EgovARIAErrorTest]  URL인코딩(encrypted+url):_ITkIPGdXOGtfGQ7KO5n1A
2024-08-22 11:08:20,757  INFO [org.egovframe.rte.fdl.cryptography.EgovARIAErrorTest]  통과 !!!
```