### PR TITLE
fix: PaginationInfo 0 분모 나눗셈 예외(/ by zero) 방지 가드 추가

### DIFF
--- a/Presentation/org.egovframe.rte.ptl.mvc/src/main/java/org/egovframe/rte/ptl/mvc/tags/ui/pagination/PaginationInfo.java
+++ b/Presentation/org.egovframe.rte.ptl.mvc/src/main/java/org/egovframe/rte/ptl/mvc/tags/ui/pagination/PaginationInfo.java
@@ -122,6 +122,10 @@ public class PaginationInfo {
     }
 
     public int getTotalPageCount() {
+        if (getRecordCountPerPage() <= 0 || getTotalRecordCount() <= 0) {
+            totalPageCount = 0;
+            return totalPageCount;
+        }
         totalPageCount = ((getTotalRecordCount() - 1) / getRecordCountPerPage()) + 1;
         return totalPageCount;
     }
@@ -135,6 +139,10 @@ public class PaginationInfo {
     }
 
     public int getFirstPageNoOnPageList() {
+        if (getPageSize() <= 0) {
+            firstPageNoOnPageList = 1;
+            return firstPageNoOnPageList;
+        }
         firstPageNoOnPageList = ((getCurrentPageNo() - 1) / getPageSize()) * getPageSize() + 1;
         return firstPageNoOnPageList;
     }

--- a/Presentation/org.egovframe.rte.ptl.mvc/src/test/java/org/egovframe/rte/ptl/mvc/tags/ui/pagination/PaginationTest.java
+++ b/Presentation/org.egovframe.rte.ptl.mvc/src/test/java/org/egovframe/rte/ptl/mvc/tags/ui/pagination/PaginationTest.java
@@ -47,4 +47,55 @@ public class PaginationTest {
         assertEquals(0, tag.doStartTag());
     }
 
+    /**
+     * recordCountPerPage 가 미설정(기본값 0)인 경우 getTotalPageCount() 에서
+     * '/ by zero' ArithmeticException 이 발생하지 않고 0 을 반환하는지 검증한다.
+     */
+    @Test
+    public void totalPageCountWithZeroRecordCountPerPageTest() {
+        PaginationInfo pageInfo = new PaginationInfo();
+        pageInfo.setTotalRecordCount(51);
+        assertEquals(0, pageInfo.getTotalPageCount());
+    }
+
+    /**
+     * pageSize 가 미설정(기본값 0)인 경우 getFirstPageNoOnPageList() 에서
+     * '/ by zero' ArithmeticException 이 발생하지 않고 1 을 반환하는지 검증한다.
+     */
+    @Test
+    public void firstPageNoOnPageListWithZeroPageSizeTest() {
+        PaginationInfo pageInfo = new PaginationInfo();
+        pageInfo.setCurrentPageNo(1);
+        assertEquals(1, pageInfo.getFirstPageNoOnPageList());
+    }
+
+    /**
+     * 전체 건수가 0 이면 페이지 수는 0 이어야 한다.
+     */
+    @Test
+    public void totalPageCountWithZeroTotalRecordCountTest() {
+        PaginationInfo pageInfo = new PaginationInfo();
+        pageInfo.setRecordCountPerPage(10);
+        pageInfo.setTotalRecordCount(0);
+        assertEquals(0, pageInfo.getTotalPageCount());
+    }
+
+    /**
+     * 정상 입력에 대한 계산 결과가 수정 전과 동일하게 유지되는지 회귀 검증한다.
+     */
+    @Test
+    public void paginationCalculationRegressionTest() {
+        PaginationInfo pageInfo = new PaginationInfo();
+        pageInfo.setCurrentPageNo(3);
+        pageInfo.setPageSize(5);
+        pageInfo.setRecordCountPerPage(10);
+        pageInfo.setTotalRecordCount(51);
+
+        assertEquals(6, pageInfo.getTotalPageCount());
+        assertEquals(1, pageInfo.getFirstPageNoOnPageList());
+        assertEquals(5, pageInfo.getLastPageNoOnPageList());
+        assertEquals(20, pageInfo.getFirstRecordIndex());
+        assertEquals(30, pageInfo.getLastRecordIndex());
+    }
+
 }


### PR DESCRIPTION
## 변경 이유

`PaginationInfo.getTotalPageCount()`는 `((getTotalRecordCount() - 1) / getRecordCountPerPage()) + 1`을 계산합니다(`PaginationInfo.java:122` 부근). `recordCountPerPage`는 plain `int` 필드이며 public 세터로 외부에서 설정되는데, 미설정 시 기본값이 `0`이라 분모가 `0`이 되어 정수 나눗셈에서 `ArithmeticException: / by zero`가 발생합니다.

`getFirstPageNoOnPageList()`도 동일하게 `((getCurrentPageNo() - 1) / getPageSize()) * getPageSize() + 1`에서 `pageSize == 0`이면 같은 예외가 발생합니다(`PaginationInfo.java:139` 부근).

필드가 plain `int`이고 public 세터로 노출되어 있어, 세터를 호출하지 않은 인스턴스가 그대로 사용되는 미설정 상태에 도달 가능합니다.

## 변경 내용

- `getTotalPageCount()`: `recordCountPerPage <= 0` 또는 `totalRecordCount <= 0`이면 `totalPageCount = 0`을 반환하도록 가드를 추가했습니다(페이지 없음).
- `getFirstPageNoOnPageList()`: `pageSize <= 0`이면 `firstPageNoOnPageList = 1`을 반환하도록 가드를 추가했습니다(첫 페이지).
- 정상 입력(분모 > 0)에서는 기존 계산식과 결과가 동일하며, 0/음수 분모에서만 예외 대신 안전한 폴백을 반환합니다.

## 테스트 방법

`PaginationTest`에 버그 재현 및 회귀 테스트를 추가했습니다.

- 수정 전: `recordCountPerPage == 0`에서 `getTotalPageCount()`가, `pageSize == 0`에서 `getFirstPageNoOnPageList()`가 각각 `ArithmeticException`을 던지는 것을 재현합니다.
- 수정 후: 동일 입력에서 예외 없이 폴백 값(0, 1)을 반환합니다.
- 정상 입력에서 페이지 수·첫 페이지 번호 계산 결과가 변하지 않음을 함께 검증합니다(총 4건).

## 영향 범위

- 대상: `org.egovframe.rte.ptl.mvc.tags.ui.pagination.PaginationInfo`의 `getTotalPageCount`, `getFirstPageNoOnPageList`.
- public 메서드 시그니처 변경 없음. 정상 입력 결과 불변이므로 기존 페이징 동작과 하위 호환됩니다.
- 외부 의존성·설정 변경 없음.
