### PR TITLE
fix: StringTimestampTypeHandler 스레드 안전성 개선

### DIFF
--- a/Persistence/org.egovframe.rte.psl.dataaccess/src/main/java/org/egovframe/rte/psl/dataaccess/typehandler/StringTimestampTypeHandler.java
+++ b/Persistence/org.egovframe.rte.psl.dataaccess/src/main/java/org/egovframe/rte/psl/dataaccess/typehandler/StringTimestampTypeHandler.java
@@ -21,8 +21,9 @@ import com.ibatis.sqlmap.client.extensions.TypeHandlerCallback;
 
 import java.sql.SQLException;
 import java.sql.Timestamp;
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 
 /**
  * String - Timestamp 변환을 지원하는 TypeHandler 확장 클래스
@@ -52,9 +53,15 @@ public class StringTimestampTypeHandler implements TypeHandlerCallback {
     private static final String DATE_FORMAT = "yyyyMMddHHmmss";
 
     /**
-     * SimpleDateFormat - DATE_FORMAT 기반 포맷터
+     * DateTimeFormatter - DATE_FORMAT 기반 포맷터
+     * <p>
+     * {@link java.text.SimpleDateFormat} 은 thread-safe 하지 않으나, {@link DateTimeFormatter} 는
+     * 불변(immutable) 객체로 여러 스레드가 안전하게 공유할 수 있다. iBatis 의
+     * {@link TypeHandlerCallback} 구현체는 싱글톤으로 공유되어 동시에 호출되므로
+     * 포맷터를 thread-safe 한 구현으로 사용한다.
+     * </p>
      */
-    private static final SimpleDateFormat SDF = new SimpleDateFormat(DATE_FORMAT, java.util.Locale.getDefault());
+    private static final DateTimeFormatter DTF = DateTimeFormatter.ofPattern(DATE_FORMAT);
 
     /**
      * JDBC 의 Timestamp 로 조회된 값을 resultMap 처리 시 결과
@@ -71,7 +78,7 @@ public class StringTimestampTypeHandler implements TypeHandlerCallback {
             return null;
         }
         Timestamp ts = getter.getTimestamp();
-        return SDF.format(ts);
+        return DTF.format(ts.toLocalDateTime());
     }
 
     /**
@@ -89,9 +96,9 @@ public class StringTimestampTypeHandler implements TypeHandlerCallback {
             setter.setNull(java.sql.Types.DATE);
         } else {
             try {
-                Timestamp ts = new Timestamp(SDF.parse((String) parameter).getTime());
+                Timestamp ts = Timestamp.valueOf(LocalDateTime.parse((String) parameter, DTF));
                 setter.setTimestamp(ts);
-            } catch (ParseException e) {
+            } catch (DateTimeParseException e) {
                 throw new SQLException("Error parsing string to timestamp.  Cause: " + e.getMessage());
             }
         }

--- a/Persistence/org.egovframe.rte.psl.dataaccess/src/test/java/org/egovframe/rte/psl/dataaccess/typehandler/StringTimestampTypeHandlerTest.java
+++ b/Persistence/org.egovframe.rte.psl.dataaccess/src/test/java/org/egovframe/rte/psl/dataaccess/typehandler/StringTimestampTypeHandlerTest.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2008-2024 MOIS(Ministry of the Interior and Safety).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.egovframe.rte.psl.dataaccess.typehandler;
+
+import com.ibatis.sqlmap.client.extensions.ParameterSetter;
+import com.ibatis.sqlmap.client.extensions.ResultGetter;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Proxy;
+import java.sql.Timestamp;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Collections;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * {@link StringTimestampTypeHandler} 단위 테스트.
+ * <p>
+ * iBatis 의 TypeHandler 는 싱글톤으로 공유되어 여러 스레드에서 동시에 호출된다.
+ * 과거 구현은 {@code static SimpleDateFormat} 을 공유하여 thread-safe 하지 않았고,
+ * 동시 호출 시 잘못된 결과나 예외(NumberFormatException, ArrayIndexOutOfBoundsException 등)를
+ * 유발할 수 있었다. 본 테스트는 단일 인스턴스를 다수 스레드가 동시에 사용해도
+ * 결과가 정확하고 예외가 없음을 검증한다.
+ * </p>
+ */
+public class StringTimestampTypeHandlerTest {
+
+    private static final String FORMATTED = "20240102030405";
+    private static final Timestamp EXPECTED_TS = Timestamp.valueOf("2024-01-02 03:04:05");
+
+    /** 지정한 Timestamp 를 반환하는 ResultGetter 프록시 (필요 메서드만 구현). */
+    private ResultGetter resultGetter(final Timestamp ts) {
+        return (ResultGetter) Proxy.newProxyInstance(
+                getClass().getClassLoader(),
+                new Class<?>[]{ResultGetter.class},
+                (proxy, method, args) -> {
+                    switch (method.getName()) {
+                        case "wasNull":
+                            return Boolean.FALSE;
+                        case "getTimestamp":
+                            return ts;
+                        default:
+                            throw new UnsupportedOperationException(method.getName());
+                    }
+                });
+    }
+
+    /** setTimestamp 호출값을 캡처하는 ParameterSetter 프록시 (필요 메서드만 구현). */
+    private ParameterSetter capturingSetter(final AtomicReference<Timestamp> captured) {
+        return (ParameterSetter) Proxy.newProxyInstance(
+                getClass().getClassLoader(),
+                new Class<?>[]{ParameterSetter.class},
+                (proxy, method, args) -> {
+                    if ("setTimestamp".equals(method.getName()) && args != null && args.length == 1) {
+                        captured.set((Timestamp) args[0]);
+                        return null;
+                    }
+                    throw new UnsupportedOperationException(method.getName());
+                });
+    }
+
+    @Test
+    public void roundTripPreservesValue() throws Exception {
+        StringTimestampTypeHandler handler = new StringTimestampTypeHandler();
+
+        // Timestamp -> String
+        assertEquals(FORMATTED, handler.getResult(resultGetter(EXPECTED_TS)));
+
+        // String -> Timestamp
+        AtomicReference<Timestamp> captured = new AtomicReference<>();
+        handler.setParameter(capturingSetter(captured), FORMATTED);
+        assertEquals(EXPECTED_TS, captured.get());
+    }
+
+    @Test
+    public void sharedInstanceIsThreadSafe() throws Exception {
+        final StringTimestampTypeHandler handler = new StringTimestampTypeHandler();
+        final int threads = 16;
+        final int iterations = 500;
+        final ExecutorService pool = Executors.newFixedThreadPool(threads);
+        final CountDownLatch ready = new CountDownLatch(threads);
+        final CountDownLatch start = new CountDownLatch(1);
+        final List<Throwable> failures = Collections.synchronizedList(new ArrayList<>());
+
+        for (int t = 0; t < threads; t++) {
+            pool.execute(() -> {
+                ready.countDown();
+                try {
+                    start.await();
+                    for (int i = 0; i < iterations; i++) {
+                        // format 경로
+                        Object formatted = handler.getResult(resultGetter(EXPECTED_TS));
+                        if (!FORMATTED.equals(formatted)) {
+                            failures.add(new AssertionError("getResult=" + formatted));
+                        }
+                        // parse 경로
+                        AtomicReference<Timestamp> captured = new AtomicReference<>();
+                        handler.setParameter(capturingSetter(captured), FORMATTED);
+                        if (!EXPECTED_TS.equals(captured.get())) {
+                            failures.add(new AssertionError("setParameter=" + captured.get()));
+                        }
+                    }
+                } catch (Throwable e) {
+                    failures.add(e);
+                }
+            });
+        }
+
+        ready.await(5, TimeUnit.SECONDS);
+        start.countDown();
+        pool.shutdown();
+        assertTrue(pool.awaitTermination(30, TimeUnit.SECONDS), "동시성 테스트 시간 초과");
+        assertTrue(failures.isEmpty(), "동시 호출 중 오류 발생: " + failures);
+    }
+}


