### PR TITLE
fix: convert2CamelCase 빈/null 입력 예외 방지

### DIFF
--- a/Foundation/org.egovframe.rte.fdl.security/src/main/java/org/egovframe/rte/fdl/security/userdetails/util/CamelCaseUtil.java
+++ b/Foundation/org.egovframe.rte.fdl.security/src/main/java/org/egovframe/rte/fdl/security/userdetails/util/CamelCaseUtil.java
@@ -37,6 +37,12 @@ public final class CamelCaseUtil {
     }
 
     public static String convert2CamelCase(String underScore) {
+        // null 또는 빈 문자열은 변환할 대상이 없으므로 그대로 반환한다.
+        // (빈 문자열일 때 isSkipCase의 charAt(0)에서 StringIndexOutOfBoundsException이,
+        //  null일 때 NullPointerException이 발생하던 문제를 방지한다.)
+        if (underScore == null || underScore.isEmpty()) {
+            return underScore;
+        }
         if (isSkipCase(underScore)) {
             return underScore;
         }

--- a/Foundation/org.egovframe.rte.fdl.security/src/test/java/org/egovframe/rte/fdl/security/userdetails/CamelCaseUtilTest.java
+++ b/Foundation/org.egovframe.rte.fdl.security/src/test/java/org/egovframe/rte/fdl/security/userdetails/CamelCaseUtilTest.java
@@ -10,6 +10,7 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 /**
  * CamelCase 유틸리티 테스트 (JUnit 5)
@@ -27,6 +28,16 @@ public class CamelCaseUtilTest {
         assertEquals("column1", CamelCaseUtil.convert2CamelCase("column_1"));
         assertEquals("column1Test", CamelCaseUtil.convert2CamelCase("column_1_test"));
         assertEquals("Column1Test", CamelCaseUtil.convert2CamelCase("_column_1_test_"));
+    }
+
+    /**
+     * 빈 문자열은 charAt(0)에서, null은 NullPointerException이 발생하던 것을
+     * 그대로 반환하도록 가드를 추가했다.
+     */
+    @Test
+    public void convert2CamelCaseEmptyAndNull() {
+        assertEquals("", CamelCaseUtil.convert2CamelCase(""));
+        assertNull(CamelCaseUtil.convert2CamelCase(null));
     }
 
 }

--- a/Persistence/org.egovframe.rte.psl.dataaccess/src/main/java/org/egovframe/rte/psl/dataaccess/util/CamelUtil.java
+++ b/Persistence/org.egovframe.rte.psl.dataaccess/src/main/java/org/egovframe/rte/psl/dataaccess/util/CamelUtil.java
@@ -44,6 +44,12 @@ public final class CamelUtil {
      * @return Camel 표기법 변수명
      */
     public static String convert2CamelCase(String underScore) {
+        // null 또는 빈 문자열은 변환할 대상이 없으므로 그대로 반환한다.
+        // (빈 문자열일 때 charAt(0)에서 StringIndexOutOfBoundsException이,
+        //  null일 때 indexOf 호출에서 NullPointerException이 발생하던 문제를 방지한다.)
+        if (underScore == null || underScore.isEmpty()) {
+            return underScore;
+        }
         // '_' 가 나타나지 않으면 이미 camel case 로 가정함.
         // 단 첫째문자가 대문자이면 camel case 변환 (전체를 소문자로) 처리가
         // 필요하다고 가정함. --> 아래 로직을 수행하면 바뀜

--- a/Persistence/org.egovframe.rte.psl.dataaccess/src/test/java/org/egovframe/rte/psl/dataaccess/utils/CamelUtilTest.java
+++ b/Persistence/org.egovframe.rte.psl.dataaccess/src/test/java/org/egovframe/rte/psl/dataaccess/utils/CamelUtilTest.java
@@ -4,6 +4,7 @@ import org.egovframe.rte.psl.dataaccess.util.CamelUtil;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class CamelUtilTest {
 
@@ -16,6 +17,16 @@ public class CamelUtilTest {
         assertEquals(camelString, CamelUtil.convert2CamelCase(camelString));
         assertEquals("notCamelstring", CamelUtil.convert2CamelCase(notCamelString));
         assertEquals("uppercase", CamelUtil.convert2CamelCase(upperCaseString));
+    }
+
+    /**
+     * 빈 문자열은 charAt(0)에서, null은 indexOf 호출에서 예외가 발생하던 것을
+     * 그대로 반환하도록 가드를 추가했다.
+     */
+    @Test
+    public void testConvert2CamelCaseEmptyAndNull() {
+        assertEquals("", CamelUtil.convert2CamelCase(""));
+        assertNull(CamelUtil.convert2CamelCase(null));
     }
 
 }


### PR DESCRIPTION
## 문제

언더스코어 표기를 카멜 표기로 바꾸는 두 유틸이 빈 문자열·`null` 입력에서 예외를 던집니다.

- `org.egovframe.rte.psl.dataaccess.util.CamelUtil.convert2CamelCase`
- `org.egovframe.rte.fdl.security.userdetails.util.CamelCaseUtil.convert2CamelCase`

```java
// CamelUtil
if (underScore.indexOf('_') < 0 && Character.isLowerCase(underScore.charAt(0))) {
```

빈 문자열이면 `charAt(0)`에서 `StringIndexOutOfBoundsException`이, `null`이면 `indexOf` 호출(`CamelCaseUtil`은 `isSkipCase` 내부)에서 `NullPointerException`이 발생합니다.

특히 `CamelUtil`은 `EgovMap.put`이 **모든 맵 키마다** 호출합니다.

```java
public Object put(Object key, Object value) {
    return super.put(CamelUtil.convert2CamelCase((String) key), value);
}
```

따라서 키가 `null`이거나 빈 문자열이면 MyBatis `EgovMap` resultType 처리 경로에서 예외로 이어질 수 있습니다.

## 수정

두 유틸 모두 진입부에 `null`/빈 문자열 가드를 추가해 입력을 그대로 반환하도록 했습니다.

```java
if (underScore == null || underScore.isEmpty()) {
    return underScore;
}
```

기존 변환 동작은 그대로 유지됩니다.

## 검증

각 테스트 클래스에 빈 문자열·`null` 회귀 테스트를 추가했습니다.

```
mvn -pl Persistence/org.egovframe.rte.psl.dataaccess -am test -Dtest=CamelUtilTest
Tests run: 2, Failures: 0, Errors: 0, Skipped: 0

mvn -pl Foundation/org.egovframe.rte.fdl.security -am test -Dtest=CamelCaseUtilTest
Tests run: 2, Failures: 0, Errors: 0, Skipped: 0
```