### PR TITLE
refactor: Foundation 지역 StringBuffer를 StringBuilder로 변경 (불필요한 동기화 제거)

### DIFF
--- a/Foundation/org.egovframe.rte.fdl.filehandling/src/main/java/org/egovframe/rte/fdl/filehandling/EgovFileUtil.java
+++ b/Foundation/org.egovframe.rte.fdl.filehandling/src/main/java/org/egovframe/rte/fdl/filehandling/EgovFileUtil.java
@@ -178,7 +178,7 @@ public class EgovFileUtil {
      * String 영으로 파일의 내용을 읽는다.
      */
     public static String readFile(File file, String encoding) throws IOException {
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
         List<String> lines = readTextLines(file, encoding);
 
         for (Iterator<String> it = lines.iterator(); ; ) {
@@ -441,8 +441,8 @@ public class EgovFileUtil {
     /**
      * 지정한 위치의 하위 디렉토리 목록을 가져온다.
      */
-    private StringBuffer listChildren(final FileObject dir, final boolean recursive, final String prefix) throws FileSystemException {
-        StringBuffer line = new StringBuffer();
+    private StringBuilder listChildren(final FileObject dir, final boolean recursive, final String prefix) throws FileSystemException {
+        StringBuilder line = new StringBuilder();
         final FileObject[] children = dir.getChildren();
 
         for (final FileObject child : children) {

--- a/Foundation/org.egovframe.rte.fdl.idgnr/src/main/java/org/egovframe/rte/fdl/idgnr/impl/strategy/EgovIdGnrStrategyImpl.java
+++ b/Foundation/org.egovframe.rte.fdl.idgnr/src/main/java/org/egovframe/rte/fdl/idgnr/impl/strategy/EgovIdGnrStrategyImpl.java
@@ -78,7 +78,7 @@ public class EgovIdGnrStrategyImpl implements EgovIdGnrStrategy {
         }
 
         int difference = cipers - originalStrLength;
-        StringBuffer strBuf = new StringBuffer();
+        StringBuilder strBuf = new StringBuilder();
         for (int i = 0; i < difference; i++) {
             strBuf.append(ch);
         }

--- a/Foundation/org.egovframe.rte.fdl.string/src/main/java/org/egovframe/rte/fdl/string/EgovStringUtil.java
+++ b/Foundation/org.egovframe.rte.fdl.string/src/main/java/org/egovframe/rte/fdl/string/EgovStringUtil.java
@@ -903,7 +903,7 @@ public final class EgovStringUtil {
         if (str == null) {
             return null;
         }
-        return new StringBuffer(str).reverse().toString();
+        return new StringBuilder(str).reverse().toString();
     }
 
     /**


### PR DESCRIPTION
## 수정 사유

단일 스레드 메서드 내부에서만 사용하는 문자열 버퍼에 동기화 비용이 있는 `StringBuffer` 대신 `StringBuilder`를 사용하도록 변경했습니다. 정적분석 도구가 권장하는 개선(PMD `AvoidStringBufferField` 계열, SonarQube `java:S1149`)이며, egovframe-common-components에 제출한 동일 계열 PR(eGovFramework/egovframe-common-components#1138, #1139)의 실행환경(Foundation) 버전입니다.

## 수정 내용

| 파일 | 변경 |
| --- | --- |
| `fdl.filehandling/.../EgovFileUtil.java` | `readFile` 지역 변수 1곳, `listChildren`(private) 반환형·지역 변수 2곳 |
| `fdl.string/.../EgovStringUtil.java` | `reverse`의 지역 표현식 1곳 |
| `fdl.idgnr/.../EgovIdGnrStrategyImpl.java` | 지역 변수 1곳 |

- **public API는 변경하지 않았습니다.** 같은 파일의 `EgovFileUtil.readTextFile`은 반환형이 `StringBuffer`인 공개 메서드라 호환성을 위해 의도적으로 제외했습니다.
- `listChildren`은 private 메서드로 클래스 외부에 노출되지 않으며, 호출부는 `LOGGER.debug`의 인자(CharSequence)라 동작이 동일합니다.

## 테스트 여부

- [x] 변경된 3개 모듈(fdl.string, fdl.idgnr, fdl.filehandling) 로컬 `mvn compile` 통과 (JDK 17)
- [x] 모든 대상이 메서드 지역 범위임을 확인 (필드·공개 반환형·파라미터 아님)
