### PR TITLE
test: EgovDateUtil.getFullAge 분기 커버리지 보강

### DIFF
--- a/Foundation/org.egovframe.rte.fdl.string/src/test/java/org/egovframe/rte/fdl/string/EgovDateUtilTest.java
+++ b/Foundation/org.egovframe.rte.fdl.string/src/test/java/org/egovframe/rte/fdl/string/EgovDateUtilTest.java
@@ -173,6 +173,78 @@ public class EgovDateUtilTest {
     }
 
     /**
+     * [Flow #-4-1] Positive Case : getFullAge() 의 세기 접두/생일 경과 분기를 고정하는 characterization 테스트.
+     * 현재 동작을 그대로 명세화한다(소스 무변경).
+     */
+    @Test
+    public void testGetFullAgeCenturyPrefix() throws ParseException {
+        // 주민번호 7번째 자리 0 → 1800년도 출생 ("18" + YYMMDD)
+        // birthDate=18800101, keyDate=19000101 → 0101>=0101(당일) → 1900-1880 = 20
+        assertEquals(20, EgovDateUtil.getFullAge("8001010000000", "19000101"));
+
+        // 주민번호 7번째 자리 9 → 1800년도 출생
+        // birthDate=18851231, keyDate=19000101 → 0101<1231(생일 전) → 1900-1885-1 = 14
+        assertEquals(14, EgovDateUtil.getFullAge("8512319000000", "19000101"));
+
+        // 주민번호 7번째 자리 1 → 1900년도 출생
+        // birthDate=19770101, keyDate=20090323 → 0323>=0101 → 2009-1977 = 32
+        assertEquals(32, EgovDateUtil.getFullAge("7701011234567", "20090323"));
+
+        // 주민번호 7번째 자리 2 → 1900년도 출생
+        // birthDate=19770101, keyDate=20090323 → 0323>=0101 → 2009-1977 = 32
+        assertEquals(32, EgovDateUtil.getFullAge("7701012234567", "20090323"));
+
+        // 주민번호 7번째 자리 3 → 2000년도 출생 ("20" + YYMMDD)
+        // birthDate=20050101, keyDate=20200101 → 0101>=0101(당일) → 2020-2005 = 15
+        assertEquals(15, EgovDateUtil.getFullAge("0501013000000", "20200101"));
+
+        // 주민번호 7번째 자리 4 → 2000년도 출생
+        // birthDate=20071231, keyDate=20200630 → 0630<1231(생일 전) → 2020-2007-1 = 12
+        assertEquals(12, EgovDateUtil.getFullAge("0712314000000", "20200630"));
+    }
+
+    /**
+     * [Flow #-4-2] Negative/Boundary Case : getFullAge() 의 0 반환 경로(미인식 세기코드, keyDate null)를 고정한다.
+     */
+    @Test
+    public void testGetFullAgeReturnsZero() throws ParseException {
+        // 미인식 세기코드(5,6,7,8) → birthDate=null → 0 반환
+        assertEquals(0, EgovDateUtil.getFullAge("8001015000000", "20200101"));
+        assertEquals(0, EgovDateUtil.getFullAge("8001016000000", "20200101"));
+        assertEquals(0, EgovDateUtil.getFullAge("8001017000000", "20200101"));
+        assertEquals(0, EgovDateUtil.getFullAge("8001018000000", "20200101"));
+
+        // keyDate == null → birthDate 유효해도 0 반환
+        assertEquals(0, EgovDateUtil.getFullAge("7701011234567", null));
+    }
+
+    /**
+     * [Flow #-4-3] Boundary Case : 생일 경과 여부(MMDD 비교) 경계를 고정한다.
+     */
+    @Test
+    public void testGetFullAgeBirthdayBoundary() throws ParseException {
+        // birthDate=19000615
+        // keyDate=20200614 → 0614<0615(생일 전날) → 2020-1900-1 = 119
+        assertEquals(119, EgovDateUtil.getFullAge("0006151000000", "20200614"));
+
+        // keyDate=20200615 → 0615>=0615(생일 당일) → 2020-1900 = 120
+        assertEquals(120, EgovDateUtil.getFullAge("0006151000000", "20200615"));
+
+        // keyDate=20200616 → 0616>=0615(생일 다음날) → 2020-1900 = 120
+        assertEquals(120, EgovDateUtil.getFullAge("0006151000000", "20200616"));
+    }
+
+    /**
+     * [Flow #-4-4] Positive Case : getCurrentFullAge() 가 현재 일자로 getFullAge() 에 위임함을 확인하는 스모크 테스트.
+     */
+    @Test
+    public void testGetCurrentFullAgeDelegation() throws ParseException {
+        // 미인식 세기코드(7번째 자리 5)는 출생년도가 정해지지 않아 현재일자 기준에서도 0 을 반환한다.
+        // (현재일자에 의존하지 않는 결정적 단정으로 위임 동작을 검증한다.)
+        assertEquals(0, EgovDateUtil.getCurrentFullAge("8001015000000"));
+    }
+
+    /**
      * [Flow #-5] Positive Case : 시작일자와 종료일자 사이의 일수(마지막 일자 제외된 일수)
      */
     @Test


### PR DESCRIPTION
## 변경 이유

`EgovDateUtil.getFullAge(socialNo, keyDate)`는 만 나이를 계산하는 메서드로, 주민등록번호 7번째 자리로 출생 세기를 판별하는 다분기 로직을 가집니다. 그러나 기존 테스트는 1900년대 1개 케이스만 검증하여 세기 판별 분기와 생일 경과 분기에 대한 회귀 안전망이 없었습니다.

## 변경 내용

소스는 변경하지 않고 현재 동작을 고정하는 characterization 테스트만 추가했습니다.

- 세기 접두 전수 검증: 7번째 자리 0/9는 1800년대, 1/2는 1900년대, 3/4는 2000년대
- 0 반환 경로: 미인식 세기코드(5~8), keyDate가 null인 경우
- 생일 경계: 기준일 MMDD가 생일 전(만나이-1), 당일, 이후(만나이) 3개 케이스
- `getCurrentFullAge` 위임 스모크: 현재일자 의존을 배제한 결정적 단정만 유지

## 테스트 방법

```bash
mvn -pl Foundation/org.egovframe.rte.fdl.string test
```

EgovDateUtilTest 12건, 모듈 50건 모두 통과합니다. 모든 기대값은 메서드 동작을 산술로 검산하여 명시했습니다.

## 영향 범위

소스 변경 없이 테스트만 추가하므로 런타임 동작에 영향이 없으며 회귀 위험이 없습니다.
