### PR TITLE
fix: EgovIndexFileWriter에 setResourceLoader 추가로 classpath 리소스 경로 NPE 방지

### DIFF
--- a/Batch/org.egovframe.rte.bat.core/src/main/java/org/egovframe/rte/bat/core/item/file/EgovIndexFileWriter.java
+++ b/Batch/org.egovframe.rte.bat.core/src/main/java/org/egovframe/rte/bat/core/item/file/EgovIndexFileWriter.java
@@ -60,6 +60,17 @@ public class EgovIndexFileWriter<T> implements ItemStreamWriter<T> {
 
     private ResourceLoader resourceLoader;
     private JobParameters jobParameters;
+
+    /**
+     * classpath 리소스 경로 해석에 사용할 ResourceLoader를 주입한다.
+     * 형제 클래스 EgovIndexFileReader와 동일하게, classpath 기반 indexResource를 사용할 때
+     * 이 값이 주입되지 않으면 configureWriterIndexResouce()에서 NullPointerException이 발생한다.
+     *
+     * @param resourceLoader classpath 리소스 로더
+     */
+    public void setResourceLoader(ResourceLoader resourceLoader) {
+        this.resourceLoader = resourceLoader;
+    }
     private String writerResourceType;
     private Resource resource;
     private LineAggregator<T> lineAggregator;

--- a/Batch/org.egovframe.rte.bat.core/src/test/java/org/egovframe/rte/bat/core/item/file/EgovIndexFileWriterResourceLoaderTest.java
+++ b/Batch/org.egovframe.rte.bat.core/src/test/java/org/egovframe/rte/bat/core/item/file/EgovIndexFileWriterResourceLoaderTest.java
@@ -1,0 +1,66 @@
+package org.egovframe.rte.bat.core.item.file;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.io.DefaultResourceLoader;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * {@link EgovIndexFileWriter}가 classpath 기반 indexResource를 해석할 수 있도록
+ * ResourceLoader 주입 경로를 갖추었는지 검증한다.
+ *
+ * <p>형제 클래스 EgovIndexFileReader와 달리 Writer에는 setResourceLoader가 없어,
+ * classpath 경로 사용 시 configureWriterIndexResouce()의 resourceLoader.getResource()에서
+ * 항상 NullPointerException이 발생했다. 이 테스트는 주입 전(NPE)·후(NPE 아님)를 대조한다.</p>
+ */
+class EgovIndexFileWriterResourceLoaderTest {
+
+    /** private configureWriterIndexResouce()를 호출하고 실제 원인 예외를 그대로 던진다. */
+    private void invokeConfigure(EgovIndexFileWriter<?> writer) throws Throwable {
+        Method m = EgovIndexFileWriter.class.getDeclaredMethod("configureWriterIndexResouce");
+        m.setAccessible(true);
+        try {
+            m.invoke(writer);
+        } catch (InvocationTargetException e) {
+            throw e.getCause();
+        }
+    }
+
+    @Test
+    @DisplayName("ResourceLoader 미주입 시 classpath indexResource 해석에서 NPE가 발생한다(버그 재현)")
+    void withoutResourceLoaderThrowsNpe() {
+        EgovIndexFileWriter<Object> writer = new EgovIndexFileWriter<>();
+        // classpath 경로(/ ./ target/ 접두 없음, ':\' 없음) → resourceLoader.getResource() 분기로 진입
+        writer.setIndexResource("egovframe/sample_NDX(1).txt");
+
+        assertThrows(NullPointerException.class, () -> invokeConfigure(writer));
+    }
+
+    @Test
+    @DisplayName("ResourceLoader 주입 시 classpath indexResource가 정상 해석되어 resource가 설정된다")
+    void withResourceLoaderResolvesClasspathResource() throws Throwable {
+        EgovIndexFileWriter<Object> writer = new EgovIndexFileWriter<>();
+        // 테스트 classpath에 실존하는 파일시스템 디렉토리("egovidxtest")를 resourceDirectory로 사용한다.
+        // (+1) 옵션·기존 파일 없음 → 초기 파일명을 resourceLoader.getResource()로 해석해 resource에 설정한다.
+        writer.setIndexResource("egovidxtest/DATA_NDX(1).txt");
+        writer.setResourceLoader(new DefaultResourceLoader());
+
+        invokeConfigure(writer); // 예외 없이 완료되어야 한다
+
+        assertNotNull(writer.getResource(),
+                "주입된 ResourceLoader로 classpath 경로가 해석되어 resource가 설정되어야 한다");
+    }
+
+    @Test
+    @DisplayName("setResourceLoader가 Reader와 동일하게 공개 메서드로 제공된다")
+    void setterExists() throws NoSuchMethodException {
+        Method setter = EgovIndexFileWriter.class.getMethod("setResourceLoader",
+                org.springframework.core.io.ResourceLoader.class);
+        assertNotNull(setter);
+    }
+}

--- a/Batch/org.egovframe.rte.bat.core/src/test/resources/egovidxtest/.keep
+++ b/Batch/org.egovframe.rte.bat.core/src/test/resources/egovidxtest/.keep
@@ -1,0 +1,1 @@
+placeholder for EgovIndexFileWriter classpath resolution test


### PR DESCRIPTION
## 배경
`EgovIndexFileWriter`는 classpath 기반 `indexResource`를 해석할 때 `configureWriterIndexResouce()`에서 `resourceLoader.getResource(...)`를 호출합니다. 그러나 이 클래스에는 `resourceLoader` 필드를 주입할 수 있는 경로가 없습니다. `ResourceLoaderAware`를 구현하지도 않고 세터도 없어 필드가 항상 `null`로 남고, classpath 경로를 사용하면 `NullPointerException`이 발생합니다.

형제 클래스 `EgovIndexFileReader`는 동일한 목적의 `setResourceLoader(ResourceLoader)`를 이미 제공합니다. Writer에만 이 주입 경로가 빠져 있습니다.

## 변경 내용
`EgovIndexFileReader`와 동일하게 `EgovIndexFileWriter`에 `setResourceLoader(ResourceLoader)`를 추가합니다. 파일시스템 경로 분기는 `ResourceLoader`를 사용하지 않으므로 영향이 없고, classpath 경로에서만 주입된 로더로 정상 해석됩니다.

## 테스트
- `ResourceLoader` 미주입 시 classpath `indexResource` 해석에서 `NullPointerException`이 발생함을 확인(버그 재현).
- `ResourceLoader` 주입 후 classpath 경로가 정상 해석되어 `resource`가 설정됨을 확인.
- 세터가 Reader와 동일한 공개 메서드로 제공됨을 확인.

## 영향
기존 코드를 수정하지 않고 setter를 추가하기만 하는 변경입니다. 기존 파일시스템 경로 사용자는 영향받지 않으며, classpath 경로 사용 시에만 새 주입 경로가 동작합니다.
