### PR TITLE
fix: EgovMyBatisBatchItemWriter의 사용되지 않는 reflection 루프 제거

### DIFF
--- a/Batch/org.egovframe.rte.bat.core/src/main/java/org/egovframe/rte/bat/core/item/database/EgovMyBatisBatchItemWriter.java
+++ b/Batch/org.egovframe.rte.bat.core/src/main/java/org/egovframe/rte/bat/core/item/database/EgovMyBatisBatchItemWriter.java
@@ -19,21 +19,6 @@ import org.egovframe.rte.bat.support.EgovJobVariableListener;
 import org.egovframe.rte.bat.support.EgovResourceVariable;
 import org.egovframe.rte.bat.support.EgovStepVariableListener;
 import org.mybatis.spring.batch.MyBatisBatchItemWriter;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.batch.item.Chunk;
-import org.springframework.util.ReflectionUtils;
-
-import java.beans.BeanInfo;
-import java.beans.IntrospectionException;
-import java.beans.Introspector;
-import java.beans.PropertyDescriptor;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 
 /**
  * EgovMyBatisBatchItemWriter 클래스
@@ -53,8 +38,6 @@ import java.util.Map;
  * @since 2017.09.06
  */
 public class EgovMyBatisBatchItemWriter<T> extends MyBatisBatchItemWriter<T> {
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(EgovMyBatisBatchItemWriter.class);
 
     /**
      * egovframework EgovResourceVariable
@@ -93,39 +76,6 @@ public class EgovMyBatisBatchItemWriter<T> extends MyBatisBatchItemWriter<T> {
 
     public void setStepVariable(EgovStepVariableListener stepVariable) {
         this.stepVariable = stepVariable;
-    }
-
-    @Override
-    @SuppressWarnings("unchecked")
-    public void write(Chunk<? extends T> chunk) {
-        List<Object> list = new ArrayList<>();
-        Map<String, Object> map;
-
-        try {
-            for (T item : chunk.getItems()) {
-                map = new HashMap<>();
-                BeanInfo beanInfo = Introspector.getBeanInfo(item.getClass());
-
-                if (resourceVariable != null)
-                    map.putAll(resourceVariable.getVariableMap());
-                if (jobVariable != null)
-                    map.putAll(jobVariable.getVariableMap());
-                if (stepVariable != null)
-                    map.putAll(stepVariable.getVariableMap());
-
-                for (PropertyDescriptor pd : beanInfo.getPropertyDescriptors()) {
-                    Method reader = pd.getReadMethod();
-                    if (reader != null)
-                        map.put(pd.getName(), reader.invoke(item));
-                }
-
-                list.add(map);
-            }
-        } catch (IntrospectionException | IllegalAccessException | InvocationTargetException e) {
-            ReflectionUtils.handleReflectionException(e);
-        }
-
-        super.write((Chunk<? extends T>) chunk);
     }
 
 }


### PR DESCRIPTION
## 개요

`EgovMyBatisBatchItemWriter.write(Chunk)`가 chunk의 각 item에 대해 reflection으로 파라미터 `Map`을 만들어 `List`에 모으지만, 그 결과를 전혀 사용하지 않고 폐기하고 있어 제거합니다.

## 문제

```java
@Override
public void write(Chunk<? extends T> chunk) {
    List<Object> list = new ArrayList<>();
    Map<String, Object> map;
    try {
        for (T item : chunk.getItems()) {
            map = new HashMap<>();
            BeanInfo beanInfo = Introspector.getBeanInfo(item.getClass());
            // ... 공유 변수 putAll ...
            for (PropertyDescriptor pd : beanInfo.getPropertyDescriptors()) {
                Method reader = pd.getReadMethod();
                if (reader != null)
                    map.put(pd.getName(), reader.invoke(item));
            }
            list.add(map);
        }
    } catch (...) { ReflectionUtils.handleReflectionException(e); }

    super.write((Chunk<? extends T>) chunk);   // ← 위에서 만든 list/map은 미사용, 원본 chunk로 호출
}
```

- `list`/`map`은 메서드 지역 변수이며 `super.write(chunk)`는 **원본 chunk**로 호출됩니다. 즉 위 루프의 산출물은 어디에도 전달되지 않고 전량 폐기됩니다(dead code).
- 그 결과, 대용량 배치 write 경로에서 chunk마다 item별로 `Introspector.getBeanInfo` + `getPropertyDescriptors` + 모든 getter 호출(`reader.invoke`)이 **불필요하게** 수행됩니다.

## 변경

결과가 사용되지 않는 reflection 루프와, 그로 인해 순수 위임만 남는 `write` 오버라이드를 제거했습니다. 더 이상 필요 없는 import도 함께 정리했습니다. 제거 후에는 부모 `MyBatisBatchItemWriter.write`가 그대로 사용되어 **동작은 동일**합니다.

## 검증

- `EgovMybatisTest`(본 writer로 DB update step을 포함한 Job을 실행하는 통합 테스트)가 변경 후에도 통과합니다(`BUILD SUCCESS`). 이는 제거된 코드가 실제 동작에 기여하지 않았음을 확인해 줍니다.

## 참고

위 `Map`은 본래 공유 변수(`EgovResourceVariable`/`EgovJobVariableListener`/`EgovStepVariableListener`)를 statement 파라미터에 주입하려던 의도로 보이나, 실제로는 배선되지 않아 동작하지 않습니다(reader 쪽 `EgovMyBatisPagingItemReader`는 `setParameterValues`로 정상 동작). 본 PR은 죽은 코드 제거에 한정하며, **변수 주입 기능 복구는 별도 이슈로 제안**합니다.