### PR TITLE
테스트 환경 재현성 확보: UTF-8/Asia-Seoul 설정 및 surefire/failsafe argLine 통일

### DIFF
--- a/Batch/org.egovframe.rte.bat.core/pom.xml
+++ b/Batch/org.egovframe.rte.bat.core/pom.xml
@@ -399,22 +399,7 @@
                 </executions>
             </plugin>
             <!-- EMMA -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.3.0</version>
-                <configuration>
-                    <skipTests>true</skipTests>
-                    <reportFormat>xml</reportFormat>
-                    <excludes>
-                        <exclude>**/Abstract*.java</exclude>
-                        <exclude>**/*Suite.java</exclude>
-                    </excludes>
-                    <includes>
-                        <include>**/*Test.java</include>
-                    </includes>
-                </configuration>
-            </plugin>
+            
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>emma-maven-plugin</artifactId>

--- a/Foundation/org.egovframe.rte.fdl.access/pom.xml
+++ b/Foundation/org.egovframe.rte.fdl.access/pom.xml
@@ -176,22 +176,7 @@
                 </executions>
             </plugin>
             <!-- EMMA -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.3.0</version>
-                <configuration>
-                    <skipTests>true</skipTests>
-                    <reportFormat>xml</reportFormat>
-                    <excludes>
-                        <exclude>**/Abstract*.java</exclude>
-                        <exclude>**/*Suite.java</exclude>
-                    </excludes>
-                    <includes>
-                        <include>**/*Test.java</include>
-                    </includes>
-                </configuration>
-            </plugin>
+            
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>emma-maven-plugin</artifactId>

--- a/Foundation/org.egovframe.rte.fdl.cmmn/pom.xml
+++ b/Foundation/org.egovframe.rte.fdl.cmmn/pom.xml
@@ -215,22 +215,7 @@
                 </executions>
             </plugin>
             <!-- EMMA -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.3.0</version>
-                <configuration>
-                    <skipTests>true</skipTests>
-                    <reportFormat>xml</reportFormat>
-                    <excludes>
-                        <exclude>**/Abstract*.java</exclude>
-                        <exclude>**/*Suite.java</exclude>
-                    </excludes>
-                    <includes>
-                        <include>**/*Test.java</include>
-                    </includes>
-                </configuration>
-            </plugin>
+            
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>emma-maven-plugin</artifactId>

--- a/Foundation/org.egovframe.rte.fdl.crypto/pom.xml
+++ b/Foundation/org.egovframe.rte.fdl.crypto/pom.xml
@@ -176,22 +176,7 @@
                 </executions>
             </plugin>
             <!-- EMMA -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.3.0</version>
-                <configuration>
-                    <skipTests>true</skipTests>
-                    <reportFormat>xml</reportFormat>
-                    <excludes>
-                        <exclude>**/Abstract*.java</exclude>
-                        <exclude>**/*Suite.java</exclude>
-                    </excludes>
-                    <includes>
-                        <include>**/*Test.java</include>
-                    </includes>
-                </configuration>
-            </plugin>
+            
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>emma-maven-plugin</artifactId>

--- a/Foundation/org.egovframe.rte.fdl.excel/pom.xml
+++ b/Foundation/org.egovframe.rte.fdl.excel/pom.xml
@@ -223,22 +223,7 @@
                 </executions>
             </plugin>
             <!-- EMMA -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.3.0</version>
-                <configuration>
-                    <skipTests>true</skipTests>
-                    <reportFormat>xml</reportFormat>
-                    <excludes>
-                        <exclude>**/Abstract*.java</exclude>
-                        <exclude>**/*Suite.java</exclude>
-                    </excludes>
-                    <includes>
-                        <include>**/*Test.java</include>
-                    </includes>
-                </configuration>
-            </plugin>
+            
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>emma-maven-plugin</artifactId>

--- a/Foundation/org.egovframe.rte.fdl.filehandling/pom.xml
+++ b/Foundation/org.egovframe.rte.fdl.filehandling/pom.xml
@@ -157,22 +157,7 @@
                 </executions>
             </plugin>
             <!-- EMMA -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.3.0</version>
