### PR TITLE
fix(filehandling): EgovFileUtil.readFile 빈 파일 NoSuchElementException 방지

### DIFF
--- a/Foundation/org.egovframe.rte.fdl.filehandling/src/main/java/org/egovframe/rte/fdl/filehandling/EgovFileUtil.java
+++ b/Foundation/org.egovframe.rte.fdl.filehandling/src/main/java/org/egovframe/rte/fdl/filehandling/EgovFileUtil.java
@@ -181,13 +181,8 @@ public class EgovFileUtil {
         StringBuffer sb = new StringBuffer();
         List<String> lines = readTextLines(file, encoding);
 
-        for (Iterator<String> it = lines.iterator(); ; ) {
+        for (Iterator<String> it = lines.iterator(); it.hasNext(); ) {
             sb.append(it.next());
-            if (it.hasNext()) {
-                sb.append("");
-            } else {
-                break;
-            }
         }
 
         return sb.toString();

--- a/Foundation/org.egovframe.rte.fdl.filehandling/src/test/java/org/egovframe/rte/fdl/filehandling/FilehandlingServiceTest.java
+++ b/Foundation/org.egovframe.rte.fdl.filehandling/src/test/java/org/egovframe/rte/fdl/filehandling/FilehandlingServiceTest.java
@@ -223,6 +223,26 @@ public class FilehandlingServiceTest {
     }
 
     /**
+     * 빈 파일 읽기 테스트. 내용이 없는 파일은 빈 문자열을 반환해야 한다.
+     */
+    @Test
+    public void testReadEmptyFile() throws IOException {
+        String emptyPath = tmppath + "/empty.txt";
+        EgovFileUtil.writeFile(emptyPath, "", "UTF-8");
+        assertEquals("", EgovFileUtil.readFile(new File(emptyPath), "UTF-8"));
+    }
+
+    /**
+     * 여러 줄 파일 읽기 테스트. 줄들이 종전과 동일하게 연결되어야 한다.
+     */
+    @Test
+    public void testReadMultiLineFile() throws IOException {
+        String multiPath = tmppath + "/multiline.txt";
+        EgovFileUtil.writeFile(multiPath, "line1\nline2\nline3", "UTF-8");
+        assertEquals("line1line2line3", EgovFileUtil.readFile(new File(multiPath), "UTF-8"));
+    }
+
+    /**
      * 파일 복사 테스트.
      */
     @Test


### PR DESCRIPTION
## 문제

`EgovFileUtil.readFile(File, encoding)`의 라인 결합 루프가 `hasNext()` 검사 없이 `it.next()`를 먼저 호출한다.

```java
for (Iterator<String> it = lines.iterator(); ; ) {
    sb.append(it.next());          // 빈 리스트면 즉시 예외
    if (it.hasNext()) {
        sb.append("");             // 항상 no-op (죽은 코드)
    } else {
        break;
    }
}
```

내용이 없는 파일은 라인 리스트가 비어 있어 첫 `it.next()`에서 `NoSuchElementException`이 미포착 전파된다. 기대값은 빈 문자열이다.

## 수정

표준 `hasNext()` 가드 루프로 교체했다.

```java
for (Iterator<String> it = lines.iterator(); it.hasNext(); ) {
    sb.append(it.next());
}
```

- 빈 파일은 빈 문자열을 반환한다.
- `sb.append("")`는 어떤 입력에서도 no-op이므로, 비어 있지 않은 단일/여러 줄 입력의 출력은 종전과 바이트 단위로 동일하다. 라인 구분자 처리 의미는 변경하지 않았다(`readLines` 계열이 구분자를 제거하는 기존 동작 유지).

## 테스트

`FilehandlingServiceTest`에 2건 추가, 모듈 25건 통과.

- `testReadEmptyFile`: 빈 파일 → `""` 반환
- `testReadMultiLineFile`: 여러 줄 입력의 결합 결과가 종전과 동일함을 고정(회귀 가드)