### PR TITLE
[fix] EgovMyBatisBatchItemWriter 공유 변수 주입 기능 복구 (이슈 #239)

### DIFF
--- a/Batch/org.egovframe.rte.bat.core/src/main/java/org/egovframe/rte/bat/core/item/database/EgovMyBatisBatchItemWriter.java
+++ b/Batch/org.egovframe.rte.bat.core/src/main/java/org/egovframe/rte/bat/core/item/database/EgovMyBatisBatchItemWriter.java
@@ -21,7 +21,6 @@ import org.egovframe.rte.bat.support.EgovStepVariableListener;
 import org.mybatis.spring.batch.MyBatisBatchItemWriter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.batch.item.Chunk;
 import org.springframework.util.ReflectionUtils;
 
 import java.beans.BeanInfo;
@@ -30,9 +29,7 @@ import java.beans.Introspector;
 import java.beans.PropertyDescriptor;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 /**
@@ -71,6 +68,10 @@ public class EgovMyBatisBatchItemWriter<T> extends MyBatisBatchItemWriter<T> {
      */
     private EgovStepVariableListener stepVariable = null;
 
+    public EgovMyBatisBatchItemWriter() {
+        setItemToParameterConverter(this::mergeSharedVariables);
+    }
+
     public EgovResourceVariable getResourceVariable() {
         return resourceVariable;
     }
@@ -95,37 +96,37 @@ public class EgovMyBatisBatchItemWriter<T> extends MyBatisBatchItemWriter<T> {
         this.stepVariable = stepVariable;
     }
 
-    @Override
-    @SuppressWarnings("unchecked")
-    public void write(Chunk<? extends T> chunk) {
-        List<Object> list = new ArrayList<>();
-        Map<String, Object> map;
+    /**
+     * item과 공유 변수(resourceVariable/jobVariable/stepVariable)를 병합한 파라미터로 변환한다.
+     * 공유 변수가 하나도 설정되지 않은 경우 기존 동작(item을 그대로 파라미터로 사용)을 그대로 보존한다.
+     */
+    Object mergeSharedVariables(T item) {
+        if (resourceVariable == null && jobVariable == null && stepVariable == null) {
+            return item;
+        }
+
+        Map<String, Object> map = new HashMap<>();
+
+        if (resourceVariable != null)
+            map.putAll(resourceVariable.getVariableMap());
+        if (jobVariable != null)
+            map.putAll(jobVariable.getVariableMap());
+        if (stepVariable != null)
+            map.putAll(stepVariable.getVariableMap());
 
         try {
-            for (T item : chunk.getItems()) {
-                map = new HashMap<>();
-                BeanInfo beanInfo = Introspector.getBeanInfo(item.getClass());
-
-                if (resourceVariable != null)
-                    map.putAll(resourceVariable.getVariableMap());
-                if (jobVariable != null)
-                    map.putAll(jobVariable.getVariableMap());
-                if (stepVariable != null)
-                    map.putAll(stepVariable.getVariableMap());
-
-                for (PropertyDescriptor pd : beanInfo.getPropertyDescriptors()) {
-                    Method reader = pd.getReadMethod();
-                    if (reader != null)
-                        map.put(pd.getName(), reader.invoke(item));
-                }
-
-                list.add(map);
+            BeanInfo beanInfo = Introspector.getBeanInfo(item.getClass());
+            // item 프로퍼티가 공유 변수보다 우선하도록 이후에 덮어쓴다 (공유 변수는 보충 용도)
+            for (PropertyDescriptor pd : beanInfo.getPropertyDescriptors()) {
+                Method reader = pd.getReadMethod();
+                if (reader != null)
+                    map.put(pd.getName(), reader.invoke(item));
             }
         } catch (IntrospectionException | IllegalAccessException | InvocationTargetException e) {
             ReflectionUtils.handleReflectionException(e);
         }
 
-        super.write((Chunk<? extends T>) chunk);
+        return map;
     }
 
 }

--- a/Batch/org.egovframe.rte.bat.core/src/test/java/org/egovframe/rte/bat/core/item/database/EgovMyBatisBatchItemWriterTest.java
+++ b/Batch/org.egovframe.rte.bat.core/src/test/java/org/egovframe/rte/bat/core/item/database/EgovMyBatisBatchItemWriterTest.java
@@ -1,0 +1,108 @@
+package org.egovframe.rte.bat.core.item.database;
+
+import org.egovframe.rte.bat.sample.domain.trade.Trade;
+import org.egovframe.rte.bat.support.EgovJobVariableListener;
+import org.egovframe.rte.bat.support.EgovResourceVariable;
+import org.egovframe.rte.bat.support.EgovStepVariableListener;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.util.Map;
+import java.util.Properties;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+/**
+ * EgovMyBatisBatchItemWriter JUnit Test 클래스
+ *
+ * @author 배치실행개발팀
+ * @version 1.0
+ * @see <pre>
+ * == 개정이력(Modification Information) ==
+ *
+ *   수정일        수정자           수정내용
+ *  -------      -------------  ----------------------
+ *   2026.07.17  배치실행개발팀   최초 생성
+ * </pre>
+ * @since 2026.07.17
+ */
+class EgovMyBatisBatchItemWriterTest {
+
+    @Test
+    void mergeSharedVariables_returnsItemUnchanged_whenNoSharedVariableConfigured() {
+        EgovMyBatisBatchItemWriter<Trade> writer = new EgovMyBatisBatchItemWriter<>();
+        Trade item = new Trade("ISIN001", 100L, new BigDecimal("10.5"), "customer1");
+
+        Object parameter = writer.mergeSharedVariables(item);
+
+        assertSame(item, parameter);
+    }
+
+    @Test
+    void mergeSharedVariables_mergesResourceVariableIntoItemProperties() {
+        EgovMyBatisBatchItemWriter<Trade> writer = new EgovMyBatisBatchItemWriter<>();
+        EgovResourceVariable resourceVariable = new EgovResourceVariable();
+        resourceVariable.setVariable("batchDate", "20260717");
+        writer.setResourceVariable(resourceVariable);
+
+        Trade item = new Trade("ISIN001", 100L, new BigDecimal("10.5"), "customer1");
+        item.setId(1L);
+
+        Object parameter = writer.mergeSharedVariables(item);
+
+        assertInstanceOf(Map.class, parameter);
+        @SuppressWarnings("unchecked")
+        Map<String, Object> map = (Map<String, Object>) parameter;
+        assertEquals("20260717", map.get("batchDate"));
+        assertEquals("customer1", map.get("customer"));
+        assertEquals("ISIN001", map.get("isin"));
+    }
+
+    @Test
+    void mergeSharedVariables_itemPropertyTakesPriorityOverSharedVariableOnKeyCollision() {
+        EgovMyBatisBatchItemWriter<Trade> writer = new EgovMyBatisBatchItemWriter<>();
+        EgovResourceVariable resourceVariable = new EgovResourceVariable();
+        resourceVariable.setVariable("customer", "shared-customer");
+        writer.setResourceVariable(resourceVariable);
+
+        Trade item = new Trade("ISIN001", 100L, new BigDecimal("10.5"), "item-customer");
+        item.setId(1L);
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> map = (Map<String, Object>) writer.mergeSharedVariables(item);
+
+        assertEquals("item-customer", map.get("customer"));
+    }
+
+    @Test
+    void mergeSharedVariables_stepVariableOverridesJobVariableOverridesResourceVariable() {
+        EgovMyBatisBatchItemWriter<Trade> writer = new EgovMyBatisBatchItemWriter<>();
+
+        EgovResourceVariable resourceVariable = new EgovResourceVariable();
+        resourceVariable.setVariable("region", "from-resource");
+        writer.setResourceVariable(resourceVariable);
+
+        Properties jobPros = new Properties();
+        jobPros.setProperty("region", "from-job");
+        EgovJobVariableListener jobVariable = new EgovJobVariableListener();
+        jobVariable.setPros(jobPros);
+        writer.setJobVariable(jobVariable);
+
+        Properties stepPros = new Properties();
+        stepPros.setProperty("region", "from-step");
+        EgovStepVariableListener stepVariable = new EgovStepVariableListener();
+        stepVariable.setPros(stepPros);
+        writer.setStepVariable(stepVariable);
+
+        Trade item = new Trade("ISIN001", 100L, new BigDecimal("10.5"), "customer1");
+        item.setId(1L);
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> map = (Map<String, Object>) writer.mergeSharedVariables(item);
+
+        assertEquals("from-step", map.get("region"));
+    }
+
+}


### PR DESCRIPTION
## 변경 사유

이슈 #239에서 지적된 대로, `EgovMyBatisBatchItemWriter`에 `setResourceVariable`/`setJobVariable`/`setStepVariable`로 공유 변수를 설정해도 MyBatis statement 파라미터에 반영되지 않는 문제가 있었습니다. `write(Chunk)`가 item과 공유 변수를 병합한 Map을 만들면서도 실제로는 `super.write()`에 원본 chunk를 그대로 넘겨 병합 결과를 사용하지 않고 있었습니다. reader 쪽(`EgovMyBatisPagingItemReader`)은 동일 기능이 정상 동작해 reader/writer 간 동작 비대칭이 있었습니다.

## 변경 내용

- `write(Chunk)` 오버라이드를 제거하고, `MyBatisBatchItemWriter`가 제공하는 `setItemToParameterConverter(Converter<T, ?>)` 확장 지점을 사용하도록 변경했습니다.
- 공유 변수가 하나도 설정되지 않은 경우 item을 그대로 반환해 **기존 사용자의 동작을 100% 보존**합니다.
- 공유 변수가 설정된 경우에만 item 프로퍼티를 Map으로 변환한 뒤 공유 변수(resource → job → step 순으로 병합)와 합치고, **item 자신의 프로퍼티가 공유 변수보다 우선**하도록 했습니다(공유 변수는 item에 없는 값을 보충하는 용도).
- `EgovMyBatisBatchItemWriterTest`를 신설해 (1) 공유 변수 미설정 시 기존 동작 보존, (2) 공유 변수 병합, (3) item 프로퍼티 우선순위, (4) step > job > resource 우선순위를 검증합니다.

## 테스트 방법 / 영향 범위

`Batch/org.egovframe.rte.bat.core` 모듈에서 `mvn test` 실행, 18개 테스트(신규 4개 포함) 전부 통과했습니다. 공유 변수를 사용하지 않는 기존 사용자는 동작 변화가 없고, 공유 변수를 설정했던 경우는 (원래 의도대로) 값이 실제로 반영되도록 동작이 바뀝니다 — 이는 이슈에서 요구한 기능 복구 자체입니다.

- [x] 단일 주제만 다룸 (다른 변경 없음)
- [x] 기존 동작에 영향 없음 (공유 변수 미사용 시) / 영향 범위 명시 (공유 변수 사용 시 실제 반영되도록 수정 — 의도된 변화)
- [x] 테스트 통과 확인