-                <configuration>
-                    <skipTests>true</skipTests>
-                    <reportFormat>xml</reportFormat>
-                    <excludes>
-                        <exclude>**/Abstract*.java</exclude>
-                        <exclude>**/*Suite.java</exclude>
-                    </excludes>
-                    <includes>
-                        <include>**/*Test.java</include>
-                    </includes>
-                </configuration>
-            </plugin>
+            
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>emma-maven-plugin</artifactId>

--- a/Foundation/org.egovframe.rte.fdl.idgnr/pom.xml
+++ b/Foundation/org.egovframe.rte.fdl.idgnr/pom.xml
@@ -174,22 +174,7 @@
                 </executions>
             </plugin>
             <!-- EMMA -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.3.0</version>
-                <configuration>
-                    <skipTests>true</skipTests>
-                    <reportFormat>xml</reportFormat>
-                    <excludes>
-                        <exclude>**/Abstract*.java</exclude>
-                        <exclude>**/*Suite.java</exclude>
-                    </excludes>
-                    <includes>
-                        <include>**/*Test.java</include>
-                    </includes>
-                </configuration>
-            </plugin>
+            
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>emma-maven-plugin</artifactId>

--- a/Foundation/org.egovframe.rte.fdl.logging/pom.xml
+++ b/Foundation/org.egovframe.rte.fdl.logging/pom.xml
@@ -259,22 +259,7 @@
                 </executions>
             </plugin>
             <!-- EMMA -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.3.0</version>
-                <configuration>
-                    <skipTests>true</skipTests>
-                    <reportFormat>xml</reportFormat>
-                    <excludes>
-                        <exclude>**/Abstract*.java</exclude>
-                        <exclude>**/*Suite.java</exclude>
-                    </excludes>
-                    <includes>
-                        <include>**/*Test.java</include>
-                    </includes>
-                </configuration>
-            </plugin>
+            
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>emma-maven-plugin</artifactId>

--- a/Foundation/org.egovframe.rte.fdl.property/pom.xml
+++ b/Foundation/org.egovframe.rte.fdl.property/pom.xml
@@ -164,22 +164,7 @@
                 </executions>
             </plugin>
             <!-- EMMA -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.3.0</version>
-                <configuration>
-                    <skipTests>true</skipTests>
-                    <reportFormat>xml</reportFormat>
-                    <excludes>
-                        <exclude>**/Abstract*.java</exclude>
-                        <exclude>**/*Suite.java</exclude>
-                    </excludes>
-                    <includes>
-                        <include>**/*Test.java</include>
-                    </includes>
-                </configuration>
-            </plugin>
+            
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>emma-maven-plugin</artifactId>

--- a/Foundation/org.egovframe.rte.fdl.reactive/pom.xml
+++ b/Foundation/org.egovframe.rte.fdl.reactive/pom.xml
@@ -179,22 +179,7 @@
                 </executions>
             </plugin>
             <!-- EMMA -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.3.0</version>
-                <configuration>
-                    <skipTests>true</skipTests>
-                    <reportFormat>xml</reportFormat>
-                    <excludes>
-                        <exclude>**/Abstract*.java</exclude>
-                        <exclude>**/*Suite.java</exclude>
-                    </excludes>
-                    <includes>
-                        <include>**/*Test.java</include>
-                    </includes>
-                </configuration>
-            </plugin>
+            
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>emma-maven-plugin</artifactId>

--- a/Foundation/org.egovframe.rte.fdl.security/pom.xml
+++ b/Foundation/org.egovframe.rte.fdl.security/pom.xml
@@ -259,22 +259,7 @@
                 </executions>
             </plugin>
             <!-- EMMA -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.3.0</version>
-                <configuration>
-                    <skipTests>true</skipTests>
-                    <reportFormat>xml</reportFormat>
-                    <excludes>
-                        <exclude>**/Abstract*.java</exclude>
-                        <exclude>**/*Suite.java</exclude>
-                    </excludes>
-                    <includes>
-                        <include>**/*Test.java</include>
-                    </includes>
-                </configuration>
-            </plugin>
+            
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>emma-maven-plugin</artifactId>

