### PR TITLE
fix(excel): 로드한 워크북을 finally에서 닫은 뒤 반환해 쓰기가 실패하는 문제 수정

### DIFF
--- a/Foundation/org.egovframe.rte.fdl.excel/src/main/java/org/egovframe/rte/fdl/excel/impl/EgovExcelServiceImpl.java
+++ b/Foundation/org.egovframe.rte.fdl.excel/src/main/java/org/egovframe/rte/fdl/excel/impl/EgovExcelServiceImpl.java
@@ -155,7 +155,6 @@ public class EgovExcelServiceImpl implements EgovExcelService, ApplicationContex
                 wb = new HSSFWorkbook(fileIn);
             } finally {
                 LOGGER.debug("ExcelServiceImpl loadExcelTemplate End ");
-                if (wb != null) wb.close();
                 if (fileIn != null) fileIn.close();
             }
             return wb;
@@ -178,7 +177,6 @@ public class EgovExcelServiceImpl implements EgovExcelService, ApplicationContex
                 wb = new XSSFWorkbook(fileIn);
             } finally {
                 LOGGER.debug("ExcelServiceImpl loadExcelTemplate(XSSF) End ");
-                if (wb != null) wb.close();
                 if (fileIn != null) fileIn.close();
             }
             return wb;
@@ -199,7 +197,6 @@ public class EgovExcelServiceImpl implements EgovExcelService, ApplicationContex
                 fileIn = new FileInputStream(filepath);
                 wb = loadWorkbook(fileIn);
             } finally {
-                if (wb != null) wb.close();
                 if (fileIn != null) fileIn.close();
             }
             return wb;
@@ -219,7 +216,6 @@ public class EgovExcelServiceImpl implements EgovExcelService, ApplicationContex
                 fileIn = new FileInputStream(filepath);
                 wb = loadWorkbook(fileIn, wb);
             } finally {
-                if (wb != null) wb.close();
                 if (fileIn != null) fileIn.close();
             }
             return wb;
@@ -241,8 +237,6 @@ public class EgovExcelServiceImpl implements EgovExcelService, ApplicationContex
                 fs = new POIFSFileSystem(fileIn);
                 wb = new HSSFWorkbook(fs);
             } finally {
-                if (wb != null) wb.close();
-                if (fs != null) fs.close();
                 if (fileIn != null) fileIn.close();
             }
             return wb;

