### PR TITLE
fix: EgovSAXValidatorService XXE 방어 적용 및 JAXP 파서로 현대화

### DIFF
--- a/Foundation/org.egovframe.rte.fdl.xml/src/main/java/org/egovframe/rte/fdl/xml/EgovSAXValidatorService.java
+++ b/Foundation/org.egovframe.rte.fdl.xml/src/main/java/org/egovframe/rte/fdl/xml/EgovSAXValidatorService.java
@@ -22,8 +22,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xml.sax.SAXException;
 import org.xml.sax.XMLReader;
-import org.xml.sax.helpers.XMLReaderFactory;
 
+import javax.xml.XMLConstants;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.parsers.SAXParserFactory;
 import java.io.IOException;
 import java.util.Set;
 
@@ -70,8 +72,26 @@ public class EgovSAXValidatorService extends AbstractXMLUtility {
             LOGGER.debug(message);
         }
 
-        //파서를 생성한다. SAX 파서는 파서의 직접 생성이 가능하다.
-        XMLReader parser = XMLReaderFactory.createXMLReader("org.apache.xerces.parsers.SAXParser");
+        // 파서를 생성한다. 제거된 standalone Xerces 클래스 대신 JAXP SAXParserFactory(JDK 내장 파서)를 사용한다.
+        SAXParserFactory saxParserFactory = SAXParserFactory.newInstance();
+
+        // XXE(XML External Entity) 방어 - 외부 엔티티/외부 DTD 로딩을 차단한다.
+        // 형제 클래스 EgovDOMValidatorService와 동일한 보안 처리(2026.02.28 KISA 조치)를 적용한다.
+        try {
+            saxParserFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+            saxParserFactory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+            saxParserFactory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+            saxParserFactory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+        } catch (ParserConfigurationException | SAXException e) {
+            LOGGER.debug("SAX parser does not support one or more XXE-related features: {}", e.getMessage());
+        }
+
+        XMLReader parser;
+        try {
+            parser = saxParserFactory.newSAXParser().getXMLReader();
+        } catch (ParserConfigurationException e) {
+            throw new SAXException(e);
+        }
         parser.setFeature("http://xml.org/sax/features/validation", isValid);
         if (getSCHEMAFile() != null) {
             parser.setFeature("http://apache.org/xml/features/validation/schema", true);

--- a/Foundation/org.egovframe.rte.fdl.xml/src/test/java/org/egovframe/rte/fdl/xml/EgovSAXValidatorXxeTest.java
+++ b/Foundation/org.egovframe.rte.fdl.xml/src/test/java/org/egovframe/rte/fdl/xml/EgovSAXValidatorXxeTest.java
@@ -1,0 +1,34 @@
+package org.egovframe.rte.fdl.xml;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * {@link EgovSAXValidatorService} 의 XXE(XML External Entity) 방어를 검증한다.
+ *
+ * <p>형제 클래스 {@code EgovDOMValidatorService} 와 달리 SAX 파서에는 외부 엔티티/외부 DTD
+ * 차단이 적용되지 않아, 외부 엔티티를 참조하는 XML 입력 시 외부 리소스에 접근(XXE, CWE-611)할
+ * 수 있었다. 외부 엔티티 차단이 적용되면 선언된 외부 엔티티를 해석하지 않으므로, 존재하지 않는
+ * 파일을 가리키는 외부 엔티티가 있어도 파일 접근 시도(및 그로 인한 예외) 없이 파싱이 완료된다.</p>
+ */
+class EgovSAXValidatorXxeTest {
+
+    @Test
+    @DisplayName("외부 일반 엔티티는 해석되지 않아 외부 리소스에 접근하지 않는다")
+    void externalGeneralEntityIsNotResolved() {
+        // 외부 엔티티가 해석되면 존재하지 않는 파일에 접근해 예외가 발생한다.
+        // 방어가 적용되면 엔티티를 해석하지 않아 예외 없이 정상(well-formed) 파싱된다.
+        String xml = "<?xml version=\"1.0\"?>\n"
+                + "<!DOCTYPE root [ <!ENTITY xxe SYSTEM \"file:///nonexistent-xxe-probe-egovframe\"> ]>\n"
+                + "<root>&xxe;</root>";
+
+        EgovSAXValidatorService saxValidator = new EgovSAXValidatorService();
+        saxValidator.setXML(xml);
+
+        boolean wellFormed = assertDoesNotThrow(() -> saxValidator.parse(false));
+        assertTrue(wellFormed, "외부 엔티티 차단 시 외부 리소스 접근 없이 well-formed 파싱되어야 한다");
+    }
+}


### PR DESCRIPTION
## 변경 이유

`EgovSAXValidatorService.parse()`가 SAX 파서에 외부 엔티티/외부 DTD 차단을 적용하지 않아, 외부 엔티티를 참조하는 XML 입력 시 외부 리소스에 접근(XXE, CWE-611)할 수 있었습니다.

형제 클래스 `EgovDOMValidatorService`에는 2026.02.28 KISA 조치로 동일 방어(`FEATURE_SECURE_PROCESSING`, 외부 일반/파라미터 엔티티·외부 DTD 로딩 차단)가 적용돼 있으나 SAX 검증기에는 누락돼 있었습니다.

추가로 파서를 Java 9에서 제거된 standalone Xerces 클래스명(`org.apache.xerces.parsers.SAXParser`)으로 직접 생성하고 있어, 해당 라이브러리가 없는 현행 JDK 환경에서는 `parse()`가 동작하지 않았습니다(`SAX2 driver class ... not found`).

## 변경 내용

- 파서 생성을 JAXP `SAXParserFactory`(JDK 내장 파서)로 변경합니다. 형제 DOM 검증기가 `DocumentBuilderFactory`를 쓰는 것과 동일한 방식입니다.
- `FEATURE_SECURE_PROCESSING`과 외부 일반/파라미터 엔티티·외부 DTD 로딩 차단을 적용합니다.
- 기존 검증(validation)·스키마 설정은 그대로 유지합니다.

## 테스트 방법

- `EgovSAXValidatorXxeTest`: 존재하지 않는 파일을 가리키는 외부 엔티티가 선언된 XML을 파싱할 때, 외부 엔티티가 해석되지 않아 외부 리소스 접근 없이 well-formed로 처리됨을 검증합니다. (차단 기능 제거 시 외부 리소스 접근 시도로 예외가 발생함을 확인했습니다.)
- 기존 `ControlXMLTest` 회귀를 확인했습니다.

## 영향 범위

SAX 검증기의 파서 생성·보안 설정만 변경하며 검증 결과 동작은 동일합니다.