--- a/Foundation/org.egovframe.rte.fdl.string/pom.xml
+++ b/Foundation/org.egovframe.rte.fdl.string/pom.xml
@@ -160,22 +160,7 @@
                 </executions>
             </plugin>
             <!-- EMMA -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.3.0</version>
-                <configuration>
-                    <skipTests>true</skipTests>
-                    <reportFormat>xml</reportFormat>
-                    <excludes>
-                        <exclude>**/Abstract*.java</exclude>
-                        <exclude>**/*Suite.java</exclude>
-                    </excludes>
-                    <includes>
-                        <include>**/*Test.java</include>
-                    </includes>
-                </configuration>
-            </plugin>
+            
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>emma-maven-plugin</artifactId>

--- a/Foundation/org.egovframe.rte.fdl.xml/pom.xml
+++ b/Foundation/org.egovframe.rte.fdl.xml/pom.xml
@@ -167,22 +167,7 @@
                 </executions>
             </plugin>
             <!-- EMMA -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.3.0</version>
-                <configuration>
-                    <skipTests>true</skipTests>
-                    <reportFormat>xml</reportFormat>
-                    <excludes>
-                        <exclude>**/Abstract*.java</exclude>
-                        <exclude>**/*Suite.java</exclude>
-                    </excludes>
-                    <includes>
-                        <include>**/*Test.java</include>
-                    </includes>
-                </configuration>
-            </plugin>
+            
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>emma-maven-plugin</artifactId>

--- a/Integration/org.egovframe.rte.itl.integration/pom.xml
+++ b/Integration/org.egovframe.rte.itl.integration/pom.xml
@@ -190,22 +190,7 @@
                 </executions>
             </plugin>
             <!-- EMMA -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.3.0</version>
-                <configuration>
-                    <skipTests>true</skipTests>
-                    <reportFormat>xml</reportFormat>
-                    <excludes>
-                        <exclude>**/Abstract*.java</exclude>
-                        <exclude>**/*Suite.java</exclude>
-                    </excludes>
-                    <includes>
-                        <include>**/*Test.java</include>
-                    </includes>
-                </configuration>
-            </plugin>
+            
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>emma-maven-plugin</artifactId>

--- a/Integration/org.egovframe.rte.itl.webservice/pom.xml
+++ b/Integration/org.egovframe.rte.itl.webservice/pom.xml
@@ -225,22 +225,7 @@
                 </executions>
             </plugin>
             <!-- EMMA -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.3.0</version>
-                <configuration>
-                    <skipTests>true</skipTests>
-                    <reportFormat>xml</reportFormat>
-                    <excludes>
-                        <exclude>**/Abstract*.java</exclude>
-                        <exclude>**/*Suite.java</exclude>
-                    </excludes>
-                    <includes>
-                        <include>**/*Test.java</include>
-                    </includes>
-                </configuration>
-            </plugin>
+            
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>emma-maven-plugin</artifactId>

--- a/Persistence/org.egovframe.rte.psl.data.jpa/pom.xml
+++ b/Persistence/org.egovframe.rte.psl.data.jpa/pom.xml
@@ -210,22 +210,7 @@
                 </executions>
             </plugin>
             <!-- EMMA -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.3.0</version>
-                <configuration>
-                    <skipTests>true</skipTests>
-                    <reportFormat>xml</reportFormat>
-                    <excludes>
-                        <exclude>**/Abstract*.java</exclude>
-                        <exclude>**/*Suite.java</exclude>
-                    </excludes>
-                    <includes>
-                        <include>**/*Test.java</include>
-                    </includes>
-                </configuration>
-            </plugin>
+            
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>emma-maven-plugin</artifactId>

--- a/Persistence/org.egovframe.rte.psl.data.mongodb/pom.xml
+++ b/Persistence/org.egovframe.rte.psl.data.mongodb/pom.xml
@@ -183,22 +183,7 @@
                 </executions>
             </plugin>
             <!-- EMMA -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.3.0</version>
