### PR TITLE
fix: EgovARIA·EgovGeneralCryptoServiceImpl setBlockSize 0·음수 입력 검증

### DIFF
--- a/Foundation/org.egovframe.rte.fdl.crypto/src/main/java/org/egovframe/rte/fdl/crypto/impl/EgovARIACryptoServiceImpl.java
+++ b/Foundation/org.egovframe.rte.fdl.crypto/src/main/java/org/egovframe/rte/fdl/crypto/impl/EgovARIACryptoServiceImpl.java
@@ -45,6 +45,11 @@ public class EgovARIACryptoServiceImpl implements EgovARIACryptoService {
     }
 
     public void setBlockSize(int blockSize) {
+        // blockSize가 0이면 encrypt(File)의 read 루프가 종료되지 않아 무한 루프에 빠지고(CWE-835),
+        // 음수이면 버퍼 할당에서 예외가 발생하므로 양수만 허용한다.
+        if (blockSize <= 0) {
+            throw new IllegalArgumentException("blockSize must be a positive number: " + blockSize);
+        }
         if (blockSize % BLOCKSIZE_MODULAR != 0) {
             blockSize += (BLOCKSIZE_MODULAR - blockSize % BLOCKSIZE_MODULAR);
         }

--- a/Foundation/org.egovframe.rte.fdl.crypto/src/main/java/org/egovframe/rte/fdl/crypto/impl/EgovGeneralCryptoServiceImpl.java
+++ b/Foundation/org.egovframe.rte.fdl.crypto/src/main/java/org/egovframe/rte/fdl/crypto/impl/EgovGeneralCryptoServiceImpl.java
@@ -53,6 +53,11 @@ public class EgovGeneralCryptoServiceImpl implements EgovGeneralCryptoService {
     }
 
     public void setBlockSize(int blockSize) {
+        // blockSize가 0이면 encrypt(File)의 read 루프가 종료되지 않아 무한 루프에 빠지고(CWE-835),
+        // 음수이면 버퍼 할당에서 NegativeArraySizeException이 발생하므로 양수만 허용한다.
+        if (blockSize <= 0) {
+            throw new IllegalArgumentException("blockSize must be a positive number: " + blockSize);
+        }
         this.blockSize = blockSize;
     }
 

--- a/Foundation/org.egovframe.rte.fdl.crypto/src/test/java/org/egovframe/rte/fdl/crypto/impl/EgovCryptoBlockSizeValidationTest.java
+++ b/Foundation/org.egovframe.rte.fdl.crypto/src/test/java/org/egovframe/rte/fdl/crypto/impl/EgovCryptoBlockSizeValidationTest.java
@@ -1,0 +1,36 @@
+package org.egovframe.rte.fdl.crypto.impl;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * {@link EgovARIACryptoServiceImpl}·{@link EgovGeneralCryptoServiceImpl}의 setBlockSize가
+ * 0/음수를 거부하는지 검증한다.
+ *
+ * <p>blockSize가 0이면 encrypt(File)의 read 루프가 종료되지 않아 무한 루프(CWE-835)에 빠지고,
+ * 음수이면 버퍼 할당에서 예외가 발생한다. setBlockSize에서 양수만 허용하도록 입력을 검증한다.</p>
+ */
+class EgovCryptoBlockSizeValidationTest {
+
+    @Test
+    @DisplayName("ARIA: blockSize 0·음수는 IllegalArgumentException으로 거부한다")
+    void ariaRejectsNonPositiveBlockSize() {
+        EgovARIACryptoServiceImpl service = new EgovARIACryptoServiceImpl();
+        assertThrows(IllegalArgumentException.class, () -> service.setBlockSize(0));
+        assertThrows(IllegalArgumentException.class, () -> service.setBlockSize(-16));
+        // 양수는 정상(내부적으로 BLOCKSIZE_MODULAR 배수로 정규화)
+        assertDoesNotThrow(() -> service.setBlockSize(512));
+    }
+
+    @Test
+    @DisplayName("General: blockSize 0·음수는 IllegalArgumentException으로 거부한다")
+    void generalRejectsNonPositiveBlockSize() {
+        EgovGeneralCryptoServiceImpl service = new EgovGeneralCryptoServiceImpl();
+        assertThrows(IllegalArgumentException.class, () -> service.setBlockSize(0));
+        assertThrows(IllegalArgumentException.class, () -> service.setBlockSize(-1));
+        assertDoesNotThrow(() -> service.setBlockSize(1024));
+    }
+}

--- a/Foundation/org.egovframe.rte.fdl.logging/logs/daily/dailyRollingSample.log.2026-07-05-14-15-29
+++ b/Foundation/org.egovframe.rte.fdl.logging/logs/daily/dailyRollingSample.log.2026-07-05-14-15-29
@@ -1,0 +1,1 @@
+2026-07-05 14:15:29,370 DEBUG [dailyLogger] DailyRollingFileAppender test


### PR DESCRIPTION
## 배경
`EgovARIACryptoServiceImpl`·`EgovGeneralCryptoServiceImpl`의 `encrypt(File, String, File)`는 `new byte[blockSize]` 버퍼로 파일을 읽어 암호화합니다. `blockSize`는 `setBlockSize(int)`로 설정되는데, 두 클래스 모두 이 값의 유효성을 검사하지 않습니다.

`setBlockSize(0)`이 호출되면 버퍼가 길이 0이 되어 `InputStream.read(buffer)`가 항상 0을 반환합니다. 두 클래스의 읽기 루프(`while ((len = read(...)) != -1)`, `while ((length = read(...)) >= 0)`)는 이 0을 종료 조건으로 인식하지 못해 무한 루프에 빠집니다(CWE-835). 음수 `blockSize`는 `EgovGeneralCryptoServiceImpl`에서 `new byte[blockSize]` 시 `NegativeArraySizeException`을 일으킵니다.

기본값은 1024이므로 정상 사용에는 문제가 없으나, 설정값이 0이나 음수로 주입되면 파일 암호화가 멈추거나 실패합니다.

## 변경 내용
두 클래스의 `setBlockSize(int)`가 0 이하의 값을 `IllegalArgumentException`으로 거부하도록 입력 검증을 추가합니다. `EgovARIACryptoServiceImpl`은 기존에도 `setBlockSize`에서 blockSize를 `BLOCKSIZE_MODULAR` 배수로 정규화하고 있어, 같은 지점에 검증을 더합니다.

## 테스트
두 클래스의 `setBlockSize(0)`·음수 입력이 `IllegalArgumentException`을 던지고, 양수 입력은 정상 처리됨을 확인하는 테스트를 추가했습니다. 기존 crypto 모듈 테스트도 그대로 통과합니다.

## 영향
정상적인 양수 blockSize 사용에는 영향이 없으며, 잘못된 0·음수 설정이 무한 루프나 예외로 이어지기 전에 설정 시점에서 거부됩니다.
