### PR TITLE
fix: AuthorityResourceMetadata.reload() 동시성 개선(제자리 변이로 인한 ConcurrentModificationException 방지)

### DIFF
--- a/Foundation/org.egovframe.rte.fdl.access/src/main/java/org/egovframe/rte/fdl/access/bean/AuthorityResourceMetadata.java
+++ b/Foundation/org.egovframe.rte.fdl.access/src/main/java/org/egovframe/rte/fdl/access/bean/AuthorityResourceMetadata.java
@@ -17,7 +17,7 @@ package org.egovframe.rte.fdl.access.bean;
 
 import org.egovframe.rte.fdl.access.service.EgovAccessService;
 
-import java.util.Iterator;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -36,18 +36,19 @@ import java.util.Map;
  * 2019.10.01	유지보수            최초 생성
  * 2021.02.01   유지보수            권한재설정 수정
  * 2024.03.29   유지보수            권한재설정(reload() method) 수정
+ * 2026.06.10   유지보수            reload() 동시성 개선(제자리 변이 → 참조 원자교체, volatile)
  * </pre>
  * @since 2019.10.01
  */
 public class AuthorityResourceMetadata {
 
-    private static List<Map<String, Object>> authorityList;
-    private static List<Map<String, Object>> resourceMap;
+    private static volatile List<Map<String, Object>> authorityList;
+    private static volatile List<Map<String, Object>> resourceMap;
     private EgovAccessService egovAccessService;
 
     public AuthorityResourceMetadata(List<Map<String, Object>> authorityList, List<Map<String, Object>> resourceMap) {
-        this.authorityList = authorityList;
-        this.resourceMap = resourceMap;
+        AuthorityResourceMetadata.authorityList = authorityList;
+        AuthorityResourceMetadata.resourceMap = resourceMap;
     }
 
     public static List<Map<String, Object>> getAuthorityList() {
@@ -63,19 +64,13 @@ public class AuthorityResourceMetadata {
     }
 
     public void reload() throws Exception {
-        List<Map<String, Object>> authList = egovAccessService.getAuthorityUser();
-        Iterator<Map<String, Object>> authIterator = authList.iterator();
-        authorityList.clear();
-        while (authIterator.hasNext()) {
-            authorityList.add(authIterator.next());
-        }
-
-        List<Map<String, Object>> rolelist = egovAccessService.getRoleAndUrl();
-        Iterator<Map<String, Object>> roleIterator = rolelist.iterator();
-        resourceMap.clear();
-        while (roleIterator.hasNext()) {
-            resourceMap.add(roleIterator.next());
-        }
+        // 새 리스트를 만들어 static 참조를 원자적으로 교체한다.
+        // 기존에는 authorityList/resourceMap을 clear()+add()로 제자리 변이했는데,
+        // getAuthorities()/getRoles()가 요청마다 같은 리스트를 순회·반환하므로
+        // 갱신과 동시에 ConcurrentModificationException이 발생하거나 부분(빈) 상태가
+        // 읽힐 수 있었다. 참조 교체 방식은 읽는 쪽이 항상 완전한 스냅샷만 보게 한다.
+        authorityList = new ArrayList<>(egovAccessService.getAuthorityUser());
+        resourceMap = new ArrayList<>(egovAccessService.getRoleAndUrl());
     }
 
 }

--- a/Foundation/org.egovframe.rte.fdl.access/src/test/java/org/egovframe/rte/fdl/access/bean/AuthorityResourceMetadataConcurrencyTest.java
+++ b/Foundation/org.egovframe.rte.fdl.access/src/test/java/org/egovframe/rte/fdl/access/bean/AuthorityResourceMetadataConcurrencyTest.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2008-2026 MOIS(Ministry of the Interior and Safety).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.egovframe.rte.fdl.access.bean;
+
+import org.egovframe.rte.fdl.access.service.EgovAccessService;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * {@link AuthorityResourceMetadata}의 {@code reload()}가 동시 읽기와 안전한지 검증한다.
+ *
+ * <p>{@code getAuthorities()}/{@code getRoles()}는 요청마다 static 권한/리소스 리스트를
+ * 순회·반환한다. 기존 {@code reload()}는 같은 리스트를 {@code clear()}+{@code add()}로
+ * 제자리 변이하여, 갱신과 동시에 순회가 일어나면 {@link java.util.ConcurrentModificationException}이
+ * 발생하거나 부분(빈) 상태가 읽혔다. 본 테스트는 reload와 읽기를 동시에 반복하여
+ * 예외 없이 동작하는지 확인한다.
+ */
+class AuthorityResourceMetadataConcurrencyTest {
+
+    /** 호출 시마다 size개의 항목을 가진 새 리스트를 반환하는 단순 구현. */
+    private static final class FakeAccessService implements EgovAccessService {
+        private final int size;
+
+        private FakeAccessService(int size) {
+            this.size = size;
+        }
+
+        private List<Map<String, Object>> build() {
+            List<Map<String, Object>> list = new ArrayList<>();
+            for (int i = 0; i < size; i++) {
+                Map<String, Object> row = new HashMap<>();
+                row.put("userid", "u" + i);
+                row.put("authority", "ROLE_" + i);
+                list.add(row);
+            }
+            return list;
+        }
+
+        @Override
+        public List<Map<String, Object>> getAuthorityUser() {
+            return build();
+        }
+
+        @Override
+        public List<Map<String, Object>> getRoleAndUrl() {
+            return build();
+        }
+    }
+
+    @AfterEach
+    void resetStaticState() {
+        new AuthorityResourceMetadata(new ArrayList<>(), new ArrayList<>());
+    }
+
+    @Test
+    @DisplayName("reload()와 동시 읽기(순회)가 ConcurrentModificationException 없이 동작한다")
+    void reloadConcurrentWithReadsIsThreadSafe() throws Exception {
+        int seedSize = 50;
+        AuthorityResourceMetadata meta = new AuthorityResourceMetadata(
+                new ArrayList<>(new FakeAccessService(seedSize).getAuthorityUser()),
+                new ArrayList<>(new FakeAccessService(seedSize).getRoleAndUrl()));
+        meta.setEgovAccessService(new FakeAccessService(seedSize));
+
+        int threadCount = 16;
+        int rounds = 300;
+        ExecutorService pool = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch startGate = new CountDownLatch(1);
+        AtomicReference<Throwable> failure = new AtomicReference<>();
+        List<Future<?>> futures = new ArrayList<>();
+
+        for (int t = 0; t < threadCount; t++) {
+            final boolean reloader = (t % 2 == 0);
+            futures.add(pool.submit(() -> {
+                try {
+                    startGate.await();
+                    for (int r = 0; r < rounds && failure.get() == null; r++) {
+                        if (reloader) {
+                            meta.reload();
+                        } else {
+                            // getAuthorities()/getRoles()와 동일한 순회 패턴
+                            long sink = 0;
+                            List<Map<String, Object>> authList = AuthorityResourceMetadata.getAuthorityList();
+                            if (authList != null) {
+                                for (Map<String, Object> row : authList) {
+                                    sink += String.valueOf(row.get("userid")).length();
+                                }
+                            }
+                            List<Map<String, Object>> resourceMap = AuthorityResourceMetadata.getResourceMap();
+                            if (resourceMap != null) {
+                                for (Map<String, Object> row : resourceMap) {
+                                    sink += String.valueOf(row.get("authority")).length();
+                                }
+                            }
+                            if (sink < 0) {
+                                throw new IllegalStateException("unreachable");
+                            }
+                        }
+                    }
+                } catch (Throwable e) {
+                    failure.compareAndSet(null, e);
+                }
+            }));
+        }
+
+        startGate.countDown();
+        pool.shutdown();
+        assertTrue(pool.awaitTermination(30, TimeUnit.SECONDS), "동시성 테스트 시간 초과");
+        for (Future<?> f : futures) {
+            f.get();
+        }
+
+        assertNull(failure.get(), () -> "동시 reload/읽기 중 예외 발생: " + failure.get());
+    }
+
+    @Test
+    @DisplayName("reload() 후 최신 스냅샷이 반영된다")
+    void reloadReplacesSnapshot() throws Exception {
+        AuthorityResourceMetadata meta = new AuthorityResourceMetadata(new ArrayList<>(), new ArrayList<>());
+        meta.setEgovAccessService(new FakeAccessService(7));
+
+        meta.reload();
+
+        assertEquals(7, AuthorityResourceMetadata.getAuthorityList().size());
+        assertEquals(7, AuthorityResourceMetadata.getResourceMap().size());
+        assertEquals("u0", AuthorityResourceMetadata.getAuthorityList().get(0).get("userid"));
+    }
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

`reload()`가 static 리스트(`authorityList`, `resourceMap`)를 `clear()` 후 `add()`로 직접 비우고 다시 채웁니다. 이 리스트는 `EgovUserDetailsHelper.getAuthorities()`/`getRoles()`가 요청마다 읽습니다.

그래서 권한을 `reload()`하는 도중 요청이 들어오면 순회 중에 `ConcurrentModificationException`이 나거나, 비우고 채우는 사이의 빈 리스트가 읽힙니다. `reload()`는 재기동 없이 권한을 갱신하려는 용도라 트래픽이 도는 중에 호출됩니다.

새 `ArrayList`를 만들어 참조만 바꾸도록 고쳤고, 두 필드는 `volatile`로 뒀습니다. 읽는 쪽은 항상 다 채워진 리스트를 보게 되고, 내용은 기존과 동일합니다.

변경 파일: `AuthorityResourceMetadata.java`.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

`AuthorityResourceMetadataConcurrencyTest`를 추가했습니다. `reload()`와 리스트 순회를 16개 스레드로 동시에 돌립니다. 동시성 경합이라 수동 조작으로는 재현이 어렵고, 이 테스트로 확인합니다. 고치기 전에는 `ConcurrentModificationException`으로 실패하고, 고친 뒤 통과합니다.

## 테스트 브라우저 Test Browser

해당 없음.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

해당 없음.