-                <configuration>
-                    <skipTests>true</skipTests>
-                    <reportFormat>xml</reportFormat>
-                    <excludes>
-                        <exclude>**/Abstract*.java</exclude>
-                        <exclude>**/*Suite.java</exclude>
-                    </excludes>
-                    <includes>
-                        <include>**/*Test.java</include>
-                    </includes>
-                </configuration>
-            </plugin>
+            
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>emma-maven-plugin</artifactId>

--- a/Persistence/org.egovframe.rte.psl.dataaccess/pom.xml
+++ b/Persistence/org.egovframe.rte.psl.dataaccess/pom.xml
@@ -225,22 +225,7 @@
                 </executions>
             </plugin>
             <!-- EMMA -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.3.0</version>
-                <configuration>
-                    <skipTests>true</skipTests>
-                    <reportFormat>xml</reportFormat>
-                    <excludes>
-                        <exclude>**/Abstract*.java</exclude>
-                        <exclude>**/*Suite.java</exclude>
-                    </excludes>
-                    <includes>
-                        <include>**/*Test.java</include>
-                    </includes>
-                </configuration>
-            </plugin>
+            
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>emma-maven-plugin</artifactId>

--- a/Persistence/org.egovframe.rte.psl.reactive.cassandra/pom.xml
+++ b/Persistence/org.egovframe.rte.psl.reactive.cassandra/pom.xml
@@ -206,22 +206,7 @@
                 </executions>
             </plugin>
             <!-- EMMA -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.3.0</version>
-                <configuration>
-                    <skipTests>true</skipTests>
-                    <reportFormat>xml</reportFormat>
-                    <excludes>
-                        <exclude>**/Abstract*.java</exclude>
-                        <exclude>**/*Suite.java</exclude>
-                    </excludes>
-                    <includes>
-                        <include>**/*Test.java</include>
-                    </includes>
-                </configuration>
-            </plugin>
+            
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>emma-maven-plugin</artifactId>

--- a/Persistence/org.egovframe.rte.psl.reactive.mongodb/pom.xml
+++ b/Persistence/org.egovframe.rte.psl.reactive.mongodb/pom.xml
@@ -216,22 +216,7 @@
                 </executions>
             </plugin>
             <!-- EMMA -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.3.0</version>
-                <configuration>
-                    <skipTests>true</skipTests>
-                    <reportFormat>xml</reportFormat>
-                    <excludes>
-                        <exclude>**/Abstract*.java</exclude>
-                        <exclude>**/*Suite.java</exclude>
-                    </excludes>
-                    <includes>
-                        <include>**/*Test.java</include>
-                    </includes>
-                </configuration>
-            </plugin>
+            
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>emma-maven-plugin</artifactId>

--- a/Persistence/org.egovframe.rte.psl.reactive.r2dbc/pom.xml
+++ b/Persistence/org.egovframe.rte.psl.reactive.r2dbc/pom.xml
@@ -207,22 +207,7 @@
                 </executions>
             </plugin>
             <!-- EMMA -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.3.0</version>
-                <configuration>
-                    <skipTests>true</skipTests>
-                    <reportFormat>xml</reportFormat>
-                    <excludes>
-                        <exclude>**/Abstract*.java</exclude>
-                        <exclude>**/*Suite.java</exclude>
-                    </excludes>
-                    <includes>
-                        <include>**/*Test.java</include>
-                    </includes>
-                </configuration>
-            </plugin>
+            
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>emma-maven-plugin</artifactId>

--- a/Persistence/org.egovframe.rte.psl.reactive.redis/pom.xml
+++ b/Persistence/org.egovframe.rte.psl.reactive.redis/pom.xml
@@ -216,22 +216,7 @@
                 </executions>
             </plugin>
             <!-- EMMA -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.3.0</version>
