### PR TITLE
fix(dataaccess): CalendarMapperTypeHandler 인덱스 getResult NULL 가드 추가

### DIFF
--- a/Persistence/org.egovframe.rte.psl.dataaccess/src/main/java/org/egovframe/rte/psl/dataaccess/typehandler/CalendarMapperTypeHandler.java
+++ b/Persistence/org.egovframe.rte.psl.dataaccess/src/main/java/org/egovframe/rte/psl/dataaccess/typehandler/CalendarMapperTypeHandler.java
@@ -67,9 +67,13 @@ public class CalendarMapperTypeHandler implements TypeHandler<Calendar> {
 
     public Calendar getResult(ResultSet rs, int columnIndex) throws SQLException {
         java.util.Calendar cal = java.util.Calendar.getInstance();
-        java.sql.Timestamp ts = rs.getTimestamp(columnIndex);
-        cal.setTime(ts);
-        return cal;
+        if (rs.getTimestamp(columnIndex) == null) {
+            return null;
+        } else {
+            java.sql.Timestamp ts = rs.getTimestamp(columnIndex);
+            cal.setTime(ts);
+            return cal;
+        }
     }
 
     public Calendar getResult(CallableStatement cs, int columnIndex) throws SQLException {

--- a/Persistence/org.egovframe.rte.psl.dataaccess/src/test/java/org/egovframe/rte/psl/dataaccess/typehandler/CalendarMapperTypeHandlerTest.java
+++ b/Persistence/org.egovframe.rte.psl.dataaccess/src/test/java/org/egovframe/rte/psl/dataaccess/typehandler/CalendarMapperTypeHandlerTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2008-2024 MOIS(Ministry of the Interior and Safety).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.egovframe.rte.psl.dataaccess.typehandler;
+
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Proxy;
+import java.sql.ResultSet;
+import java.sql.Timestamp;
+import java.util.Calendar;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * {@link CalendarMapperTypeHandler} 단위 테스트.
+ * <p>
+ * 인덱스 기반 {@code getResult(ResultSet, int)} 는 컬럼명 기반 형제 메서드와 달리
+ * NULL Timestamp 컬럼에 대한 가드가 없어 {@code Calendar.setTime(null)} 으로 인한
+ * NullPointerException 을 유발했다. 본 테스트는 NULL 컬럼이 예외 없이 {@code null} 을
+ * 반환하고, 비-NULL 컬럼은 종전과 동일하게 변환됨을 검증한다.
+ * </p>
+ */
+public class CalendarMapperTypeHandlerTest {
+
+    /** 지정한 컬럼인덱스에서 주어진 Timestamp 를 반환하는 ResultSet 프록시 (필요 메서드만 구현). */
+    private ResultSet resultSet(final Timestamp ts) {
+        return (ResultSet) Proxy.newProxyInstance(
+                getClass().getClassLoader(),
+                new Class<?>[]{ResultSet.class},
+                (proxy, method, args) -> {
+                    if ("getTimestamp".equals(method.getName())) {
+                        return ts;
+                    }
+                    throw new UnsupportedOperationException(method.getName());
+                });
+    }
+
+    @Test
+    public void nullColumnReturnsNullWithoutNpe() throws Exception {
+        CalendarMapperTypeHandler handler = new CalendarMapperTypeHandler();
+        assertNull(handler.getResult(resultSet(null), 1));
+    }
+
+    @Test
+    public void nonNullColumnConverts() throws Exception {
+        CalendarMapperTypeHandler handler = new CalendarMapperTypeHandler();
+        Timestamp ts = Timestamp.valueOf("2024-01-02 03:04:05");
+        Calendar cal = handler.getResult(resultSet(ts), 1);
+        assertEquals(ts.getTime(), cal.getTimeInMillis());
+    }
+}


### PR DESCRIPTION
## 문제

`CalendarMapperTypeHandler`의 인덱스 기반 `getResult(ResultSet, int)`에 NULL 가드가 없다. 컬럼명 기반 형제 메서드는 가드가 있다.

```java
// 컬럼명 변형 — NULL 가드 있음
public Calendar getResult(ResultSet rs, String columnName) throws SQLException {
    java.util.Calendar cal = java.util.Calendar.getInstance();
    if (rs.getTimestamp(columnName) == null) {
        return null;
    } else { ... }
}

// 인덱스 변형 — 가드 없음
public Calendar getResult(ResultSet rs, int columnIndex) throws SQLException {
    java.util.Calendar cal = java.util.Calendar.getInstance();
    java.sql.Timestamp ts = rs.getTimestamp(columnIndex);  // NULL이면 ts=null
    cal.setTime(ts);                                       // NullPointerException
    return cal;
}
```

NULL Timestamp 컬럼을 인덱스로 매핑하면 `Calendar.setTime(null)`에서 `NullPointerException`이 발생한다. MyBatis가 인덱스 기반 매핑 경로에서 이 메서드를 호출할 때 노출된다.

## 수정

형제 메서드와 동일한 NULL 가드를 대칭으로 추가했다.

```java
public Calendar getResult(ResultSet rs, int columnIndex) throws SQLException {
    java.util.Calendar cal = java.util.Calendar.getInstance();
    if (rs.getTimestamp(columnIndex) == null) {
        return null;
    } else {
        java.sql.Timestamp ts = rs.getTimestamp(columnIndex);
        cal.setTime(ts);
        return cal;
    }
}
```

- NULL 컬럼은 형제 메서드와 동일하게 `null`을 반환한다.
- 비-NULL 값의 변환 동작은 종전과 동일하다.

## 테스트

`CalendarMapperTypeHandlerTest` 신규 2건, 모듈 통과. 기존 테스트 컨벤션(JDK Proxy `ResultSet`)을 따라 외부 의존성 없이 검증한다.

- `nullColumnReturnsNullWithoutNpe`: NULL 컬럼 → 예외 없이 `null`
- `nonNullColumnConverts`: 비-NULL → millis 일치 변환