### PR TITLE
fix: EgovPartitionFlatFileItemWriter 로그 플레이스홀더 누락 수정

### DIFF
--- a/Batch/org.egovframe.rte.bat.core/src/main/java/org/egovframe/rte/bat/core/item/file/EgovPartitionFlatFileItemWriter.java
+++ b/Batch/org.egovframe.rte.bat.core/src/main/java/org/egovframe/rte/bat/core/item/file/EgovPartitionFlatFileItemWriter.java
@@ -578,7 +578,7 @@ public class EgovPartitionFlatFileItemWriter<T> extends ExecutionContextUserSupp
                     try {
                         stream.close();
                     } catch (IOException e) {
-                        LOGGER.debug("EgovPartitionFlatFileItemWriter initializeBufferedWriter() : {}", e.getClass().getName(), e.getMessage());
+                        LOGGER.debug("EgovPartitionFlatFileItemWriter initializeBufferedWriter() : {} : {}", e.getClass().getName(), e.getMessage());
                     }
                 }
             }


### PR DESCRIPTION
## 개요

`EgovPartitionFlatFileItemWriter.initializeBufferedWriter()`의 예외 로그가 `{}` 플레이스홀더 1개에 인자 2개(예외 클래스명, 예외 메시지)를 전달하여, 예외 메시지가 로그에 출력되지 않습니다. (PMD `InvalidLogMessageFormat`)

## 변경 내용

플레이스홀더를 하나 추가해 예외 클래스명과 메시지가 모두 출력되도록 수정했습니다.

## 검증

`mvn -pl Batch/org.egovframe.rte.bat.core -am compile` 빌드 성공. 로그 출력 정확성만 개선되며 동작 변경은 없습니다.
