### PR TITLE
chore: Batch 모듈의 System.out.println을 SLF4J LOGGER로 대체

### DIFF
--- a/Batch/org.egovframe.rte.bat.core/src/main/java/org/egovframe/rte/bat/core/step/ShellScriptSupport.java
+++ b/Batch/org.egovframe.rte.bat.core/src/main/java/org/egovframe/rte/bat/core/step/ShellScriptSupport.java
@@ -15,6 +15,8 @@
  */
 package org.egovframe.rte.bat.core.step;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.util.ReflectionUtils;
 
 import java.io.BufferedReader;
@@ -23,6 +25,8 @@ import java.io.InputStreamReader;
 import java.util.regex.Pattern;
 
 public class ShellScriptSupport {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ShellScriptSupport.class);
 
     private static String OS = System.getProperty("os.name").toLowerCase();
     private static String OSEncoding = System.getProperty("file.encoding");
@@ -54,7 +58,7 @@ public class ShellScriptSupport {
             BufferedReader br = new BufferedReader(isr)) {
             String line;
             while ((line = br.readLine()) != null) {
-                System.out.println(line);
+                LOGGER.info("{}", line);
             }
         }
 

--- a/Batch/org.egovframe.rte.bat.core/src/main/java/org/egovframe/rte/bat/item/DefaultItemReader.java
+++ b/Batch/org.egovframe.rte.bat.core/src/main/java/org/egovframe/rte/bat/item/DefaultItemReader.java
@@ -320,7 +320,7 @@ public class DefaultItemReader<T> implements ItemStreamReader<T> {
     private void printXmlConfig() {
         if (printXmlConf) {
             if (DELIMITED_FILE_TYPE.equalsIgnoreCase(this.readerResourceType)) {
-                System.out.println("======= " + stepName + " READER 설정(XML 버전) =========\n"
+                LOGGER.info("======= " + stepName + " READER 설정(XML 버전) =========\n"
                         + "<bean id=\"" + stepName + ".reader\" class=\"org.springframework.batch.item.file.FlatFileItemReader\" scope=\"step\">\n"
                         + "  <property name=\"resource\" value=\"" + this.resourceName + "\" />\n"
                         + "  <property name=\"lineMapper\">\n"
@@ -341,7 +341,7 @@ public class DefaultItemReader<T> implements ItemStreamReader<T> {
                         + "</bean>\n"
                         + "================================================");
             } else if (FIXED_LENGTH_FILE_TYPE.equalsIgnoreCase(this.readerResourceType)) {
-                System.out.println("======= " + stepName + " READER 설정(XML 버전) =========\n"
+                LOGGER.info("======= " + stepName + " READER 설정(XML 버전) =========\n"
                         + "<bean id=\"" + stepName + ".reader\" class=\"org.springframework.batch.item.file.FlatFileItemReader\" scope=\"step\">\n"
                         + "  <property name=\"resource\" value=\"" + this.resourceName + "\" />\n"
                         + "  <property name=\"lineMapper\">\n"
@@ -362,7 +362,7 @@ public class DefaultItemReader<T> implements ItemStreamReader<T> {
                         + "</bean>\n"
                         + "================================================");
             } else if (JDBC_DB_TYPE.equalsIgnoreCase(this.readerResourceType)) {
-                System.out.println("======= " + stepName + " READER 설정(XML 버전) =========\n"
+                LOGGER.info("======= " + stepName + " READER 설정(XML 버전) =========\n"
                         + "<bean id=\"" + stepName + ".reader\" class=\"org.springframework.batch.item.database.JdbcCursorItemReader\" scope=\"step\">\n"
                         + "  <property name=\"dataSource\" ref=\"dataSource\" />\n"
                         + "  <property name=\"sql\" value=\"" + this.sql + "\" />\n"

--- a/Batch/org.egovframe.rte.bat.core/src/main/java/org/egovframe/rte/bat/item/DefaultItemWriter.java
+++ b/Batch/org.egovframe.rte.bat.core/src/main/java/org/egovframe/rte/bat/item/DefaultItemWriter.java
@@ -288,7 +288,7 @@ public class DefaultItemWriter<T> implements ItemStreamWriter<T> {
     private void printXmlConfig() {
         if (printXmlConf) {
             if (DELIMITED_FILE_TYPE.equalsIgnoreCase(this.writerResourceType)) {
-                System.out.println("======= " + stepName + " WRITER 설정(XML 버전) =========\n"
+                LOGGER.info("======= " + stepName + " WRITER 설정(XML 버전) =========\n"
                         + "<bean id=\"" + stepName + ".writer\" class=\"org.springframework.batch.item.file.FlatFileItemWriter\" scope=\"step\">\n"
                         + "  <property name=\"resource\" value=\"" + this.resourceName + "\" />\n"
                         + "  <property name=\"lineAggregator\">\n"
@@ -304,7 +304,7 @@ public class DefaultItemWriter<T> implements ItemStreamWriter<T> {
                         + "</bean>\n"
                         + "================================================");
             } else if (FIXED_LENGTH_FILE_TYPE.equalsIgnoreCase(this.writerResourceType)) {
-                System.out.println("======= " + stepName + " Writer 설정(XML 버전) =========\n"
+                LOGGER.info("======= " + stepName + " Writer 설정(XML 버전) =========\n"
                         + "<bean id=\"" + stepName + ".writer\" class=\"org.springframework.batch.item.file.FlatFileItemWriter\" scope=\"step\">\n"
                         + "  <property name=\"resource\" value=\"" + this.resourceName + "\" />\n"
                         + "  <property name=\"lineAggregator\">\n"
@@ -320,7 +320,7 @@ public class DefaultItemWriter<T> implements ItemStreamWriter<T> {
                         + "</bean>\n"
                         + "================================================");
             } else if (JDBC_DB_TYPE.equalsIgnoreCase(this.writerResourceType)) {
-                System.out.println("======= " + stepName + " Writer 설정(XML 버전) =========\n"
+                LOGGER.info("======= " + stepName + " Writer 설정(XML 버전) =========\n"
                         + "<bean id=\"" + stepName + ".writer\" class=\"org.egovframe.rte.bat.core.item.database.EgovJdbcBatchItemWriter\">\n"
                         + "  <property name=\"assertUpdates\" value=\"true\" />\n"
                         + "  <property name=\"itemPreparedStatementSetter\">\n"


### PR DESCRIPTION
## 수정 사유

Batch 모듈 3개 클래스가 셸 실행 출력과 배치 설정 정보를 `System.out.println`으로 콘솔에 직접 출력하고 있습니다. 표준 출력 직접 사용은 로그 레벨·포맷·출력 대상 제어가 불가능하고 운영 환경 로그 수집에서 누락되며, 정적분석 도구가 지적하는 항목입니다(PMD `SystemPrintln`, SonarQube `java:S106`). 저장소의 다른 코드와 동일하게 SLF4J LOGGER를 사용하도록 정리했습니다. egovframe-common-components의 동일 계열 PR(eGovFramework/egovframe-common-components#1097, #1118)의 실행환경 버전입니다.

## 수정 내용

| 파일 | 변경 |
| --- | --- |
| `bat/core/step/ShellScriptSupport.java` | 셸 프로세스 출력 1곳을 `LOGGER.info("{}", line)`으로 대체. SLF4J Logger 필드·import 추가 |
| `bat/item/DefaultItemReader.java` | READER 설정(XML 버전) 안내 출력 3곳을 `LOGGER.info`로 대체 (기존 LOGGER 필드 재사용) |
| `bat/item/DefaultItemWriter.java` | WRITER 설정(XML 버전) 안내 출력 3곳을 `LOGGER.info`로 대체 (기존 LOGGER 필드 재사용) |

- 출력 문자열 내용은 변경하지 않았으며, 출력 채널만 표준 출력 → SLF4J로 변경했습니다.
- Reader/Writer는 이미 같은 클래스에서 SLF4J LOGGER를 사용 중이라 의존성 추가가 없습니다.

## 테스트 여부

- [x] Batch 모듈(org.egovframe.rte.bat.core) 로컬 `mvn compile` 통과 (JDK 17)
- 관련 PR: 같은 계열 Foundation 리팩터 #271
