### PR TITLE
fix: TypeLoaderUsingMetadata 타입 캐시 동시성 안전성 개선

### DIFF
--- a/Integration/org.egovframe.rte.itl.integration/src/main/java/org/egovframe/rte/itl/integration/type/support/TypeLoaderUsingMetadata.java
+++ b/Integration/org.egovframe.rte.itl.integration/src/main/java/org/egovframe/rte/itl/integration/type/support/TypeLoaderUsingMetadata.java
@@ -24,6 +24,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.InitializingBean;
 
 import java.util.HashMap;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.Map;
 import java.util.Map.Entry;
 
@@ -56,7 +57,8 @@ public class TypeLoaderUsingMetadata implements TypeLoader, InitializingBean {
     /**
      * 기존에 load된 Type을 담고 있는 map
      */
-    private Map<String, Type> typePool = new HashMap<String, Type>();
+    // 싱글톤 빈으로 주입되어 여러 스레드에서 getType()으로 동시 접근되므로 thread-safe 맵을 사용한다.
+    private Map<String, Type> typePool = new ConcurrentHashMap<String, Type>();
 
     /**
      * Default Constructor
@@ -210,9 +212,9 @@ public class TypeLoaderUsingMetadata implements TypeLoader, InitializingBean {
             loadingTypes.remove(id);
         }
 
-        typePool.put(id, type);
-
-        return type;
+        // 동시에 같은 id를 load한 다른 스레드가 있으면 먼저 등록된 인스턴스를 정본으로 사용한다.
+        Type existing = typePool.putIfAbsent(id, type);
+        return existing != null ? existing : type;
     }
 
 }

--- a/Integration/org.egovframe.rte.itl.integration/src/test/java/org/egovframe/rte/itl/integration/type/support/TypeLoaderUsingMetadataConcurrencyTest.java
+++ b/Integration/org.egovframe.rte.itl.integration/src/test/java/org/egovframe/rte/itl/integration/type/support/TypeLoaderUsingMetadataConcurrencyTest.java
@@ -1,0 +1,73 @@
+package org.egovframe.rte.itl.integration.type.support;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import org.egovframe.rte.itl.integration.type.Type;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * {@link TypeLoaderUsingMetadata} 의 동시 {@code getType} 호출에 대한 캐시 안전성을 검증한다.
+ *
+ * <p>{@code typePool} 은 싱글톤 빈에서 여러 스레드가 {@code getType} 으로 공유하는데, 이전
+ * 구현은 동기화 없는 {@code HashMap} 을 검사 후 갱신해 콜드 캐시에 동시 진입하면 맵 손상이나
+ * 스레드별로 서로 다른 인스턴스 반환이 발생할 수 있었다. {@code ConcurrentHashMap} 과
+ * {@code putIfAbsent} 적용 후, 동시 호출이 예외 없이 동일한 정본 인스턴스를 반환함을 검증한다.</p>
+ */
+class TypeLoaderUsingMetadataConcurrencyTest {
+
+    @Test
+    @DisplayName("동일 타입을 동시에 load해도 예외 없이 같은 정본 인스턴스를 반환한다")
+    void concurrentGetTypeReturnsCanonicalInstance() throws Exception {
+        // boolean[] 는 리스트-원시 타입이라 RecordTypeDefinitionDao 없이 캐싱 경로를 탄다.
+        TypeLoaderUsingMetadata loader = new TypeLoaderUsingMetadata();
+
+        int threads = 16;
+        ExecutorService pool = Executors.newFixedThreadPool(threads);
+        CountDownLatch ready = new CountDownLatch(threads);
+        CountDownLatch start = new CountDownLatch(1);
+        CountDownLatch done = new CountDownLatch(threads);
+        List<Type> results = Collections.synchronizedList(new ArrayList<>());
+        List<Throwable> errors = Collections.synchronizedList(new ArrayList<>());
+
+        try {
+            for (int i = 0; i < threads; i++) {
+                pool.submit(() -> {
+                    ready.countDown();
+                    try {
+                        start.await();
+                        results.add(loader.getType("boolean[]"));
+                    } catch (Throwable t) {
+                        errors.add(t);
+                    } finally {
+                        done.countDown();
+                    }
+                });
+            }
+
+            assertTrue(ready.await(5, TimeUnit.SECONDS));
+            start.countDown();
+            assertTrue(done.await(5, TimeUnit.SECONDS));
+        } finally {
+            pool.shutdownNow();
+        }
+
+        assertTrue(errors.isEmpty(), "동시 getType 중 예외가 발생하지 않아야 한다: " + errors);
+        assertEquals(threads, results.size());
+
+        Type canonical = loader.getType("boolean[]");
+        for (Type t : results) {
+            assertSame(canonical, t, "모든 스레드가 캐시된 동일 인스턴스를 반환해야 한다");
+        }
+    }
+}


### PR DESCRIPTION
## 변경 이유

`TypeLoaderUsingMetadata.typePool`이 동기화 없는 `HashMap`입니다. 이 클래스는 싱글톤 빈으로 주입되고(`TypeLoader` 인터페이스의 public `getType()`), 웹서비스 연계 처리 등에서 여러 스레드가 동시에 호출합니다.

`getType()`은 캐시를 `typePool.get(id)`로 검사한 뒤 로딩 후 `typePool.put(id, type)`로 갱신합니다. 콜드 캐시에 동시 진입하면:
- `HashMap`에 대한 동시 `put`으로 맵 손상(리사이즈 중 무한 루프·엔트리 유실)이 발생할 수 있고,
- 각 스레드가 자신이 만든 인스턴스를 그대로 반환해 동일 타입에 대해 서로 다른 인스턴스가 돌아갑니다.

## 변경 내용

- `typePool`을 `ConcurrentHashMap`으로 변경합니다.
- 로딩 후 `putIfAbsent`로 먼저 등록된 인스턴스를 정본으로 반환해, 동시 호출에도 동일 타입에 대해 일관된 인스턴스를 제공합니다.

단일 스레드 동작은 동일합니다(`putIfAbsent`가 null을 반환하므로 새로 만든 인스턴스를 반환).

## 테스트 방법

`TypeLoaderUsingMetadataConcurrencyTest`: 16개 스레드가 동일 타입(`boolean[]`)을 동시에 `getType` 호출했을 때 예외 없이 모두 같은 정본 인스턴스를 반환함을 검증합니다. (변경 전 코드에서는 스레드마다 다른 인스턴스를 반환해 이 단정이 실패함을 확인했습니다.) 모듈 전체 테스트(67건) 회귀를 확인했습니다.

## 영향 범위

타입 캐시 맵의 동시성 처리만 변경하며 반환 타입의 의미는 동일합니다. 머지된 동시성 개선(StringTimestampTypeHandler·AuthorityResourceMetadata)과 같은 맥락입니다.
