### PR TITLE
[ObjectRetrievalFailureException] 이클립스 문제(Probems) 해결

### DIFF
--- a/Persistence/org.egovframe.rte.psl.dataaccess/src/main/java/org/egovframe/rte/psl/orm/ObjectRetrievalFailureException.java
+++ b/Persistence/org.egovframe.rte.psl.dataaccess/src/main/java/org/egovframe/rte/psl/orm/ObjectRetrievalFailureException.java
@@ -49,7 +49,7 @@ public class ObjectRetrievalFailureException extends DataRetrievalFailureExcepti
 	 * @param persistentClass the persistent class
 	 * @param identifier the ID of the object that should have been retrieved
 	 */
-	public ObjectRetrievalFailureException(Class persistentClass, Object identifier) {
+	public ObjectRetrievalFailureException(Class<?> persistentClass, Object identifier) {
 		this(persistentClass, identifier,
 				"Object of class [" + persistentClass.getName() + "] with identifier [" + identifier + "]: not found",
 				null);
@@ -64,7 +64,7 @@ public class ObjectRetrievalFailureException extends DataRetrievalFailureExcepti
 	 * @param cause the source exception
 	 */
 	public ObjectRetrievalFailureException(
-			Class persistentClass, Object identifier, String msg, Throwable cause) {
+			Class<?> persistentClass, Object identifier, String msg, Throwable cause) {
 
 		super(msg, cause);
 		this.persistentClass = persistentClass;
@@ -104,8 +104,8 @@ public class ObjectRetrievalFailureException extends DataRetrievalFailureExcepti
 	 * Return the persistent class of the object that was not found.
 	 * If no Class was specified, this method returns null.
 	 */
-	public Class getPersistentClass() {
-		return (this.persistentClass instanceof Class ? (Class) this.persistentClass : null);
+	public Class<?> getPersistentClass() {
+		return (this.persistentClass instanceof Class ? (Class<?>) this.persistentClass : null);
 	}
 
 	/**
@@ -114,7 +114,7 @@ public class ObjectRetrievalFailureException extends DataRetrievalFailureExcepti
 	 */
 	public String getPersistentClassName() {
 		if (this.persistentClass instanceof Class) {
-			return ((Class) this.persistentClass).getName();
+			return ((Class<?>) this.persistentClass).getName();
 		}
 		return (this.persistentClass != null ? this.persistentClass.toString() : null);
 	}


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [x] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

검토자를 위해 수정된 소스 내용을 설명해 주세요. Please describe the modified source for reviewers.

### [ObjectRetrievalFailureException] 이클립스 문제(Probems) 해결
- Class is a raw type. References to generic type Class<T> should be parameterized
- 클래스는 원시 유형입니다. 제네릭 유형 Class<T>에 대한 참조는 매개변수화되어야 합니다.
- `Class` 를 `Class<?>` 로 수정

브랜치 생성
```
2024/probems/ObjectRetrievalFailureException
```

Class is a raw type. References to generic type Class<T> should be parameterized	ObjectRetrievalFailureException.java	/org.egovframe.rte.psl.dataaccess/src/main/java/org/egovframe/rte/psl/orm	line 52	Java Problem
```java
//	public ObjectRetrievalFailureException(Class persistentClass, Object identifier) {
	public ObjectRetrievalFailureException(Class<?> persistentClass, Object identifier) {
```

Class is a raw type. References to generic type Class<T> should be parameterized	ObjectRetrievalFailureException.java	/org.egovframe.rte.psl.dataaccess/src/main/java/org/egovframe/rte/psl/orm	line 67	Java Problem
```java
//			Class persistentClass, Object identifier, String msg, Throwable cause) {
			Class<?> persistentClass, Object identifier, String msg, Throwable cause) {
```

Class is a raw type. References to generic type Class<T> should be parameterized	ObjectRetrievalFailureException.java	/org.egovframe.rte.psl.dataaccess/src/main/java/org/egovframe/rte/psl/orm	line 107	Java Problem
```java
//	public Class getPersistentClass() {
	public Class<?> getPersistentClass() {
```

Class is a raw type. References to generic type Class<T> should be parameterized	ObjectRetrievalFailureException.java	/org.egovframe.rte.psl.dataaccess/src/main/java/org/egovframe/rte/psl/orm	line 108	Java Problem
```java
//		return (this.persistentClass instanceof Class ? (Class) this.persistentClass : null);
		return (this.persistentClass instanceof Class ? (Class<?>) this.persistentClass : null);
```

Class is a raw type. References to generic type Class<T> should be parameterized	ObjectRetrievalFailureException.java	/org.egovframe.rte.psl.dataaccess/src/main/java/org/egovframe/rte/psl/orm	line 117	Java Problem
```java
//			return ((Class) this.persistentClass).getName();
			return ((Class<?>) this.persistentClass).getName();
```

## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [ ] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

테스트 전과 후의 스크린샷 또는 캡처 영상을 이곳에 첨부해 주세요. Please attach screenshots or video captures of your before and after tests here.
