### PR TITLE
fix: EgovStringUtil.search 빈 target 무한 루프 방지

### DIFF
--- a/Foundation/org.egovframe.rte.fdl.string/src/main/java/org/egovframe/rte/fdl/string/EgovStringUtil.java
+++ b/Foundation/org.egovframe.rte.fdl.string/src/main/java/org/egovframe/rte/fdl/string/EgovStringUtil.java
@@ -282,6 +282,13 @@ public final class EgovStringUtil {
      * search
      */
     public static int search(String source, String target) {
+        // source 또는 target이 null/빈 문자열이면 셀 대상이 없으므로 0을 반환한다.
+        // 특히 target이 빈 문자열이면 indexOf("")가 항상 0을 반환해
+        // i가 0에 고정되어 무한 루프에 빠지므로 반드시 먼저 걸러낸다.
+        if (source == null || source.isEmpty() || target == null || target.isEmpty()) {
+            return 0;
+        }
+
         int result = 0;
         String strCheck = source;
         for (int i = 0; i < source.length(); ) {

--- a/Foundation/org.egovframe.rte.fdl.string/src/test/java/org/egovframe/rte/fdl/string/EgovStringUtilTest.java
+++ b/Foundation/org.egovframe.rte.fdl.string/src/test/java/org/egovframe/rte/fdl/string/EgovStringUtilTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
+import java.time.Duration;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -404,6 +405,36 @@ public class EgovStringUtilTest {
         String str = "a,b,c,d";
         // 2. get token list
         assertEquals(4, EgovStringUtil.getTokens(str).size());
+    }
+
+    /**
+     * search는 source 안에서 target이 나타나는 횟수를 센다.
+     */
+    @Test
+    public void testSearchCount() {
+        assertEquals(2, EgovStringUtil.search("aXbXc", "X"));
+        assertEquals(0, EgovStringUtil.search("abc", "z"));
+        assertEquals(2, EgovStringUtil.search("aaaa", "aa"));
+    }
+
+    /**
+     * target이 빈 문자열이면 indexOf("")가 항상 0을 반환해
+     * 기존 구현은 무한 루프에 빠졌다. 이제는 0을 반환해야 한다.
+     */
+    @Test
+    public void testSearchEmptyTargetDoesNotLoop() {
+        assertTimeoutPreemptively(Duration.ofSeconds(2),
+                () -> assertEquals(0, EgovStringUtil.search("abc", "")));
+    }
+
+    /**
+     * null 입력은 NPE 없이 0을 반환해야 한다.
+     */
+    @Test
+    public void testSearchNullInputs() {
+        assertEquals(0, EgovStringUtil.search(null, "a"));
+        assertEquals(0, EgovStringUtil.search("abc", null));
+        assertEquals(0, EgovStringUtil.search("", "a"));
     }
 
 }


### PR DESCRIPTION
## 문제

`EgovStringUtil.search(String source, String target)`는 `source` 안에서 `target`이 나타나는 횟수를 셉니다.

```java
public static int search(String source, String target) {
    int result = 0;
    String strCheck = source;
    for (int i = 0; i < source.length(); ) {
        int loc = strCheck.indexOf(target);
        if (loc == -1) {
            break;
        } else {
            result++;
            i = loc + target.length();
            strCheck = strCheck.substring(i);
        }
    }
    return result;
}
```

`target`이 빈 문자열(`""`)이면 `strCheck.indexOf("")`가 항상 `0`을 반환합니다. 이때 `i = loc + target.length()`가 `0`으로 고정되고 `strCheck = strCheck.substring(0)`로 문자열이 줄어들지 않아, `source`가 비어 있지 않은 한 `for` 루프가 종료되지 않습니다. 공개 정적 유틸이라 호출 측 입력에 따라 CPU 점유·스레드 행으로 이어질 수 있습니다(CWE-835).

또한 `source`나 `target`이 `null`이면 각각 `source.length()`, `indexOf(null)`에서 `NullPointerException`이 발생합니다.

## 수정

진입부에 가드를 추가했습니다. `source` 또는 `target`이 `null`이거나 빈 문자열이면 셀 대상이 없으므로 `0`을 반환합니다. 이는 Apache Commons Lang `StringUtils.countMatches`와 동일한 규약입니다.

```java
if (source == null || source.isEmpty() || target == null || target.isEmpty()) {
    return 0;
}
```

기존의 정상 카운트 동작은 그대로 유지됩니다.

## 검증

`EgovStringUtilTest`에 테스트 3건을 추가했습니다.

- 정상 카운트(`search("aXbXc", "X") == 2` 등)
- 빈 `target` 무한 루프 방지(`assertTimeoutPreemptively`로 2초 내 `0` 반환 확인)
- `null`/빈 입력이 예외 없이 `0` 반환

```
mvn -pl Foundation/org.egovframe.rte.fdl.string -am test -Dtest=EgovStringUtilTest
Tests run: 30, Failures: 0, Errors: 0, Skipped: 0
```