### PR TITLE
refactor: reactive 예외 클래스 message 필드 섀도잉 제거 및 serialVersionUID 추가

### DIFF
--- a/Presentation/org.egovframe.rte.ptl.reactive/src/main/java/org/egovframe/rte/ptl/reactive/exception/EgovException.java
+++ b/Presentation/org.egovframe.rte.ptl.reactive/src/main/java/org/egovframe/rte/ptl/reactive/exception/EgovException.java
@@ -33,9 +33,9 @@ package org.egovframe.rte.ptl.reactive.exception;
  */
 public class EgovException extends RuntimeException {
 
-    protected EgovErrorCode egovErrorCode;
+    private static final long serialVersionUID = 1L;
 
-    protected String message;
+    protected EgovErrorCode egovErrorCode;
 
     public EgovException(EgovErrorCode egovErrorCode) {
         this(egovErrorCode, true, null);
@@ -50,17 +50,12 @@ public class EgovException extends RuntimeException {
     }
 
     public EgovException(EgovErrorCode egovErrorCode, boolean messageCode, String message) {
+        super(messageCode ? egovErrorCode.getMessage() : message);
         this.egovErrorCode = egovErrorCode;
-        if (messageCode) message = egovErrorCode.getMessage();
-        this.message = message;
     }
 
     public EgovErrorCode getEgovErrorCode() {
         return egovErrorCode;
-    }
-
-    public String getMessage() {
-        return message;
     }
 
 }

--- a/Presentation/org.egovframe.rte.ptl.reactive/src/main/java/org/egovframe/rte/ptl/reactive/exception/EgovServiceException.java
+++ b/Presentation/org.egovframe.rte.ptl.reactive/src/main/java/org/egovframe/rte/ptl/reactive/exception/EgovServiceException.java
@@ -33,25 +33,21 @@ package org.egovframe.rte.ptl.reactive.exception;
  */
 public class EgovServiceException extends RuntimeException {
 
-    protected EgovErrorCode egovErrorCode;
+    private static final long serialVersionUID = 1L;
 
-    protected String message;
+    protected EgovErrorCode egovErrorCode;
 
     public EgovServiceException(String message) {
         this(EgovErrorCode.INTERNAL_SERVER_ERROR, message);
     }
 
     public EgovServiceException(EgovErrorCode egovErrorCode, String message) {
+        super(message);
         this.egovErrorCode = egovErrorCode;
-        this.message = message;
     }
 
     public EgovErrorCode getEgovErrorCode() {
         return egovErrorCode;
-    }
-
-    public String getMessage() {
-        return message;
     }
 
 }

--- a/Presentation/org.egovframe.rte.ptl.reactive/src/test/java/org/egovframe/rte/ptl/reactive/exception/EgovExceptionTest.java
+++ b/Presentation/org.egovframe.rte.ptl.reactive/src/test/java/org/egovframe/rte/ptl/reactive/exception/EgovExceptionTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2008-2024 MOIS(Ministry of the Interior and Safety).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.egovframe.rte.ptl.reactive.exception;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+/**
+ * EgovException 단위 테스트
+ *
+ * <p>각 생성자의 getMessage() 반환값(동작 보존)과 Throwable 표준 메시지 전파(개선)를 검증한다.</p>
+ */
+public class EgovExceptionTest {
+
+    @Test
+    public void messageConstructor() {
+        EgovException ex = new EgovException("invalid");
+
+        assertEquals("invalid", ex.getMessage());
+        assertSame(EgovErrorCode.INVALID_INPUT_VALUE, ex.getEgovErrorCode());
+    }
+
+    @Test
+    public void errorCodeAndMessageConstructor() {
+        EgovException ex = new EgovException(EgovErrorCode.NOT_FOUND, "custom");
+
+        assertEquals("custom", ex.getMessage());
+        assertSame(EgovErrorCode.NOT_FOUND, ex.getEgovErrorCode());
+    }
+
+    @Test
+    public void errorCodeConstructorUsesErrorCodeMessage() {
+        EgovException ex = new EgovException(EgovErrorCode.NOT_FOUND);
+
+        assertEquals(EgovErrorCode.NOT_FOUND.getMessage(), ex.getMessage());
+        assertSame(EgovErrorCode.NOT_FOUND, ex.getEgovErrorCode());
+    }
+
+    @Test
+    public void messageIsPropagatedToThrowable() {
+        RuntimeException re = new EgovException(EgovErrorCode.NOT_FOUND, "custom");
+
+        // 수정 전에는 super(message)를 호출하지 않아 null 이었음(개선 입증)
+        assertEquals("custom", re.getMessage());
+    }
+
+}

--- a/Presentation/org.egovframe.rte.ptl.reactive/src/test/java/org/egovframe/rte/ptl/reactive/exception/EgovServiceExceptionTest.java
+++ b/Presentation/org.egovframe.rte.ptl.reactive/src/test/java/org/egovframe/rte/ptl/reactive/exception/EgovServiceExceptionTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2008-2024 MOIS(Ministry of the Interior and Safety).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.egovframe.rte.ptl.reactive.exception;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+/**
+ * EgovServiceException 단위 테스트
+ *
+ * <p>각 생성자의 getMessage() 반환값(동작 보존)과 Throwable 표준 메시지 전파(개선)를 검증한다.</p>
+ */
+public class EgovServiceExceptionTest {
+
+    @Test
+    public void messageConstructor() {
+        EgovServiceException ex = new EgovServiceException("failed");
+
+        assertEquals("failed", ex.getMessage());
+        assertSame(EgovErrorCode.INTERNAL_SERVER_ERROR, ex.getEgovErrorCode());
+    }
+
+    @Test
+    public void errorCodeAndMessageConstructor() {
+        EgovServiceException ex = new EgovServiceException(EgovErrorCode.SERVICE_UNAVAILABLE, "failed");
+
+        assertEquals("failed", ex.getMessage());
+        assertSame(EgovErrorCode.SERVICE_UNAVAILABLE, ex.getEgovErrorCode());
+    }
+
+    @Test
+    public void messageIsPropagatedToThrowable() {
+        RuntimeException re = new EgovServiceException(EgovErrorCode.SERVICE_UNAVAILABLE, "failed");
+
+        // 수정 전에는 super(message)를 호출하지 않아 null 이었음(개선 입증)
+        assertEquals("failed", re.getMessage());
+    }
+
+}


### PR DESCRIPTION
## 배경

`org.egovframe.rte.ptl.reactive.exception` 패키지의 `EgovException`과 `EgovServiceException`은 `RuntimeException`을 상속하면서 `protected String message` 필드를 별도로 선언해 `Throwable.message`를 섀도잉했습니다. 생성자에서 `super(message)`를 호출하지 않고 자체 필드에만 값을 저장한 뒤 `getMessage()`를 오버라이드해 그 필드를 반환하는 구조였습니다.

동작 자체는 유지됐으나, 표준 `Throwable`의 메시지가 설정되지 않아 메시지가 자체 필드 경로에만 존재하고, 필드 섀도잉이라는 코드 스멜이 남아 있었습니다. 또한 두 클래스 모두 `RuntimeException` 상속으로 `Serializable`이지만 `serialVersionUID`가 선언되어 있지 않았습니다.

## 변경 내용

- `protected String message` 필드와 `getMessage()` 오버라이드를 제거하고, 생성자에서 `super(message)`를 호출해 표준 `Throwable` 메시지로 전파하도록 변경했습니다.
  - `EgovException`은 메시지 코드 분기를 보존했습니다: `super(messageCode ? egovErrorCode.getMessage() : message)`.
- `serialVersionUID`를 추가해 SpotBugs `SE_NO_SERIALVERSIONID` 경고를 해소했습니다. (예외 클래스의 표준 관례에 따른 정적분석 경고 해소이며, 직렬화 동작을 새로 활성화하거나 보장하는 변경은 아닙니다.)
- `egovErrorCode` 필드, `getEgovErrorCode()`, 위임 생성자는 스코프를 한정하기 위해 변경하지 않았습니다.

## 검증

- 모든 생성자에서 `getMessage()` 반환값이 변경 전과 동일함을 확인했습니다(동작 보존).
- 신규 단위테스트 7건을 추가하고 기존 `EgovExceptionHandlerTest` 회귀 테스트가 통과했습니다.
- 모듈 테스트 9건 전부 통과했습니다.

## 영향 범위

- `getMessage()` 반환값이 동일해 외부 동작은 보존됩니다.
- 두 예외 클래스를 상속하는 서브클래스나 `message` 필드를 직접 참조하는 외부 코드가 없음을 확인했습니다.
- 개선점: 표준 `Throwable` 메시지 전파, 필드 섀도잉 제거, 정적분석 경고 해소.
