### PR TITLE
fix: EgovDateUtil.getDayOfWeekCount 미인식 요일 입력 시 무한 루프 방지

### DIFF
--- a/Foundation/org.egovframe.rte.fdl.string/src/main/java/org/egovframe/rte/fdl/string/EgovDateUtil.java
+++ b/Foundation/org.egovframe.rte.fdl.string/src/main/java/org/egovframe/rte/fdl/string/EgovDateUtil.java
@@ -415,8 +415,21 @@ public class EgovDateUtil {
         int dayOfWeek = cd.get(Calendar.DAY_OF_WEEK);
 
         // 요일이 3자리이면 첫자리만 취한다.
-        if (yoil.length() == 3) {
+        if (yoil != null && yoil.length() == 3) {
             yoil = yoil.substring(0, 1);
+        }
+
+        // 정규화된 요일이 유효 요일집합에 속하는지 검증한다.
+        // 미인식 요일이 들어오면 아래 while 루프가 영원히 일치하지 못해 무한루프에 빠지므로 사전에 차단한다.
+        boolean validYoil = false;
+        for (String s : sYoil) {
+            if (s.equals(yoil)) {
+                validYoil = true;
+                break;
+            }
+        }
+        if (!validYoil) {
+            throw new IllegalArgumentException("요일 인자는 [일, 월, 화, 수, 목, 금, 토] 또는 3자리 형식(예: 월요일)이어야 합니다. 입력값: " + yoil);
         }
 
         while (!sYoil[(dayOfWeek - 1) % 7].equals(yoil)) {

--- a/Foundation/org.egovframe.rte.fdl.string/src/test/java/org/egovframe/rte/fdl/string/EgovDateUtilTest.java
+++ b/Foundation/org.egovframe.rte.fdl.string/src/test/java/org/egovframe/rte/fdl/string/EgovDateUtilTest.java
@@ -1,6 +1,7 @@
 package org.egovframe.rte.fdl.string;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -9,6 +10,7 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import java.text.ParseException;
 import java.util.Calendar;
 import java.util.Date;
+import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -243,6 +245,35 @@ public class EgovDateUtilTest {
         assertEquals(52, EgovDateUtil.getDayOfWeekCount("20090101", "20091231", "금"));
 
         assertEquals(52, EgovDateUtil.getDayOfWeekCount("20090101", "20091231", "토"));
+    }
+
+    /**
+     * [Flow #-7-1] Negative Case : 미인식 요일이 입력되면 무한루프 대신 IllegalArgumentException 을 던진다.
+     * (수정 전에는 sYoil 집합에 없는 요일이 들어오면 while 루프가 영원히 종료되지 않아 무한루프에 빠졌다.)
+     * 무한루프 회귀를 막기 위해 timeout 을 건다.
+     */
+    @Test
+    @Timeout(value = 5, unit = TimeUnit.SECONDS)
+    public void testDayOfWeekCountInvalidYoil() {
+        // 영문 입력(substring 후 "M")
+        assertThrows(IllegalArgumentException.class,
+                () -> EgovDateUtil.getDayOfWeekCount("20090301", "20090331", "Mon"));
+
+        // length 2 입력("월요")
+        assertThrows(IllegalArgumentException.class,
+                () -> EgovDateUtil.getDayOfWeekCount("20090301", "20090331", "월요"));
+
+        // 빈 문자열
+        assertThrows(IllegalArgumentException.class,
+                () -> EgovDateUtil.getDayOfWeekCount("20090301", "20090331", ""));
+
+        // 오타(3자리이지만 정규화 후 미인식)
+        assertThrows(IllegalArgumentException.class,
+                () -> EgovDateUtil.getDayOfWeekCount("20090301", "20090331", "ABC"));
+
+        // null
+        assertThrows(IllegalArgumentException.class,
+                () -> EgovDateUtil.getDayOfWeekCount("20090301", "20090331", null));
     }
 
     /**


### PR DESCRIPTION
## 변경 이유

`EgovDateUtil.getDayOfWeekCount(from, to, yoil)`에 유효 요일 집합 `{일, 월, 화, 수, 목, 금, 토}` 밖의 `yoil` 값이 들어오면 무한 루프가 발생합니다.

```java
while (!sYoil[(dayOfWeek - 1) % 7].equals(yoil)) {
    dayOfWeek++;
}
```

`(dayOfWeek - 1) % 7` 인덱스는 0~6만 순환하므로, `yoil`이 어떤 요일과도 일치하지 못하면 `dayOfWeek`는 무한히 증가하지만 루프는 빠져나오지 못합니다. 영문 입력("Mon"), 길이 2 입력("월요"), 빈 문자열, 3자리 오타, null 등이 이에 해당합니다. 기존 line 418의 정규화는 길이 3("X요일") 형태만 처리하고 입력 검증은 없습니다.

해당 메서드는 `public static`이고 호출 가드가 없어 외부에서 임의의 요일 문자열을 전달할 수 있습니다. 미인식 입력 시 CPU 100% 점유로 이어지는 무한 루프(DoS)가 발생합니다.

## 변경 내용

- 요일 정규화 직후 유효 요일 여부를 사전 검증합니다.
- 미인식 또는 null 입력이면 `IllegalArgumentException`을 던지며, 허용 요일을 메시지에 명시합니다.
- 기존 `while` 루프 로직은 변경하지 않아 유효 입력 경로의 동작을 그대로 보존합니다.

## 테스트 방법

- 미인식 입력 5종(영문, 길이 2, 빈 문자열, 3자리 오타, null)에 대해 `assertThrows(IllegalArgumentException)` 검증을 추가했습니다.
- 무한 루프 회귀를 막기 위해 `@Timeout`을 적용했습니다.
- 기존 유효 요일 테스트를 포함해 `org.egovframe.rte.fdl.string` 모듈 47개 테스트가 모두 통과합니다.

## 영향 범위

- 변경 전에는 미인식 `yoil`이 무한 루프였으므로, 미인식 값으로 정상 결과를 받던 호출자는 존재할 수 없습니다. 따라서 기존 동작과의 호환성은 깨지지 않습니다.
- 유효 요일 입력에 대한 반환 결과는 변경되지 않습니다.
