### PR TITLE
fix: EgovReflectionSupport 멀티스레드 lazy-init 경합 제거 (getter 메서드맵 부분초기화 NPE)

### DIFF
--- a/Batch/org.egovframe.rte.bat.core/src/main/java/org/egovframe/rte/bat/core/reflection/EgovReflectionSupport.java
+++ b/Batch/org.egovframe.rte.bat.core/src/main/java/org/egovframe/rte/bat/core/reflection/EgovReflectionSupport.java
@@ -48,8 +48,8 @@ public class EgovReflectionSupport<T> {
     private static final Logger LOGGER = LoggerFactory.getLogger(EgovReflectionSupport.class);
 
     private Object object = null;
-    private Method[] methods;
-    private HashMap<String, Method> methodMap;
+    private volatile Method[] methods;
+    private volatile HashMap<String, Method> methodMap;
     private Type[] fieldType;
 
     public EgovReflectionSupport() {
@@ -151,16 +151,26 @@ public class EgovReflectionSupport<T> {
      * Bean 생성시 한 번만 실행 된다.
      */
     public void generateGetterMethodMap(String[] names, T item) {
-        if (methods == null) {
-            methods = item.getClass().getMethods();
-            methodMap = new HashMap<String, Method>();
+        // 멀티스레드 step에서 FieldExtractor/ItemWriter 빈이 공유되면 이 인스턴스도 공유된다.
+        // 기존 코드는 methods를 먼저 대입한 뒤 methodMap을 채워, 다른 스레드가 methods != null 만 보고
+        // 아직 채워지지 않은(또는 null인) methodMap을 사용하다 NPE/부분초기화에 노출되었다.
+        // double-checked locking + 지역변수로 완성한 뒤 발행하여 부분초기화 상태가 외부에 보이지 않게 한다.
+        if (methods != null) {
+            return;
+        }
+        synchronized (this) {
+            if (methods != null) {
+                return;
+            }
+            Method[] localMethods = item.getClass().getMethods();
+            HashMap<String, Method> localMap = new HashMap<String, Method>();
             try {
                 if (ArrayUtils.isNotEmpty(names) && names.length > 0) {
                     for (int i = 0; i < names.length; i++) {
                         String strMethod;
                         if (names[i].length() > 0) {
                             strMethod = "get" + (names[i].substring(0, 1)).toUpperCase() + names[i].substring(1);
-                            methodMap.put(names[i], retrieveMethod(methods, strMethod));
+                            localMap.put(names[i], retrieveMethod(localMethods, strMethod));
                         }
                     }
                 }
@@ -168,6 +178,9 @@ public class EgovReflectionSupport<T> {
             } catch (StringIndexOutOfBoundsException | NullPointerException e) {
                 ReflectionUtils.handleReflectionException(e);
             }
+            // 완성된 map을 먼저 발행한 뒤 methods를 마지막에 대입(초기화 완료 표식)한다.
+            methodMap = localMap;
+            methods = localMethods;
         }
     }
 

--- a/Batch/org.egovframe.rte.bat.core/src/test/java/org/egovframe/rte/bat/core/reflection/EgovReflectionSupportConcurrencyTest.java
+++ b/Batch/org.egovframe.rte.bat.core/src/test/java/org/egovframe/rte/bat/core/reflection/EgovReflectionSupportConcurrencyTest.java
@@ -1,0 +1,112 @@
+package org.egovframe.rte.bat.core.reflection;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * EgovReflectionSupport 의 멀티스레드 안전성 테스트.
+ *
+ * <p>FieldExtractor/ItemWriter 빈이 멀티스레드 step 에서 공유되면 그 안의
+ * EgovReflectionSupport 인스턴스도 공유된다. 과거 generateGetterMethodMap 은
+ * methods 를 먼저 대입한 뒤 methodMap 을 채워, 다른 스레드가 부분초기화 상태를
+ * 사용하다 NPE 에 노출되었다(cold-start 경합). 본 테스트로 회귀를 방지한다.</p>
+ *
+ * @author 기여자
+ * @version 1.0
+ * @since 2026.06.09
+ */
+public class EgovReflectionSupportConcurrencyTest {
+
+    private static final String[] NAMES = {"name", "age"};
+
+    @Test
+    public void sharedInstanceColdStartIsThreadSafe() throws InterruptedException {
+        final int threads = 32;
+        final int rounds = 500;
+        ExecutorService pool = Executors.newFixedThreadPool(threads);
+        try {
+            for (int round = 0; round < rounds; round++) {
+                // 라운드마다 새 공유 인스턴스를 만들어 cold-start lazy-init 경합을 재현한다.
+                final EgovReflectionSupport<SampleVo> shared = new EgovReflectionSupport<SampleVo>();
+                final SampleVo item = new SampleVo("egov", 42);
+                final CountDownLatch startGate = new CountDownLatch(1);
+                final CountDownLatch doneGate = new CountDownLatch(threads);
+                final List<Throwable> failures = new CopyOnWriteArrayList<Throwable>();
+                final List<Object> names = new CopyOnWriteArrayList<Object>();
+                final List<Object> ages = new CopyOnWriteArrayList<Object>();
+
+                for (int t = 0; t < threads; t++) {
+                    pool.execute(() -> {
+                        try {
+                            startGate.await();
+                            shared.generateGetterMethodMap(NAMES, item);
+                            names.add(shared.invokeGettterMethod(item, "name"));
+                            ages.add(shared.invokeGettterMethod(item, "age"));
+                        } catch (Throwable e) {
+                            failures.add(e);
+                        } finally {
+                            doneGate.countDown();
+                        }
+                    });
+                }
+
+                startGate.countDown();
+                assertTrue(doneGate.await(10, TimeUnit.SECONDS), "round " + round + " timed out");
+                assertTrue(failures.isEmpty(),
+                        "round " + round + " concurrent failure: " + failures);
+                for (Object n : names) {
+                    assertEquals("egov", n, "round " + round + " name mismatch");
+                }
+                for (Object a : ages) {
+                    assertEquals(42, a, "round " + round + " age mismatch");
+                }
+            }
+        } finally {
+            pool.shutdownNow();
+        }
+    }
+
+    @Test
+    public void singleThreadGetterExtractsValues() {
+        EgovReflectionSupport<SampleVo> reflection = new EgovReflectionSupport<SampleVo>();
+        SampleVo item = new SampleVo("egov", 42);
+        reflection.generateGetterMethodMap(NAMES, item);
+        List<Object> values = new ArrayList<Object>();
+        for (String name : NAMES) {
+            values.add(reflection.invokeGettterMethod(item, name));
+        }
+        assertEquals("egov", values.get(0));
+        assertEquals(42, values.get(1));
+    }
+
+    /**
+     * 테스트용 VO. public getter 가 reflection 으로 조회된다.
+     */
+    public static class SampleVo {
+        private final String name;
+        private final int age;
+
+        public SampleVo(String name, int age) {
+            this.name = name;
+            this.age = age;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public int getAge() {
+            return age;
+        }
+    }
+}


### PR DESCRIPTION
## 개요

배치 reflection 헬퍼 `EgovReflectionSupport`(`Batch/.../reflection/EgovReflectionSupport.java`)의 `generateGetterMethodMap` 에 멀티스레드 lazy-init 경합이 있어 수정합니다.

## 문제

`EgovFieldExtractor`(`FieldExtractor`)·`EgovJdbcBatchItemWriter`(`ItemWriter`)는 빈으로 등록되어 멀티스레드 step(taskExecutor)에서 공유되며, 내부의 `EgovReflectionSupport` 인스턴스도 함께 공유됩니다.

```java
public void generateGetterMethodMap(String[] names, T item) {
    if (methods == null) {
        methods = item.getClass().getMethods();   // (1) methods 먼저 비-null 대입
        methodMap = new HashMap<>();               // (2) 이 시점까지 methodMap 은 null
        ... methodMap 채움 ...                      // (3)
    }
}
```

스레드 A가 (1)만 수행한 상태에서 스레드 B가 `methods != null` 만 보고 블록을 건너뛰면, 아직 채워지지 않은(또는 null 인) `methodMap` 을 `invokeGettterMethod` 에서 사용하여 `NullPointerException` 이 발생합니다(고정길이 레코드가 아닌, 조회 결과 누락/예외). cold-start 시 재현되는 전형적인 부분초기화 발행(publication) 버그입니다.

`EgovFixedLengthLineAggregator`(별도 PR)와 동일한 "공유 인스턴스 + lazy-init" 패턴의 형제 사례입니다.

## 수정

- double-checked locking 으로 초기화를 1회만 수행.
- `methods`·`methodMap` 을 **지역변수로 완성한 뒤**, `methodMap` 을 먼저 발행하고 `methods` 를 마지막에 대입 → 부분초기화 상태가 외부에 보이지 않음.
- 두 필드를 `volatile` 로 선언해 가시성 보장.
- 단일스레드 동작은 동일(동작 보존).

## 검증

`EgovReflectionSupportConcurrencyTest` 추가:
- `sharedInstanceColdStartIsThreadSafe` — 32스레드 × 500라운드, 라운드마다 새 공유 인스턴스로 cold-start 동시호출.
- `singleThreadGetterExtractsValues` — 단일스레드 추출 회귀.

수정 **전** 코드에서는 `round 0` 에서 `NullPointerException`(`HashMap.get(...) is null`)으로 실패하고, 수정 **후** 통과합니다.

```
Tests run: 2, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS
```