### PR TITLE
fix: EgovCommandLineRunner의 JobExecution 페이징 offset 리셋 누락 수정

### DIFF
--- a/Batch/org.egovframe.rte.bat.core/src/main/java/org/egovframe/rte/bat/core/launch/support/EgovCommandLineRunner.java
+++ b/Batch/org.egovframe.rte.bat.core/src/main/java/org/egovframe/rte/bat/core/launch/support/EgovCommandLineRunner.java
@@ -60,7 +60,6 @@ public class EgovCommandLineRunner {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(EgovCommandLineRunner.class);
     private static final int EXE_COUNT = 100;
-    private static int EXESTART = 0;
 
     /**
      * 실행 종료를 위한 SystemExiter
@@ -308,7 +307,10 @@ public class EgovCommandLineRunner {
         }
 
         List<JobExecution> executions = new ArrayList<JobExecution>();
-        List<JobInstance> lastInstances = jobExplorer.getJobInstances(jobIdentifier, EXESTART, EXE_COUNT);
+        // 페이징 offset은 호출마다 0에서 시작해야 한다. static 필드로 두면 이전 호출의 누적값이 남아
+        // (restart 처리가 이 메서드를 실패·실행중·완료 판정으로 반복 호출) 오래된 offset부터 조회해 빈 결과를 얻는다.
+        int start = 0;
+        List<JobInstance> lastInstances = jobExplorer.getJobInstances(jobIdentifier, start, EXE_COUNT);
         while (!lastInstances.isEmpty()) {
             for (JobInstance jobInstance : lastInstances) {
                 List<JobExecution> jobExecutions = jobExplorer.getJobExecutions(jobInstance);
@@ -321,8 +323,8 @@ public class EgovCommandLineRunner {
                     }
                 }
             }
-            EXESTART += EXE_COUNT;
-            lastInstances = jobExplorer.getJobInstances(jobIdentifier, EXESTART, EXE_COUNT);
+            start += EXE_COUNT;
+            lastInstances = jobExplorer.getJobInstances(jobIdentifier, start, EXE_COUNT);
         }
 
         return executions;

--- a/Batch/org.egovframe.rte.bat.core/src/test/java/org/egovframe/rte/bat/core/launch/support/EgovCommandLineRunnerExeStartTest.java
+++ b/Batch/org.egovframe.rte.bat.core/src/test/java/org/egovframe/rte/bat/core/launch/support/EgovCommandLineRunnerExeStartTest.java
@@ -1,0 +1,69 @@
+package org.egovframe.rte.bat.core.launch.support;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.batch.core.BatchStatus;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.JobInstance;
+import org.springframework.batch.core.explore.JobExplorer;
+
+/**
+ * {@link EgovCommandLineRunner}의 JobExecution 페이징 offset이 호출마다 0에서 시작하는지 검증한다.
+ * (offset을 static 필드로 두면 이전 호출의 누적값이 남아 두 번째 호출부터 빈 결과를 얻는 버그가 있었다)
+ */
+class EgovCommandLineRunnerExeStartTest {
+
+	@SuppressWarnings("unchecked")
+	private static List<JobExecution> invoke(EgovCommandLineRunner runner, String jobId) throws Exception {
+		Method m = EgovCommandLineRunner.class.getDeclaredMethod("getJobExecutionsWithStatusGreaterThan", String.class,
+				BatchStatus.class);
+		m.setAccessible(true);
+		return (List<JobExecution>) m.invoke(runner, jobId, BatchStatus.STOPPING);
+	}
+
+	/** getJobInstances(name,0,100)에서만 인스턴스를 반환하고, 다음 페이지는 비어 있는 JobExplorer 스텁. */
+	private static JobExplorer stubJobExplorer(String jobName, JobInstance instance, JobExecution execution) {
+		InvocationHandler handler = (proxy, method, args) -> {
+			switch (method.getName()) {
+			case "getJobInstances":
+				int start = (int) args[1];
+				return start == 0 ? List.of(instance) : List.of();
+			case "getJobExecutions":
+				return List.of(execution);
+			default:
+				return null;
+			}
+		};
+		return (JobExplorer) Proxy.newProxyInstance(JobExplorer.class.getClassLoader(),
+				new Class<?>[] { JobExplorer.class }, handler);
+	}
+
+	@Test
+	void pagingOffset_resetsPerCall() throws Exception {
+		String jobName = "sampleJob"; // 숫자가 아니어야 페이징 조회 경로로 진입
+
+		JobInstance instance = new JobInstance(1L, jobName);
+		JobExecution failed = new JobExecution(10L);
+		failed.setStatus(BatchStatus.FAILED); // STOPPING보다 상위
+
+		EgovCommandLineRunner runner = new EgovCommandLineRunner();
+		Field f = EgovCommandLineRunner.class.getDeclaredField("jobExplorer");
+		f.setAccessible(true);
+		f.set(runner, stubJobExplorer(jobName, instance, failed));
+
+		List<JobExecution> first = invoke(runner, jobName);
+		List<JobExecution> second = invoke(runner, jobName);
+
+		assertFalse(first.isEmpty(), "첫 호출은 실패 JobExecution을 찾아야 한다");
+		assertFalse(second.isEmpty(), "두 번째 호출도 offset이 0으로 리셋되어 동일하게 찾아야 한다");
+		assertEquals(first.size(), second.size(), "호출마다 동일한 결과여야 한다");
+	}
+}


### PR DESCRIPTION
## 문제

`getJobExecutionsWithStatusGreaterThan`는 `JobInstance`를 `EXE_COUNT` 단위로 페이징 조회하는데, 페이징 시작 offset을 `static` 필드(`EXESTART`)로 두어 메서드 진입 시 0으로 리셋되지 않습니다. restart 처리가 이 메서드를 실패·실행 중·완료 판정으로 여러 번 호출하므로, 두 번째 호출부터는 이전 호출에서 누적된 큰 offset부터 조회해 빈 목록을 얻고, 실패·실행 중 Job을 찾지 못해 재시작·abandon 로직이 오작동할 수 있습니다.

## 수정

offset을 메서드 지역 변수로 옮겨 호출마다 0에서 시작하도록 했습니다.

## 검증

동일 `JobExplorer`로 두 번 호출해도 같은 결과를 얻는지 검증하는 단위 테스트를 추가했습니다(수정 전에는 두 번째 호출이 빈 결과).