### PR TITLE
fix: reactive 예외 핸들러 JSON 응답 UTF-8 인코딩 명시

### DIFF
--- a/Presentation/org.egovframe.rte.ptl.reactive/src/main/java/org/egovframe/rte/ptl/reactive/exception/EgovExceptionHandler.java
+++ b/Presentation/org.egovframe.rte.ptl.reactive/src/main/java/org/egovframe/rte/ptl/reactive/exception/EgovExceptionHandler.java
@@ -25,6 +25,7 @@ import org.springframework.web.server.ServerWebExchange;
 import org.springframework.web.server.WebExceptionHandler;
 import reactor.core.publisher.Mono;
 
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -78,14 +79,14 @@ public class EgovExceptionHandler implements WebExceptionHandler {
 
     private Mono<Void> handlerResponse(ServerHttpResponse response, String timestamp, int status, String code, String message) {
         response.setStatusCode(HttpStatus.valueOf(status));
-        response.getHeaders().setContentType(MediaType.APPLICATION_JSON);
+        response.getHeaders().setContentType(new MediaType(MediaType.APPLICATION_JSON, StandardCharsets.UTF_8));
         Map<String, Object> map = new HashMap<>();
         map.put("timestamp", timestamp);
         map.put("status", HttpStatus.valueOf(status));
         map.put("code", code);
         map.put("message", message);
         JSONObject jsonObject = new JSONObject(map);
-        DataBuffer dataBuffer = response.bufferFactory().wrap(JSONObject.toJSONString(jsonObject).getBytes());
+        DataBuffer dataBuffer = response.bufferFactory().wrap(JSONObject.toJSONString(jsonObject).getBytes(StandardCharsets.UTF_8));
         return response.writeWith(Mono.just(dataBuffer));
     }
 

--- a/Presentation/org.egovframe.rte.ptl.reactive/src/test/java/org/egovframe/rte/ptl/reactive/exception/EgovExceptionHandlerTest.java
+++ b/Presentation/org.egovframe.rte.ptl.reactive/src/test/java/org/egovframe/rte/ptl/reactive/exception/EgovExceptionHandlerTest.java
@@ -1,11 +1,18 @@
 package org.egovframe.rte.ptl.reactive.exception;
 
+import org.egovframe.rte.ptl.reactive.annotation.EgovController;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.reactive.server.WebTestClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import reactor.core.publisher.Mono;
+
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ExtendWith(SpringExtension.class)
 public class EgovExceptionHandlerTest {
@@ -14,7 +21,7 @@ public class EgovExceptionHandlerTest {
 
     @BeforeEach
     public void setUp() {
-        this.webTestClient = WebTestClient.bindToController(new SampleController())
+        this.webTestClient = WebTestClient.bindToController(new SampleController(), new KoreanMessageController())
                 .controllerAdvice(new EgovExceptionHandler())
                 .build();
     }
@@ -25,7 +32,30 @@ public class EgovExceptionHandlerTest {
                 .uri("/test")
                 .accept(MediaType.APPLICATION_JSON)
                 .exchange()
-                .expectStatus().isNotFound();
+                .expectStatus().isNotFound()
+                .expectHeader().contentType(MediaType.parseMediaType("application/json;charset=UTF-8"));
+    }
+
+    @Test
+    public void koreanMessageTest() {
+        this.webTestClient.get()
+                .uri("/korean-message")
+                .accept(MediaType.APPLICATION_JSON)
+                .exchange()
+                .expectStatus().is5xxServerError()
+                .expectBody()
+                .consumeWith(result -> assertTrue(new String(result.getResponseBody(), StandardCharsets.UTF_8)
+                        .contains("\"message\":\"서비스 예외 메시지\"")));
+    }
+
+    @EgovController
+    private static class KoreanMessageController {
+
+        @GetMapping("/korean-message")
+        public Mono<String> koreanMessage() {
+            return Mono.error(new EgovServiceException("서비스 예외 메시지"));
+        }
+
     }
 
 }


### PR DESCRIPTION
## 변경 이유

reactive 모듈 전역 예외 핸들러(`EgovExceptionHandler`)가 JSON 에러 응답 본문을 플랫폼 기본 charset으로 직렬화합니다.

- `handlerResponse`(EgovExceptionHandler.java:88)는 `JSONObject.toJSONString(...).getBytes()`로 본문을 인코딩합니다. 인자 없는 `getBytes()`는 JVM 기본 charset(`file.encoding`)을 사용하므로, 기본값이 UTF-8이 아닌 환경(예: MS949 한글 Windows 서버)에서는 응답 바이트가 깨집니다.
- 응답 Content-Type은 `application/json`(L81)으로 charset이 명시되지 않습니다. JSON은 RFC 8259상 UTF-8이어야 합니다.
- 핸들러는 `EgovServiceException.getMessage()`를 그대로 본문에 담습니다. 애플리케이션이 한글 예외 메시지를 던지면 클라이언트가 받는 에러 메시지가 깨질 수 있습니다.

## 변경 내용

`EgovExceptionHandler.handlerResponse`만 수정했습니다.

- 응답 Content-Type을 `application/json;charset=UTF-8`로 명시(`new MediaType(MediaType.APPLICATION_JSON, StandardCharsets.UTF_8)`).
- 본문 직렬화를 `getBytes(StandardCharsets.UTF_8)`로 변경.

기존 로직과 메서드 시그니처는 그대로 두었습니다.

## 테스트 방법

`EgovExceptionHandlerTest`에 회귀 테스트를 추가했습니다.

- 기존 테스트에 응답 Content-Type이 `application/json;charset=UTF-8`인지 단정을 추가. 이 단정은 수정 전(charset 미명시)에는 실패하고 수정 후 통과하므로, 플랫폼 기본 charset과 무관하게 결정적으로 검증됩니다.
- 한글 메시지를 담은 `EgovServiceException` 경로를 추가해 응답 본문을 UTF-8로 디코딩했을 때 한글이 보존되는지 단정.

```
mvn -pl Presentation/org.egovframe.rte.ptl.reactive -am test -Dtest=EgovExceptionHandlerTest -Dsurefire.failIfNoSpecifiedTests=false
```

테스트 2건 통과(실패 0).

## 영향 범위

- reactive 모듈 에러 응답 경로에 한정되며, 정상 응답 경로는 영향이 없습니다.
- 응답 charset이 UTF-8로 고정되므로 기존에 우연히 기본 charset이 UTF-8이던 환경에서는 동작이 그대로입니다. UTF-8이 아니던 환경에서는 한글 등 비ASCII 에러 메시지가 정상 표기됩니다.