### PR TITLE
fix: AbstractXMLUtility XML 저장 시 OutputStream 자원 누수 수정

### DIFF
--- a/Foundation/org.egovframe.rte.fdl.xml/src/main/java/org/egovframe/rte/fdl/xml/AbstractXMLUtility.java
+++ b/Foundation/org.egovframe.rte.fdl.xml/src/main/java/org/egovframe/rte/fdl/xml/AbstractXMLUtility.java
@@ -42,6 +42,7 @@ import javax.xml.xpath.XPathExpressionException;
 import javax.xml.xpath.XPathFactory;
 import java.io.CharArrayReader;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.ArrayList;
@@ -355,8 +356,13 @@ public abstract class AbstractXMLUtility {
         transformer.setOutputProperty(OutputKeys.INDENT, "yes");
 
         DOMSource source = new DOMSource(doc);
-        StreamResult result = new StreamResult(Files.newOutputStream(Paths.get(path)));
-        transformer.transform(source, result);
+        // OutputStream을 try-with-resources로 관리해 transform 성공·예외와 무관하게 닫는다.
+        // 기존 코드는 스트림을 닫지 않아 반복 저장 시 파일 디스크립터가 누적되고,
+        // Windows에서는 파일 잠금이 지속될 수 있었다.
+        try (OutputStream outputStream = Files.newOutputStream(Paths.get(path))) {
+            StreamResult result = new StreamResult(outputStream);
+            transformer.transform(source, result);
+        }
     }
 
 }

--- a/Foundation/org.egovframe.rte.fdl.xml/src/test/java/org/egovframe/rte/fdl/xml/AbstractXMLUtilitySaveDocumentTest.java
+++ b/Foundation/org.egovframe.rte.fdl.xml/src/test/java/org/egovframe/rte/fdl/xml/AbstractXMLUtilitySaveDocumentTest.java
@@ -1,0 +1,59 @@
+package org.egovframe.rte.fdl.xml;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.w3c.dom.Document;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+import java.lang.reflect.Method;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * {@link AbstractXMLUtility}의 XML 저장이 OutputStream을 누수 없이 처리하고,
+ * 반복 저장에서도 정상 동작하는지 검증한다.
+ *
+ * <p>기존 코드는 {@code new StreamResult(Files.newOutputStream(...))}의 스트림을 닫지 않아,
+ * 반복 저장 시 파일 디스크립터가 누적되고 Windows에서는 파일 잠금이 지속될 수 있었다.
+ * try-with-resources 적용 후 반복 저장이 매번 완결되는지 특성 테스트로 확인한다.</p>
+ */
+class AbstractXMLUtilitySaveDocumentTest {
+
+    private Document newSimpleDocument() throws Exception {
+        Document doc = DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument();
+        doc.appendChild(doc.createElement("root"));
+        return doc;
+    }
+
+    private void saveDocument(AbstractXMLUtility util, Document doc, String path) throws Throwable {
+        Method m = AbstractXMLUtility.class.getDeclaredMethod("saveDocument", Document.class, String.class);
+        m.setAccessible(true);
+        try {
+            m.invoke(util, doc, path);
+        } catch (java.lang.reflect.InvocationTargetException e) {
+            throw e.getCause();
+        }
+    }
+
+    @Test
+    @DisplayName("동일 경로로 반복 저장해도 매번 유효한 XML이 기록된다(스트림 누수 없음)")
+    void repeatedSaveWritesValidXml(@TempDir Path tempDir) throws Throwable {
+        EgovDOMValidatorService util = new EgovDOMValidatorService();
+        Path target = tempDir.resolve("out.xml");
+
+        // 반복 저장: 스트림이 닫히지 않으면 FD가 누적되거나 잠금이 남는다.
+        for (int i = 0; i < 50; i++) {
+            saveDocument(util, newSimpleDocument(), target.toString());
+        }
+
+        assertTrue(Files.exists(target));
+        // 마지막 저장 결과가 잘 형성된(well-formed) XML로 재파싱되는지 확인
+        Document reparsed = DocumentBuilderFactory.newInstance().newDocumentBuilder()
+                .parse(target.toFile());
+        assertEquals("root", reparsed.getDocumentElement().getNodeName());
+    }
+}


### PR DESCRIPTION
## 배경
`AbstractXMLUtility`의 XML 저장 로직은 `new StreamResult(Files.newOutputStream(...))`로 생성한 `OutputStream`을 닫지 않습니다. 이 저장 경로는 XML 변경 공개 API 6곳에서 호출되며, 반복 저장하거나 `transform()`이 예외를 던지면 파일 디스크립터가 누적되고 Windows에서는 파일 잠금이 지속될 수 있습니다.

## 변경 내용
`OutputStream`을 try-with-resources로 관리해 `transform()`의 성공·예외와 무관하게 항상 닫히도록 수정합니다. `StreamResult`는 스트림을 감싸는 홀더일 뿐이므로 별도로 닫지 않으며, `transform()` 예외는 기존과 동일하게 전파됩니다.

## 테스트
동일 경로로 반복 저장한 뒤 결과가 매번 유효한(well-formed) XML로 재파싱되는지 확인하는 특성 테스트를 추가했습니다. 파일 디스크립터 수 관측은 운영체제에 의존하므로 테스트에 포함하지 않았고, 스트림 종료는 try-with-resources로 보장됩니다.

## 영향
저장 결과는 동일하며, 반복 저장·예외 상황에서 스트림이 확실히 닫힙니다.
