### PR TITLE
fix: EgovEscapableDelimitedLineTokenizer가 $ 구분자에서 던지는 Illegal group reference 예외 제거

### DIFF
--- a/Batch/org.egovframe.rte.bat.core/src/main/java/org/egovframe/rte/bat/core/item/file/transform/EgovEscapableDelimitedLineTokenizer.java
+++ b/Batch/org.egovframe.rte.bat.core/src/main/java/org/egovframe/rte/bat/core/item/file/transform/EgovEscapableDelimitedLineTokenizer.java
@@ -34,6 +34,7 @@ import java.util.List;
  * ----------------------------------------------
  * 2017.10.23	신용호			최초 생성
  * 2023.08.31	유지보수			불필요한 replaceAll을 replace 로 수정(getRegexDelimiter(), Contribution 반영)
+ * 2026.07.19	z3rotig4r		getRegexDelimiter()의 남은 replaceAll을 replace로 수정($ 구분자 시 Illegal group reference 예외 제거)
  * </pre>
  * @since 2017.10.23
  */
@@ -205,10 +206,10 @@ public class EgovEscapableDelimitedLineTokenizer extends EgovAbstractLineTokeniz
         delimiter = delimiter.replace("\\[", "\\\\[");
         delimiter = delimiter.replace("\\]", "\\\\]");
 
-        delimiter = delimiter.replaceAll("[*]", "[*]");
-        delimiter = delimiter.replaceAll("[+]", "[+]");
-        delimiter = delimiter.replaceAll("[$]", "[$]");
-        delimiter = delimiter.replaceAll("[|]", "[|]");
+        delimiter = delimiter.replace("*", "[*]");
+        delimiter = delimiter.replace("+", "[+]");
+        delimiter = delimiter.replace("$", "[$]");
+        delimiter = delimiter.replace("|", "[|]");
 
         LOGGER.debug("### EgovEscapableDelimitedLineTokenizer getRegexDelimiter() : {}", delimiter);
         return delimiter;

--- a/Batch/org.egovframe.rte.bat.core/src/test/java/org/egovframe/rte/bat/core/item/file/transform/EgovEscapableDelimitedLineTokenizerDollarTest.java
+++ b/Batch/org.egovframe.rte.bat.core/src/test/java/org/egovframe/rte/bat/core/item/file/transform/EgovEscapableDelimitedLineTokenizerDollarTest.java
@@ -1,0 +1,32 @@
+package org.egovframe.rte.bat.core.item.file.transform;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * {@link EgovEscapableDelimitedLineTokenizer}가 {@code $}를 구분자로 사용할 때
+ * 정규식 replacement의 그룹 참조 오용으로 IllegalArgumentException을 던지지 않는지 검증한다.
+ */
+class EgovEscapableDelimitedLineTokenizerDollarTest {
+
+    @Test
+    void setDelimiter_dollar_doesNotThrow() {
+        EgovEscapableDelimitedLineTokenizer tokenizer = new EgovEscapableDelimitedLineTokenizer();
+        // 수정 전에는 getRegexDelimiter()의 replaceAll("[$]","[$]")에서
+        // IllegalArgumentException: Illegal group reference 가 발생했다.
+        assertDoesNotThrow(() -> tokenizer.setDelimiter("$"),
+                "$ 구분자 설정이 예외를 던지면 안 된다");
+    }
+
+    @Test
+    void doTokenize_dollarDelimiter_splitsColumns() {
+        EgovEscapableDelimitedLineTokenizer tokenizer = new EgovEscapableDelimitedLineTokenizer();
+        tokenizer.setDelimiter("$");
+        List<String> tokens = tokenizer.doTokenize("a$b$c");
+        assertEquals(List.of("a", "b", "c"), tokens, "$ 구분자로 컬럼이 분리되어야 한다");
+    }
+}


### PR DESCRIPTION
## 문제

`getRegexDelimiter()`는 구분자에 포함된 정규식 특수문자를 이스케이프합니다. 그런데 남아 있던 `replaceAll("[$]", "[$]")`의 replacement 문자열에서 `$`는 그룹 참조 특수문자로 해석됩니다. `$` 뒤에 숫자가 아닌 `]`가 오므로, `setDelimiter("$")` 호출 시 `IllegalArgumentException: Illegal group reference`가 발생합니다.

`setDelimiter`는 public 호출 경로이며, 같은 줄의 `[*]`·`[+]`·`[|]`는 replacement에 `$`가 없어 예외가 없고 `$`만 문제입니다.

## 수정

이 파일이 2023년에 다른 `replaceAll`을 `replace`로 바꾼 것과 동일하게, 남은 네 줄도 리터럴 `replace`로 변경했습니다. 단일 문자 치환이라 동작은 같고 그룹 참조 문제만 제거됩니다.

## 검증

`$` 구분자 설정과 토큰 분리가 예외 없이 동작하는지 검증하는 단위 테스트를 추가했습니다(수정 전에는 `Illegal group reference` 재현).