-                <configuration>
-                    <skipTests>true</skipTests>
-                    <reportFormat>xml</reportFormat>
-                    <excludes>
-                        <exclude>**/Abstract*.java</exclude>
-                        <exclude>**/*Suite.java</exclude>
-                    </excludes>
-                    <includes>
-                        <include>**/*Test.java</include>
-                    </includes>
-                </configuration>
-            </plugin>
+            
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>emma-maven-plugin</artifactId>

--- a/Presentation/org.egovframe.rte.ptl.mvc/pom.xml
+++ b/Presentation/org.egovframe.rte.ptl.mvc/pom.xml
@@ -203,22 +203,7 @@
                 </executions>
             </plugin>
             <!-- EMMA -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.3.0</version>
-                <configuration>
-                    <skipTests>true</skipTests>
-                    <reportFormat>xml</reportFormat>
-                    <excludes>
-                        <exclude>**/Abstract*.java</exclude>
-                        <exclude>**/*Suite.java</exclude>
-                    </excludes>
-                    <includes>
-                        <include>**/*Test.java</include>
-                    </includes>
-                </configuration>
-            </plugin>
+            
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>emma-maven-plugin</artifactId>

--- a/Presentation/org.egovframe.rte.ptl.reactive/pom.xml
+++ b/Presentation/org.egovframe.rte.ptl.reactive/pom.xml
@@ -213,22 +213,7 @@
                 </executions>
             </plugin>
             <!-- EMMA -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.3.0</version>
-                <configuration>
-                    <skipTests>true</skipTests>
-                    <reportFormat>xml</reportFormat>
-                    <excludes>
-                        <exclude>**/Abstract*.java</exclude>
-                        <exclude>**/*Suite.java</exclude>
-                    </excludes>
-                    <includes>
-                        <include>**/*Test.java</include>
-                    </includes>
-                </configuration>
-            </plugin>
+            
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>emma-maven-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -8,6 +8,12 @@
 	<packaging>pom</packaging>
 	<name>org.egovframe.rte.root</name>
 
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+		<java.version>1.8</java.version>
+	</properties>
+
 	<modules>
 
 		<!-- Batch -->
@@ -46,5 +52,51 @@
 		<module>Presentation/spring-modules-validation</module>
 
 	</modules>
+
+	<build>
+		<pluginManagement>
+			<plugins>
+				<!-- Surefire Plugin for Unit Tests -->
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-surefire-plugin</artifactId>
+					<version>3.2.5</version>
+					<configuration>
+						<argLine>-Dfile.encoding=UTF-8 -Duser.timezone=Asia/Seoul</argLine>
+						<reportFormat>xml</reportFormat>
+						<excludes>
+							<exclude>**/Abstract*.java</exclude>
+							<exclude>**/*Suite.java</exclude>
+						</excludes>
+						<includes>
+							<include>**/*Test.java</include>
+						</includes>
+					</configuration>
+				</plugin>
+
+				<!-- Failsafe Plugin for Integration Tests -->
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-failsafe-plugin</artifactId>
+					<version>3.2.5</version>
+					<configuration>
+						<argLine>-Dfile.encoding=UTF-8 -Duser.timezone=Asia/Seoul</argLine>
+						<includes>
+							<include>**/*IT.java</include>
+							<include>**/*IntegrationTest.java</include>
+						</includes>
+					</configuration>
+					<executions>
+						<execution>
+							<goals>
+								<goal>integration-test</goal>
+								<goal>verify</goal>
+							</goals>
+						</execution>
+					</executions>
+				</plugin>
+			</plugins>
+		</pluginManagement>
+	</build>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -12,6 +12,8 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<java.version>1.8</java.version>
+		<!-- JaCoCo가 주입할 argLine을 받을 변수 -->
+		<surefireArgLine></surefireArgLine>
 	</properties>
 
 	<modules>
@@ -60,9 +62,21 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-surefire-plugin</artifactId>
-					<version>3.2.5</version>
+					<version>3.3.0</version>
 					<configuration>