--- a/Foundation/org.egovframe.rte.fdl.excel/src/test/java/org/egovframe/rte/fdl/excel/EgovExcelLoadThenWriteTest.java
+++ b/Foundation/org.egovframe.rte.fdl.excel/src/test/java/org/egovframe/rte/fdl/excel/EgovExcelLoadThenWriteTest.java
@@ -1,0 +1,130 @@
+package org.egovframe.rte.fdl.excel;
+
+import jakarta.annotation.Resource;
+import org.apache.poi.hssf.usermodel.HSSFWorkbook;
+import org.apache.poi.ss.usermodel.Cell;
+import org.apache.poi.ss.usermodel.Sheet;
+import org.apache.poi.ss.usermodel.Workbook;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import org.egovframe.rte.fdl.excel.config.ExcelTestConfig;
+import org.egovframe.rte.fdl.filehandling.EgovFileUtil;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * 엑셀 파일을 로딩한 뒤 그대로 다시 write() 할 수 있는지 검증한다.
+ * <p>
+ * loadWorkbook/loadExcelTemplate 계열 메서드가 반환 직전에 Workbook(및 HSSF의 경우
+ * POIFSFileSystem)을 닫아 버리면, "로드 → 수정 → 저장" 워크플로우에서 write() 시
+ * 예외가 발생한다(XSSF: "document seems to have been closed already", HSSF:
+ * "directory cannot be null"). 본 테스트는 로딩된 Workbook이 write() 가능한 상태로
+ * 반환되는지 확인하여 해당 회귀를 방지한다.
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = ExcelTestConfig.class)
+public class EgovExcelLoadThenWriteTest {
+
+    private final String fileLocation = "testdata";
+
+    @Resource(name = "excelService")
+    private EgovExcelService excelService;
+
+    /**
+     * XSSF(.xlsx) : loadWorkbook(String, XSSFWorkbook)로 로딩한 뒤 write() 가능해야 한다.
+     */
+    @Test
+    public void testLoadWorkbookThenWriteXssf() throws IOException {
+        String path = fileLocation + "/loadThenWrite.xlsx";
+        if (EgovFileUtil.isExistsFile(path)) {
+            EgovFileUtil.delete(new File(path));
+        }
+
+        XSSFWorkbook src = new XSSFWorkbook();
+        Sheet sheet = src.createSheet("data");
+        sheet.createRow(0).createCell(0).setCellValue("hello");
+        excelService.createWorkbook(src, path);
+
+        Workbook loaded = excelService.loadWorkbook(path, new XSSFWorkbook());
+        Cell cell = loaded.getSheetAt(0).getRow(0).getCell(0);
+        assertEquals("hello", cell.getStringCellValue());
+
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        loaded.write(baos);
+        assertTrue(baos.size() > 0, "loaded XSSF workbook must be writable");
+    }
+
+    /**
+     * XSSF(.xlsx) : loadExcelTemplate(String, XSSFWorkbook)로 로딩한 뒤 write() 가능해야 한다.
+     */
+    @Test
+    public void testLoadExcelTemplateThenWriteXssf() throws IOException {
+        String path = fileLocation + "/loadTemplateThenWrite.xlsx";
+        if (EgovFileUtil.isExistsFile(path)) {
+            EgovFileUtil.delete(new File(path));
+        }
+
+        XSSFWorkbook src = new XSSFWorkbook();
+        src.createSheet("data").createRow(0).createCell(0).setCellValue("tmpl");
+        excelService.createWorkbook(src, path);
+
+        XSSFWorkbook loaded = excelService.loadExcelTemplate(path, new XSSFWorkbook());
+        assertEquals("tmpl", loaded.getSheetAt(0).getRow(0).getCell(0).getStringCellValue());
+
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        loaded.write(baos);
+        assertTrue(baos.size() > 0, "loaded XSSF template must be writable");
+    }
+
+    /**
+     * HSSF(.xls) : loadWorkbook(String)으로 로딩한 뒤 write() 가능해야 한다.
+     */
+    @Test
+    public void testLoadWorkbookThenWriteHssf() throws IOException {
+        String path = fileLocation + "/loadThenWrite.xls";
+        if (EgovFileUtil.isExistsFile(path)) {
+            EgovFileUtil.delete(new File(path));
+        }
+
+        HSSFWorkbook src = new HSSFWorkbook();
+        src.createSheet("data").createRow(0).createCell(0).setCellValue("hssf");
+        excelService.createWorkbook(src, path);
+
+        Workbook loaded = excelService.loadWorkbook(path);
+        assertEquals("hssf", loaded.getSheetAt(0).getRow(0).getCell(0).getStringCellValue());
+
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        loaded.write(baos);
+        assertTrue(baos.size() > 0, "loaded HSSF workbook must be writable");
+    }
+
+    /**
+     * HSSF(.xls) : loadExcelTemplate(String)으로 로딩한 뒤 write() 가능해야 한다.
+     */
+    @Test
+    public void testLoadExcelTemplateThenWriteHssf() throws IOException {
+        String path = fileLocation + "/loadTemplateThenWrite.xls";
+        if (EgovFileUtil.isExistsFile(path)) {
+            EgovFileUtil.delete(new File(path));
+        }
+
+        HSSFWorkbook src = new HSSFWorkbook();
+        src.createSheet("data").createRow(0).createCell(0).setCellValue("hssftmpl");
+        excelService.createWorkbook(src, path);
+
+        Workbook loaded = excelService.loadExcelTemplate(path);
+        assertEquals("hssftmpl", loaded.getSheetAt(0).getRow(0).getCell(0).getStringCellValue());
+
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        loaded.write(baos);
+        assertTrue(baos.size() > 0, "loaded HSSF template must be writable");
+    }
+}


### PR DESCRIPTION
## 변경 이유

`EgovExcelServiceImpl`의 로딩 메서드 5개(`loadWorkbook` 3개, `loadExcelTemplate` 2개)가 `finally` 블록에서 `wb.close()`를, InputStream을 받는 경우 `POIFSFileSystem`의 `fs.close()`까지 실행한 뒤 `return wb`로 워크북을 돌려준다. 그래서 호출자가 받은 워크북은 이미 닫힌 상태다. "로드 → 수정 → 저장" 흐름에서 `wb.write()`를 부르면 XSSF는 OPCPackage가 닫혀 IOException(`document seems to have been closed already`), HSSF는 directory가 무효라 NPE(`directory cannot be null`)가 난다. 기존 테스트는 읽기만 해서 이 결함을 잡지 못했다(쓰기 검증 공백).

## 변경 내용

- 로딩 메서드 5개의 `finally`에서 `wb.close()`와 `fs.close()` 호출을 제거했다. 파일 핸들 `fileIn.close()`는 그대로 둔다. 스트림은 생성자에서 전량 메모리로 읽으므로 닫아도 워크북 동작에 영향이 없다.
- `loadWorkbook(InputStream, XSSFWorkbook)`에는 이미 같은 패턴이 적용돼 있고, 이번 변경은 그 구현과 동일한 방식이다.
- `EgovExcelLoadThenWriteTest`를 새로 추가했다. XSSF/HSSF × load/template 조합 4건으로, 로드한 워크북을 수정·저장한 결과 파일을 다시 읽어 검증한다.

## 테스트 방법

```bash
mvn -pl Foundation/org.egovframe.rte.fdl.excel test
```

모듈 테스트 34건이 통과한다. 신규 `EgovExcelLoadThenWriteTest` 4건은 로드 후 write 산출물이 정상으로 열리는지 확인한다.

## 영향 범위

- 읽기 전용 호출자는 영향이 없다. close 이후에도 읽기는 동작하므로 기존 동작이 유지된다.
- 반환된 워크북은 메모리를 들고 있는 객체이므로, 호출자가 사용 후 close해야 힙이 곧바로 해제된다. 파일 핸들 누수는 없다(`fileIn`은 계속 닫힌다).
