### PR TITLE
refactor: EgovUUIdGnrServiceImpl dead assignment 제거

### DIFF
--- a/Foundation/org.egovframe.rte.fdl.idgnr/src/main/java/org/egovframe/rte/fdl/idgnr/impl/EgovUUIdGnrServiceImpl.java
+++ b/Foundation/org.egovframe.rte.fdl.idgnr/src/main/java/org/egovframe/rte/fdl/idgnr/impl/EgovUUIdGnrServiceImpl.java
@@ -177,8 +177,7 @@ public class EgovUUIdGnrServiceImpl implements EgovIdGnrService, ApplicationCont
      */
     public void setAddress(String address) throws FdlException, NoSuchAlgorithmException {
         byte[] addressBytes = new byte[6];
-        Random random = new Random();
-        random = SecureRandom.getInstanceStrong();
+        Random random = SecureRandom.getInstanceStrong();
         random.setSeed(System.currentTimeMillis());
         if (null == address) {
             LOGGER.debug("IDGeneration Service : Using a random number as the base for id's."
@@ -275,7 +274,6 @@ final class TimeBasedUUIDGenerator {
             }
         }
 
-        time = currentTimeMillis;
         // low Time
         time = currentTimeMillis << 32;
         // mid Time


### PR DESCRIPTION
## 내용

`EgovUUIdGnrServiceImpl`에서 바로 다음 줄에 덮어써지는 무의미한 dead assignment 두 곳을 정리했습니다. 동작 변화는 없습니다.

### setAddress

```java
Random random = new Random();
random = SecureRandom.getInstanceStrong();
```

`new Random()` 인스턴스가 생성 직후 버려집니다. 변수를 `SecureRandom.getInstanceStrong()`으로 바로 초기화하도록 했습니다.

```java
Random random = SecureRandom.getInstanceStrong();
```

### generateIdFromTimestamp

```java
time = currentTimeMillis;
// low Time
time = currentTimeMillis << 32;
```

첫 할당이 바로 다음 줄에서 덮어써지므로 제거했습니다.

## 검증

동작 변경이 없는 정리이므로 기존 테스트로 회귀를 확인했습니다.

```
mvn -pl Foundation/org.egovframe.rte.fdl.idgnr -am test
(idgnr 모듈 테스트 28건 통과, 실패/오류 0)
```