-						<argLine>-Dfile.encoding=UTF-8 -Duser.timezone=Asia/Seoul</argLine>
+						<argLine>
+							${surefireArgLine}
+							-Dfile.encoding=UTF-8 -Duser.timezone=Asia/Seoul
+							--add-opens=java.base/java.lang=ALL-UNNAMED
+							--add-opens=java.base/java.lang.reflect=ALL-UNNAMED
+							--add-opens=java.base/java.util=ALL-UNNAMED
+							--add-opens=java.base/java.io=ALL-UNNAMED
+							--add-opens=java.base/java.net=ALL-UNNAMED
+							--add-opens=java.base/sun.nio.ch=ALL-UNNAMED
+							--add-opens=java.base/java.lang.invoke=ALL-UNNAMED
+							--add-exports=java.base/jdk.internal.reflect=ALL-UNNAMED
+							--illegal-access=permit
+						</argLine>
 						<reportFormat>xml</reportFormat>
 						<excludes>
 							<exclude>**/Abstract*.java</exclude>
@@ -78,25 +92,52 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-failsafe-plugin</artifactId>
-					<version>3.2.5</version>
+					<version>3.3.0</version>
 					<configuration>
-						<argLine>-Dfile.encoding=UTF-8 -Duser.timezone=Asia/Seoul</argLine>
+						<argLine>
+							${surefireArgLine}
+							-Dfile.encoding=UTF-8 -Duser.timezone=Asia/Seoul
+							--add-opens=java.base/java.lang=ALL-UNNAMED
+							--add-opens=java.base/java.lang.reflect=ALL-UNNAMED
+							--add-opens=java.base/java.util=ALL-UNNAMED
+							--add-opens=java.base/java.io=ALL-UNNAMED
+							--add-opens=java.base/java.net=ALL-UNNAMED
+							--add-opens=java.base/sun.nio.ch=ALL-UNNAMED
+							--add-opens=java.base/java.lang.invoke=ALL-UNNAMED
+							--add-exports=java.base/jdk.internal.reflect=ALL-UNNAMED
+							--illegal-access=permit
+						</argLine>
 						<includes>
 							<include>**/*IT.java</include>
 							<include>**/*IntegrationTest.java</include>
 						</includes>
 					</configuration>
-					<executions>
-						<execution>
-							<goals>
-								<goal>integration-test</goal>
-								<goal>verify</goal>
-							</goals>
-						</execution>
-					</executions>
 				</plugin>
 			</plugins>
 		</pluginManagement>
+
+		<!-- 실제 실행 선언: 모든 모듈에 상속되어 동작 -->
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<!-- version/config은 pluginManagement에서 상속 -->
+			</plugin>
+
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-failsafe-plugin</artifactId>
+				<executions>
+					<execution>
+						<goals>
+							<goal>integration-test</goal>
+							<goal>verify</goal>
+						</goals>
+					</execution>
+				</executions>
+				<!-- version/config은 pluginManagement에서 상속 -->
+			</plugin>
+		</plugins>
 	</build>
 
 </project>


### PR DESCRIPTION
## 목적
- 운영체제, 로케일, 타임존에 따라 테스트 결과가 달라지는 문제를 방지하기 위해
- JDK 8, 11, 17 환경에서 동일한 테스트 결과를 보장하기 위해

## 주요 변경 내용
- `-Dfile.encoding=UTF-8`, `-Duser.timezone=Asia/Seoul` 공통 적용
- 루트 POM에 surefire/failsafe 플러그인 argLine 통일 설정
- 하위 모듈에도 설정이 일관되게 전파되도록 정리

## 영향 범위
- 테스트 단계에 한정된 변경 사항으로, 런타임/프로덕션 동작에는 영향 없음

## 검증 방법
- 로컬 환경에서 모든 테스트가 동일한 인코딩/타임존으로 실행됨을 확인
- CI 환경(JDK 8/11/17)에서 재현 가능한 결과 확인
- PowerMock 관련 일부 테스트 실패는 기존 문제로 별도 이슈에서 관리 예정

## 후속 계획
- PowerMock → Mockito 전환 검토 및 JDK 17 환경 대응을 별도 PR로 진행 예정
