### PR TITLE
fix: reactive ConstraintValidator 8종 null 입력 NullPointerException 방지

### DIFF
--- a/Presentation/org.egovframe.rte.ptl.reactive/src/main/java/org/egovframe/rte/ptl/reactive/validation/EgovCnCheckValidation.java
+++ b/Presentation/org.egovframe.rte.ptl.reactive/src/main/java/org/egovframe/rte/ptl/reactive/validation/EgovCnCheckValidation.java
@@ -43,6 +43,9 @@ public class EgovCnCheckValidation implements ConstraintValidator<EgovCnCheck, S
 
     @Override
     public boolean isValid(String value, ConstraintValidatorContext context) {
+        if (value == null) {
+            return false;
+        }
         String mValue = value.replaceAll("-", "");
         Matcher matcher = CN_PATTERN.matcher(mValue);
         boolean check = matcher.find();

--- a/Presentation/org.egovframe.rte.ptl.reactive/src/main/java/org/egovframe/rte/ptl/reactive/validation/EgovCrnCheckValidation.java
+++ b/Presentation/org.egovframe.rte.ptl.reactive/src/main/java/org/egovframe/rte/ptl/reactive/validation/EgovCrnCheckValidation.java
@@ -43,6 +43,9 @@ public class EgovCrnCheckValidation implements ConstraintValidator<EgovCrnCheck,
 
     @Override
     public boolean isValid(String value, ConstraintValidatorContext context) {
+        if (value == null) {
+            return false;
+        }
         String mValue = value.replaceAll("-", "");
         Matcher matcher = CRN_PATTERN.matcher(mValue);
         boolean check = matcher.find();

--- a/Presentation/org.egovframe.rte.ptl.reactive/src/main/java/org/egovframe/rte/ptl/reactive/validation/EgovEnglishCheckValidation.java
+++ b/Presentation/org.egovframe.rte.ptl.reactive/src/main/java/org/egovframe/rte/ptl/reactive/validation/EgovEnglishCheckValidation.java
@@ -43,6 +43,9 @@ public class EgovEnglishCheckValidation implements ConstraintValidator<EgovEngli
 
     @Override
     public boolean isValid(String value, ConstraintValidatorContext context) {
+        if (value == null) {
+            return false;
+        }
         Matcher matcher = ENGLISH_PATTERN.matcher(value);
         return matcher.find();
     }

--- a/Presentation/org.egovframe.rte.ptl.reactive/src/main/java/org/egovframe/rte/ptl/reactive/validation/EgovKoreanCheckValidation.java
+++ b/Presentation/org.egovframe.rte.ptl.reactive/src/main/java/org/egovframe/rte/ptl/reactive/validation/EgovKoreanCheckValidation.java
@@ -43,6 +43,9 @@ public class EgovKoreanCheckValidation implements ConstraintValidator<EgovKorean
 
     @Override
     public boolean isValid(String value, ConstraintValidatorContext context) {
+        if (value == null) {
+            return false;
+        }
         Matcher matcher = KOREAN_PATTERN.matcher(value);
         return matcher.find();
     }

--- a/Presentation/org.egovframe.rte.ptl.reactive/src/main/java/org/egovframe/rte/ptl/reactive/validation/EgovMobilePhoneCheckValidation.java
+++ b/Presentation/org.egovframe.rte.ptl.reactive/src/main/java/org/egovframe/rte/ptl/reactive/validation/EgovMobilePhoneCheckValidation.java
@@ -43,6 +43,9 @@ public class EgovMobilePhoneCheckValidation implements ConstraintValidator<EgovM
 
     @Override
     public boolean isValid(String value, ConstraintValidatorContext context) {
+        if (value == null) {
+            return false;
+        }
         String mValue = value.replaceAll("-", "");
         Matcher matcher = MOBILE_PHONE_PATTERN.matcher(mValue);
         return matcher.find();

--- a/Presentation/org.egovframe.rte.ptl.reactive/src/main/java/org/egovframe/rte/ptl/reactive/validation/EgovPhoneCheckValidation.java
+++ b/Presentation/org.egovframe.rte.ptl.reactive/src/main/java/org/egovframe/rte/ptl/reactive/validation/EgovPhoneCheckValidation.java
@@ -43,6 +43,9 @@ public class EgovPhoneCheckValidation implements ConstraintValidator<EgovPhoneCh
 
     @Override
     public boolean isValid(String value, ConstraintValidatorContext context) {
+        if (value == null) {
+            return false;
+        }
         String mValue = value.replaceAll("-", "");
         Matcher matcher = PHONE_PATTERN.matcher(mValue);
         return matcher.find();

--- a/Presentation/org.egovframe.rte.ptl.reactive/src/main/java/org/egovframe/rte/ptl/reactive/validation/EgovPwdCheckValidation.java
+++ b/Presentation/org.egovframe.rte.ptl.reactive/src/main/java/org/egovframe/rte/ptl/reactive/validation/EgovPwdCheckValidation.java
@@ -80,6 +80,9 @@ public class EgovPwdCheckValidation implements ConstraintValidator<EgovPwdCheck,
 
     @Override
     public boolean isValid(String value, ConstraintValidatorContext context) {
+        if (value == null) {
+            return false;
+        }
         // 비밀번호 패턴 검증
         if (!passwordCheck(value)) {
             return false;

--- a/Presentation/org.egovframe.rte.ptl.reactive/src/main/java/org/egovframe/rte/ptl/reactive/validation/EgovRrnCheckValidation.java
+++ b/Presentation/org.egovframe.rte.ptl.reactive/src/main/java/org/egovframe/rte/ptl/reactive/validation/EgovRrnCheckValidation.java
@@ -43,6 +43,9 @@ public class EgovRrnCheckValidation implements ConstraintValidator<EgovRrnCheck,
 
     @Override
     public boolean isValid(String value, ConstraintValidatorContext context) {
+        if (value == null) {
+            return false;
+        }
         String mValue = value.replaceAll("-", "");
         Matcher matcher = RRN_PATTERN.matcher(mValue);
         boolean check = matcher.find();

--- a/Presentation/org.egovframe.rte.ptl.reactive/src/test/java/org/egovframe/rte/ptl/reactive/validation/ReactiveValidatorsNullSafeTest.java
+++ b/Presentation/org.egovframe.rte.ptl.reactive/src/test/java/org/egovframe/rte/ptl/reactive/validation/ReactiveValidatorsNullSafeTest.java
@@ -1,0 +1,41 @@
+package org.egovframe.rte.ptl.reactive.validation;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * reactive validation 패키지의 ConstraintValidator 구현이 null 입력에서
+ * NullPointerException 없이 false를 반환하는지 검증한다.
+ * (EgovEmailCheckValidation·EgovIPCheckValidation 등 형제 클래스는 이미 null-safe이다)
+ */
+class ReactiveValidatorsNullSafeTest {
+
+    @Test
+    void allValidators_nullInput_returnFalseWithoutException() {
+        assertNullSafe(new EgovCnCheckValidation());
+        assertNullSafe(new EgovCrnCheckValidation());
+        assertNullSafe(new EgovRrnCheckValidation());
+        assertNullSafe(new EgovMobilePhoneCheckValidation());
+        assertNullSafe(new EgovPhoneCheckValidation());
+        assertNullSafe(new EgovEnglishCheckValidation());
+        assertNullSafe(new EgovKoreanCheckValidation());
+        assertNullSafe(new EgovPwdCheckValidation());
+    }
+
+    private static <A extends java.lang.annotation.Annotation> void assertNullSafe(
+            jakarta.validation.ConstraintValidator<A, String> validator) {
+        boolean result = assertDoesNotThrow(() -> validator.isValid(null, null),
+                validator.getClass().getSimpleName() + "는 null 입력에서 예외를 던지면 안 된다");
+        assertFalse(result, validator.getClass().getSimpleName() + "는 null 입력에 false를 반환해야 한다");
+    }
+
+    @Test
+    void validators_stillValidateNonNullInput() {
+        // 가드 추가가 정상 입력 판정을 바꾸지 않는지 확인한다.
+        assertFalse(new EgovEnglishCheckValidation().isValid("한글", null), "영문 검증기는 한글에 false");
+        assertDoesNotThrow(() -> new EgovEnglishCheckValidation().isValid("abc", null));
+        assertDoesNotThrow(() -> new EgovRrnCheckValidation().isValid("900101-1234567", null));
+    }
+}


### PR DESCRIPTION
## 문제

reactive validation 패키지의 `ConstraintValidator` 구현 중 8종
(`EgovCnCheckValidation`·`EgovCrnCheckValidation`·`EgovRrnCheckValidation`·`EgovMobilePhoneCheckValidation`·`EgovPhoneCheckValidation`·`EgovEnglishCheckValidation`·`EgovKoreanCheckValidation`·`EgovPwdCheckValidation`)이 `isValid` 진입부에서 `value.replaceAll(...)` 또는 `PATTERN.matcher(value)`를 널 체크 없이 호출합니다. 검증 대상 필드가 `null`이면 `NullPointerException`이 발생합니다.

같은 패키지의 `EgovEmailCheckValidation`·`EgovIPCheckValidation`·`EgovNullCheckValidation`은 이미 `null`을 안전하게 처리하고 있어 내부 정책이 일관되지 않습니다.

## 수정

형제 클래스와 동일하게 각 `isValid` 진입부에 `null`이면 `false`를 반환하는 가드를 추가했습니다.

## 검증

8종 검증기가 `null` 입력에서 예외 없이 `false`를 반환하는지, 정상 입력 판정은 유지되는지 검증하는 단위 테스트를 추가했습니다(수정 전에는 `NullPointerException` 재현).