### PR TITLE
fix: MessageConverterImpl 누락된 List/Record 필드 NullPointerException 방지

### DIFF
--- a/Integration/org.egovframe.rte.itl.webservice/src/main/java/org/egovframe/rte/itl/webservice/service/impl/MessageConverterImpl.java
+++ b/Integration/org.egovframe.rte.itl.webservice/src/main/java/org/egovframe/rte/itl/webservice/service/impl/MessageConverterImpl.java
@@ -75,6 +75,11 @@ public class MessageConverterImpl implements MessageConverter {
             return source;
         } else if (type instanceof ListType) {
             LOGGER.debug("### MessageConverterImpl convertToValueObject() : Type is a List Type");
+            // 메시지 body에서 List 필드가 생략되면 source가 null로 전달된다.
+            // 타입 체계가 null을 유효 값으로 허용하므로, 역참조 전에 null을 그대로 반환한다.
+            if (source == null) {
+                return null;
+            }
             ListType listType = (ListType) type;
             Object[] components = ((Collection<?>) source).toArray();
             Class<?> arrayClass = classLoader.loadClass(listType);
@@ -85,6 +90,11 @@ public class MessageConverterImpl implements MessageConverter {
             return array;
         } else if (type instanceof RecordType) {
             LOGGER.debug("### MessageConverterImpl convertToValueObject() : Type is a Record(Map) Type");
+            // 메시지 body에서 Record 필드가 생략되면 source가 null로 전달된다.
+            // 타입 체계가 null을 유효 값으로 허용하므로, 역참조 전에 null을 그대로 반환한다.
+            if (source == null) {
+                return null;
+            }
             RecordType recordType = (RecordType) type;
             Map<String, Object> map = (Map<String, Object>) source;
             Class<?> recordClass = classLoader.loadClass(recordType);

--- a/Integration/org.egovframe.rte.itl.webservice/src/test/java/org/egovframe/rte/itl/webservice/service/impl/MessageConverterImplTest.java
+++ b/Integration/org.egovframe.rte.itl.webservice/src/test/java/org/egovframe/rte/itl/webservice/service/impl/MessageConverterImplTest.java
@@ -253,6 +253,20 @@ public class MessageConverterImplTest {
             assertEquals(person.name, personMap.get("name"));
         }
     }
+
+    @Test
+    public void testConvertToValueObjectWithNullListSource() throws Exception {
+        // 메시지 body에서 List 필드가 생략되면 source가 null로 전달된다.
+        // null 역참조(NPE) 없이 null을 반환해야 한다.
+        assertNull(messageConverter.convertToValueObject(null, personListType));
+    }
+
+    @Test
+    public void testConvertToValueObjectWithNullRecordSource() throws Exception {
+        // 메시지 body에서 Record 필드가 생략되면 source가 null로 전달된다.
+        // null 역참조(NPE) 없이 null을 반환해야 한다.
+        assertNull(messageConverter.convertToValueObject(null, recordType));
+    }
 }
 
 class ValueObject {


### PR DESCRIPTION
## 배경
`MessageConverterImpl.convertToValueObject()`는 `ListType`·`RecordType` 분기에서 `source`를 각각 `((Collection<?>) source).toArray()`, `((Map<String, Object>) source).entrySet()`로 역참조합니다. 메시지 body에서 해당 List/Record 필드가 생략되면 `source`가 `null`로 전달되고, 타입 체계는 `null`을 유효한 값으로 허용하므로 단순 잘못된 입력으로 볼 수 없습니다. 이 경우 두 분기 모두 `NullPointerException`이 발생합니다.

## 변경 내용
두 분기에서 역참조 전에 `source`가 `null`이면 `null`을 그대로 반환하도록 가드를 추가합니다. 타입 체계가 허용하는 null 값 의미를 보존하며, 재귀 호출로 처리되는 중첩 필드의 null도 안전하게 반환·대입됩니다.

## 테스트
`convertToValueObject(null, listType)`와 `convertToValueObject(null, recordType)`가 `NullPointerException` 없이 `null`을 반환함을 확인하는 테스트를 추가했습니다. 수정 전에는 두 경우 모두 null 역참조로 실패합니다. 기존 변환 테스트도 그대로 통과합니다.

## 영향
정상 값(non-null)의 변환 동작은 변경되지 않으며, 누락된 List/Record 필드에 대해서만 NPE 대신 null이 반환됩니다.