### PR DESCRIPTION
## 변경 이유

`StringTimestampTypeHandler` 는 iBatis `TypeHandlerCallback` 구현체로, iBatis 내부에서 **싱글톤으로 공유되어 여러 스레드에서 동시에 호출**됩니다. 그러나 기존 구현은 thread-safe 하지 않은 `static SimpleDateFormat` 인스턴스를 공유하여 사용합니다.

```java
private static final SimpleDateFormat SDF = new SimpleDateFormat(DATE_FORMAT, java.util.Locale.getDefault());
```

`SimpleDateFormat` 은 내부적으로 가변 `Calendar` 상태를 변경하므로 thread-safe 하지 않습니다. 다수 요청이 동시에 `getResult`(format) 또는 `setParameter`(parse) 를 호출하면 잘못된 변환 결과, `NumberFormatException`, `ArrayIndexOutOfBoundsException` 등이 비결정적으로 발생할 수 있습니다.

## 변경 내용

불변(immutable)이며 thread-safe 한 `java.time.format.DateTimeFormatter` 로 교체했습니다.

- `static SimpleDateFormat` → `static final DateTimeFormatter` (불변, 안전한 공유)
- `getResult`: `SDF.format(ts)` → `DTF.format(ts.toLocalDateTime())`
- `setParameter`: `new Timestamp(SDF.parse(...).getTime())` → `Timestamp.valueOf(LocalDateTime.parse(..., DTF))`, 예외도 `ParseException` → `DateTimeParseException`

포맷(`yyyyMMddHHmmss`)과 변환 동작은 동일하게 유지됩니다. 해당 패턴은 로케일에 의존하지 않으며, `Timestamp.toLocalDateTime()` 과 `Timestamp.valueOf(LocalDateTime)` 은 상호 역변환으로 기존 동작을 보존합니다.

## 테스트 방법

`StringTimestampTypeHandlerTest` 단위 테스트를 추가했습니다.

- `roundTripPreservesValue`: Timestamp ↔ String 변환 정확성 검증
- `sharedInstanceIsThreadSafe`: 단일 인스턴스를 16개 스레드 × 500회 동시 호출하여 결과 정확성과 예외 부재 검증 (기존 구현에서는 실패, 변경 후 통과)

```
mvn -pl Persistence/org.egovframe.rte.psl.dataaccess -am test \
  -Dtest=StringTimestampTypeHandlerTest,TypeHandlerTest
```

- 신규 테스트: 2/2 통과
- 기존 통합 테스트 `TypeHandlerTest`: 1/1 통과 (회귀 없음)

## 영향 범위

`org.egovframe.rte.psl.dataaccess` 의 String ↔ Timestamp TypeHandler 사용처에 한정됩니다. 외부 동작 및 출력 포맷 변화는 없으며, 동시성 안전성만 개선됩니다.