### PR TITLE
HTMLTagFilterRequestWrapper.getParameterMap() 여러 번 호출 시 중복 entity encoding 수정

### DIFF
--- a/Presentation/org.egovframe.rte.ptl.mvc/src/main/java/org/egovframe/rte/ptl/mvc/filter/HTMLTagFilterRequestWrapper.java
+++ b/Presentation/org.egovframe.rte.ptl.mvc/src/main/java/org/egovframe/rte/ptl/mvc/filter/HTMLTagFilterRequestWrapper.java
@@ -18,6 +18,7 @@ package org.egovframe.rte.ptl.mvc.filter;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletRequestWrapper;
 
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 /**
@@ -66,18 +67,20 @@ public class HTMLTagFilterRequestWrapper extends HttpServletRequestWrapper {
 
     public Map<String, String[]> getParameterMap() {
         Map<String, String[]> valueMap = super.getParameterMap();
-        String[] values;
+        Map<String, String[]> safeValueMap = new LinkedHashMap<String, String[]>();
         for (String key : valueMap.keySet()) {
-            values = valueMap.get(key);
+            String[] values = valueMap.get(key);
+            String[] safeValues = new String[values.length];
             for (int i = 0; i < values.length; i++) {
                 if (values[i] != null) {
-                    values[i] = getSafeParamData(values[i]);
+                    safeValues[i] = getSafeParamData(values[i]);
                 } else {
-                    values[i] = null;
+                    safeValues[i] = null;
                 }
             }
+            safeValueMap.put(key, safeValues);
         }
-        return valueMap;
+        return safeValueMap;
     }
 
     /**

--- a/Presentation/org.egovframe.rte.ptl.mvc/src/test/java/org/egovframe/rte/ptl/mvc/filter/HTMLTagFilterTest.java
+++ b/Presentation/org.egovframe.rte.ptl.mvc/src/test/java/org/egovframe/rte/ptl/mvc/filter/HTMLTagFilterTest.java
@@ -8,7 +8,9 @@ import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 
 import java.io.IOException;
+import java.util.Map;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class HTMLTagFilterTest {
@@ -28,6 +30,42 @@ public class HTMLTagFilterTest {
         String param = (String) requestWrapper.getAttribute("param01");
 
         assertEquals("param01", param);
+    }
+
+    @Test
+    public void getParameterMapShouldNotEscapeRepeatedCallsTwice() {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addParameter("param01", "<b>test&\"'</b>");
+        HTMLTagFilterRequestWrapper requestWrapper = new HTMLTagFilterRequestWrapper(request);
+
+        String[] expected = {"&lt;b&gt;test&amp;&quot;&apos;&lt;/b&gt;"};
+
+        assertArrayEquals(expected, requestWrapper.getParameterMap().get("param01"));
+        assertArrayEquals(expected, requestWrapper.getParameterMap().get("param01"));
+    }
+
+    @Test
+    public void getParameterMapShouldNotMutateOriginalRequest() {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addParameter("param01", "<b>test</b>");
+        HTMLTagFilterRequestWrapper requestWrapper = new HTMLTagFilterRequestWrapper(request);
+
+        Map<String, String[]> parameterMap = requestWrapper.getParameterMap();
+        parameterMap.get("param01")[0] = "changed";
+
+        assertEquals("&lt;b&gt;test&lt;/b&gt;", requestWrapper.getParameter("param01"));
+    }
+
+    @Test
+    public void getParameterMapShouldReturnMutableCopy() {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addParameter("param01", "<b>test</b>");
+        HTMLTagFilterRequestWrapper requestWrapper = new HTMLTagFilterRequestWrapper(request);
+
+        Map<String, String[]> parameterMap = requestWrapper.getParameterMap();
+        parameterMap.put("param02", new String[]{"added"});
+
+        assertArrayEquals(new String[]{"added"}, parameterMap.get("param02"));
     }
 
 }


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [x] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source
검토자를 위해 수정된 소스 내용을 설명해 주세요. Please describe the modified source for reviewers.

## TL;DR
HTMLTagFilterRequestWrapper 에서 getParameterMap() 을 여러 번 호출 시 entity encoding이 중복 적용될 수 있던 문제를 수정했습니다.

## 문제원인
servlet reuqest의 getParameterMap() 은 immutable 처럼 동작해야합니다.
근거: https://javadoc.io/doc/jakarta.servlet/jakarta.servlet-api/5.0.0/jakarta/servlet/ServletRequest.html#getParameterMap--
> an immutable java.util.Map containing parameter names as keys and parameter values as map values.

egov runtime의 `HTMLTagFilterRequestWrapper` 는 `getParameterMap` 호출 시마다 구현체에서 받아온 HttpServletRequest 의 Parameter map 내부를 직접 수정하는 방식을 채택했는데
이 경우 `getParameterMap` 을 여러 번 호출하게 되면 HTML 엔티티 이스케이프가 중복으로 적용되게 되어 immutable 원칙이 깨져버리고 사용자가 의도치 않은 로직 오류를 발생시킵니다.

## 해결책
`getSafeParameter` 리턴 시 복사본을 리턴하도록 하여 안전하게 처리합니다.


## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [x] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [x] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

<img width="1786" height="1184" alt="image" src="https://github.com/user-attachments/assets/4c31357c-891d-42a5-8f8f-e7ad329d5218" />
