### PR TITLE
fix(batch): EgovFlatFileByteReader 공유 가변 static LINE_CRLF 동시성·데이터 손상 제거

### DIFF
--- a/Batch/org.egovframe.rte.bat.core/src/main/java/org/egovframe/rte/bat/core/item/file/EgovFlatFileByteReader.java
+++ b/Batch/org.egovframe.rte.bat.core/src/main/java/org/egovframe/rte/bat/core/item/file/EgovFlatFileByteReader.java
@@ -54,7 +54,7 @@ public class EgovFlatFileByteReader<T> extends AbstractItemCountingItemStreamIte
     private static final Logger LOGGER = LoggerFactory.getLogger(EgovFlatFileByteReader.class);
     private static final int UNIX_CRLF = 1;
     private static final int WINDOWS_CRLF = 2;
-    public static int LINE_CRLF = 2;
+    private int lineCrlf = WINDOWS_CRLF;
     byte[] b = null;
     private RecordSeparatorPolicy recordSeparatorPolicy = new SimpleRecordSeparatorPolicy();
     private EgovByteReaderFactory bufferedReaderFactory = new EgovByteReaderFactory();
@@ -112,10 +112,17 @@ public class EgovFlatFileByteReader<T> extends AbstractItemCountingItemStreamIte
      */
     public void setOsType(String osType) {
         if (!osType.equalsIgnoreCase("WINDOWS")) {
-            LINE_CRLF = UNIX_CRLF;
+            this.lineCrlf = UNIX_CRLF;
         } else {
-            LINE_CRLF = WINDOWS_CRLF;
+            this.lineCrlf = WINDOWS_CRLF;
         }
+    }
+
+    /**
+     * 라인 구분자 길이를 반환
+     */
+    public int getLineCrlf() {
+        return this.lineCrlf;
     }
 
     /**
@@ -186,13 +193,13 @@ public class EgovFlatFileByteReader<T> extends AbstractItemCountingItemStreamIte
      */
     private byte[] readLine() {
         if (b == null) {
-            b = new byte[length + LINE_CRLF];
+            b = new byte[length + this.lineCrlf];
         }
 
         int line = 0;
 
         try {
-            line = this.reader.read(b, offset, length + LINE_CRLF);
+            line = this.reader.read(b, offset, length + this.lineCrlf);
             if (line < 0) {
                 return null;
             }

--- a/Batch/org.egovframe.rte.bat.core/src/main/java/org/egovframe/rte/bat/core/item/file/transform/EgovFixedByteTokenizer.java
+++ b/Batch/org.egovframe.rte.bat.core/src/main/java/org/egovframe/rte/bat/core/item/file/transform/EgovFixedByteTokenizer.java
@@ -15,7 +15,6 @@
  */
 package org.egovframe.rte.bat.core.item.file.transform;
 
-import org.egovframe.rte.bat.core.item.file.EgovFlatFileByteReader;
 import org.springframework.batch.item.file.transform.IncorrectLineLengthException;
 import org.springframework.batch.item.file.transform.Range;
 import org.springframework.util.ObjectUtils;
@@ -66,6 +65,14 @@ public class EgovFixedByteTokenizer extends EgovAbstractByteLineTokenizer {
      */
     private String byteEncoding = DEFAULT_CHARSET;
 
+    private static final int UNIX_CRLF = 1;
+    private static final int WINDOWS_CRLF = 2;
+
+    /**
+     * 라인 구분자 길이
+     */
+    private int lineCrlf = WINDOWS_CRLF;
+
     /**
      * 범위값을 세팅
      */
@@ -79,6 +86,24 @@ public class EgovFixedByteTokenizer extends EgovAbstractByteLineTokenizer {
      */
     public void setByteEncoding(String encoding) {
         this.byteEncoding = encoding;
+    }
+
+    /**
+     * 라인 구분자 길이를 세팅
+     */
+    public void setLineCrlf(int lineCrlf) {
+        this.lineCrlf = lineCrlf;
+    }
+
+    /**
+     * OS타입에 따라 라인 구분자 길이를 세팅
+     */
+    public void setOsType(String osType) {
+        if (!osType.equalsIgnoreCase("WINDOWS")) {
+            this.lineCrlf = UNIX_CRLF;
+        } else {
+            this.lineCrlf = WINDOWS_CRLF;
+        }
     }
 
     /**
@@ -130,7 +155,7 @@ public class EgovFixedByteTokenizer extends EgovAbstractByteLineTokenizer {
     protected List<String> doTokenize(byte[] byteString, String encoding) throws Exception {
         String token;
         List<String> tokens = new ArrayList<String>(ranges.length);
-        int lineLength = byteString.length - EgovFlatFileByteReader.LINE_CRLF;
+        int lineLength = byteString.length - this.lineCrlf;
 
         if (lineLength == 0) {
             throw new IncorrectLineLengthException("Line length must be longer than 0", maxRange, lineLength);

--- a/Batch/org.egovframe.rte.bat.core/src/test/java/org/egovframe/rte/bat/core/item/file/EgovFlatFileByteReaderTest.java
+++ b/Batch/org.egovframe.rte.bat.core/src/test/java/org/egovframe/rte/bat/core/item/file/EgovFlatFileByteReaderTest.java
@@ -1,0 +1,28 @@
+package org.egovframe.rte.bat.core.item.file;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class EgovFlatFileByteReaderTest {
+
+    @Test
+    public void testOsTypeIsIsolatedPerReader() {
+        EgovFlatFileByteReader<Object> readerA = new EgovFlatFileByteReader<>();
+        readerA.setOsType("UNIX");
+        EgovFlatFileByteReader<Object> readerB = new EgovFlatFileByteReader<>();
+        readerB.setOsType("WINDOWS");
+
+        // Regression guard: the old shared static value was overwritten by reader B.
+        assertEquals(1, readerA.getLineCrlf());
+        assertEquals(2, readerB.getLineCrlf());
+    }
+
+    @Test
+    public void testDefaultOsTypeIsWindows() {
+        EgovFlatFileByteReader<Object> reader = new EgovFlatFileByteReader<>();
+
+        assertEquals(2, reader.getLineCrlf());
+    }
+
+}

--- a/Batch/org.egovframe.rte.bat.core/src/test/java/org/egovframe/rte/bat/core/item/file/transform/EgovFixedByteTokenizerTest.java
+++ b/Batch/org.egovframe.rte.bat.core/src/test/java/org/egovframe/rte/bat/core/item/file/transform/EgovFixedByteTokenizerTest.java
@@ -1,0 +1,36 @@
+package org.egovframe.rte.bat.core.item.file.transform;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.batch.item.file.transform.Range;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class EgovFixedByteTokenizerTest {
+
+    @Test
+    public void testDefaultWindowsLineCrlf() throws Exception {
+        EgovFixedByteTokenizer tokenizer = createTokenizer();
+        byte[] line = "ABCDEF\r\n".getBytes(StandardCharsets.US_ASCII);
+
+        assertEquals(Arrays.asList("ABC", "DEF"), tokenizer.doTokenize(line, StandardCharsets.US_ASCII.name()));
+    }
+
+    @Test
+    public void testUnixLineCrlf() throws Exception {
+        EgovFixedByteTokenizer tokenizer = createTokenizer();
+        tokenizer.setOsType("UNIX");
+        byte[] line = "ABCDEF\n".getBytes(StandardCharsets.US_ASCII);
+
+        assertEquals(Arrays.asList("ABC", "DEF"), tokenizer.doTokenize(line, StandardCharsets.US_ASCII.name()));
+    }
+
+    private EgovFixedByteTokenizer createTokenizer() {
+        EgovFixedByteTokenizer tokenizer = new EgovFixedByteTokenizer();
+        tokenizer.setColumns(new Range[]{new Range(1, 3), new Range(4, 6)});
+        return tokenizer;
+    }
+
+}


### PR DESCRIPTION
## 문제
`EgovFlatFileByteReader.LINE_CRLF`는 `public static int`로 선언된 공유 가변 전역인데, 인스턴스 setter `setOsType()`이 이 전역을 직접 덮어쓴다. 이 단일 전역 값이 reader의 고정길이 버퍼 크기(`new byte[length + LINE_CRLF]`, `reader.read(..., length + LINE_CRLF)`)와 `EgovFixedByteTokenizer`의 CRLF 차감(`byteString.length - LINE_CRLF`)에 동시에 쓰인다.

osType이 서로 다른 두 reader 빈(UNIX·WINDOWS)이 한 컨텍스트에 공존하면, 마지막 `setOsType` 호출이 전역을 덮어쓴다(last-writer-wins). 그 결과 다른 빈의 고정길이 필드 경계가 1바이트씩 밀려 무성(silent) 데이터 손상으로 이어진다. CWE-362(경합 조건)·CWE-366(공유 변수 경합)·CWE-471에 해당한다.

## 수정
전역 가변 static을 인스턴스 상태로 옮긴다.

- reader: `public static int LINE_CRLF` 제거 → `private int lineCrlf`(기본값 WINDOWS=2). 버퍼 사이징은 인스턴스 필드를 참조하고 `getLineCrlf()`를 추가한다.
- tokenizer: reader의 static 참조를 끊고 자체 `private int lineCrlf`(기본값 2)와 `setLineCrlf(int)`·`setOsType(String)`를 둔다.

빈마다 값을 독립으로 보유하므로 상호 오염이 사라진다.

## 동작 보존
단일 reader의 기본/WINDOWS 구성은 값(2)이 그대로라 출력 바이트가 동일하다. CRLF를 차감하지 않는 형제 클래스 `EgovFixedByteLengthTokenizer`는 손대지 않았다.

## 주의(후방호환)
기존에는 reader에 `setOsType("UNIX")`를 한 번 호출하면 공유 static을 통해 tokenizer의 차감값도 1로 전파됐다. 분리 이후에는 UNIX 고정길이 잡의 경우 tokenizer에도 `setOsType("UNIX")`(또는 `setLineCrlf(1)`)를 명시 설정해야 한다. reader만 UNIX로 두면 tokenizer가 기본값 2로 차감해 `IncorrectLineLengthException`이 발생한다. 또한 `public static LINE_CRLF` 필드가 제거되므로, 외부에서 이 필드를 직접 참조하던 코드가 있다면 컴파일에 영향을 준다.

## 테스트
신규 4건을 추가했다.

- reader A(UNIX)·B(WINDOWS) 인스턴스 격리 — 한 빈의 설정이 다른 빈에 영향을 주지 않음을 확인하는 회귀 가드
- 기본값 2 보존
- tokenizer 기본(WINDOWS) 토큰 경계 보존
- tokenizer UNIX 경로

`mvn -pl Batch/org.egovframe.rte.bat.core -am test` 실행, 해당 모듈 테스트 18건 모두 통과.
