### PR TITLE
test: EgovResourceReleaser·EgovIdGnrStrategyImpl 단위 테스트 추가

### DIFF
--- a/Foundation/org.egovframe.rte.fdl.idgnr/src/test/java/org/egovframe/rte/fdl/idgnr/impl/strategy/EgovIdGnrStrategyImplTest.java
+++ b/Foundation/org.egovframe.rte.fdl.idgnr/src/test/java/org/egovframe/rte/fdl/idgnr/impl/strategy/EgovIdGnrStrategyImplTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2008-2024 MOIS(Ministry of the Interior and Safety).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.egovframe.rte.fdl.idgnr.impl.strategy;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * EgovIdGnrStrategyImplTest 클래스
+ * <p>
+ * ID 생성 정책 구현({@link EgovIdGnrStrategyImpl})의 fillString/makeId 동작을
+ * 결정적으로 검증한다. 소스는 수정하지 않고 현행 동작을 그대로 문서화한다.
+ * <p>
+ * == 개정이력(Modification Information) ==
+ * <p>
+ * 수정일      수정자           수정내용
+ * -------    --------    ---------------------------
+ * 2026.07.28  개발팀          최초 생성
+ */
+public class EgovIdGnrStrategyImplTest {
+
+    /**
+     * fillString - 원본보다 자리수가 크면 앞을 채움 문자로 패딩한다.
+     */
+    @Test
+    public void testFillStringPadsWithFillChar() {
+        assertEquals("00007", EgovIdGnrStrategyImpl.fillString("7", '0', 5));
+        assertEquals("00042", EgovIdGnrStrategyImpl.fillString("42", '0', 5));
+        assertEquals("xxxab", EgovIdGnrStrategyImpl.fillString("ab", 'x', 5));
+    }
+
+    /**
+     * fillString - 자리수와 원본 길이가 같으면(cipers == length) 원본을 그대로 반환한다.
+     */
+    @Test
+    public void testFillStringBoundaryEqualLength() {
+        assertEquals("12345", EgovIdGnrStrategyImpl.fillString("12345", '0', 5));
+        assertEquals("A", EgovIdGnrStrategyImpl.fillString("A", '0', 1));
+    }
+
+    /**
+     * fillString - 자리수가 원본 길이보다 작으면(cipers &lt; length, 오버플로) null 을 반환한다.
+     */
+    @Test
+    public void testFillStringOverflowReturnsNull() {
+        assertNull(EgovIdGnrStrategyImpl.fillString("123456", '0', 5));
+        assertNull(EgovIdGnrStrategyImpl.fillString("AB", '0', 1));
+    }
+
+    /**
+     * makeId - prefix 와 패딩된 문자열이 결합된다.
+     */
+    @Test
+    public void testMakeIdCombinesPrefixAndPaddedId() {
+        EgovIdGnrStrategyImpl strategy = new EgovIdGnrStrategyImpl("TEST-", 5, '0');
+        assertEquals("TEST-00007", strategy.makeId("7"));
+    }
+
+    /**
+     * makeId - 기본 생성자 + setter 로 정책을 구성한 경우(기본 fillChar '0', 기본 cipers 5).
+     */
+    @Test
+    public void testMakeIdWithDefaultConstructorAndSetters() {
+        EgovIdGnrStrategyImpl strategy = new EgovIdGnrStrategyImpl();
+        strategy.setPrefix("ID");
+        // 기본 cipers(5), 기본 fillChar('0') 적용 확인
+        assertEquals("ID00009", strategy.makeId("9"));
+
+        strategy.setCipers(3);
+        strategy.setFillChar('*');
+        assertEquals("ID**1", strategy.makeId("1"));
+    }
+
+    /**
+     * makeId - 경계(cipers == 원본 길이)에서는 패딩 없이 prefix 와 원본이 결합된다.
+     */
+    @Test
+    public void testMakeIdBoundaryEqualLength() {
+        EgovIdGnrStrategyImpl strategy = new EgovIdGnrStrategyImpl("P", 5, '0');
+        assertEquals("P12345", strategy.makeId("12345"));
+    }
+
+    /**
+     * makeId - 오버플로(cipers &lt; 원본 길이) 시 fillString 이 null 을 반환하여
+     * 문자열 결합 과정에서 "prefix" + "null" 리터럴이 만들어지는 현행 동작을 문서화한다.
+     * (소스 수정 없이 현재 구현의 동작만 검증)
+     */
+    @Test
+    public void testMakeIdOverflowProducesNullLiteral() {
+        EgovIdGnrStrategyImpl strategy = new EgovIdGnrStrategyImpl("PRE", 2, '0');
+        assertEquals("PREnull", strategy.makeId("12345"));
+    }
+}

--- a/Foundation/org.egovframe.rte.fdl.logging/src/test/java/org/egovframe/rte/fdl/logging/util/EgovResourceReleaserTest.java
+++ b/Foundation/org.egovframe.rte.fdl.logging/src/test/java/org/egovframe/rte/fdl/logging/util/EgovResourceReleaserTest.java
@@ -1,0 +1,316 @@
+/*
+ * Copyright 2008-2024 MOIS(Ministry of the Interior and Safety).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.egovframe.rte.fdl.logging.util;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.sql.Wrapper;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * EgovResourceReleaserTest 클래스
+ * <p>
+ * 리소스 정리 유틸리티({@link EgovResourceReleaser})의 단위 테스트.
+ * Mockito 등 목킹 프레임워크 없이 순수 Java 스텁/Proxy 로 각 분기(null 안전,
+ * 정상 close 호출, 미지원 Wrapper 예외)를 결정적으로 검증한다.
+ * <p>
+ * == 개정이력(Modification Information) ==
+ * <p>
+ * 수정일      수정자           수정내용
+ * -------    --------    ---------------------------
+ * 2026.07.28  개발팀          최초 생성
+ */
+public class EgovResourceReleaserTest {
+
+    /**
+     * close(Closeable...) - 정상 리소스가 실제로 close 되는지 확인.
+     */
+    @Test
+    public void testCloseInvokesCloseOnResources() {
+        FlagCloseable c1 = new FlagCloseable();
+        FlagCloseable c2 = new FlagCloseable();
+
+        EgovResourceReleaser.close(c1, c2);
+
+        assertTrue(c1.closed, "첫 번째 리소스는 close 되어야 한다");
+        assertTrue(c2.closed, "두 번째 리소스는 close 되어야 한다");
+    }
+
+    /**
+     * close(Closeable...) - null 요소가 섞여 있어도 예외 없이 안전하게 처리.
+     */
+    @Test
+    public void testCloseIsNullSafe() {
+        FlagCloseable c1 = new FlagCloseable();
+
+        assertDoesNotThrow(() -> EgovResourceReleaser.close(c1, null));
+        assertTrue(c1.closed, "null 요소가 있어도 유효한 리소스는 close 되어야 한다");
+        assertDoesNotThrow(() -> EgovResourceReleaser.close((Closeable) null));
+    }
+
+    /**
+     * close(Closeable...) - close 중 IOException 이 발생해도 밖으로 전파되지 않고 무시.
+     */
+    @Test
+    public void testCloseSwallowsIOException() {
+        Closeable throwing = () -> {
+            throw new IOException("boom");
+        };
+        assertDoesNotThrow(() -> EgovResourceReleaser.close(throwing));
+    }
+
+    /**
+     * closeDBObjects(Wrapper...) - ResultSet/Statement/Connection 각 타입이 실제로 close 되는지 확인.
+     */
+    @Test
+    public void testCloseDBObjectsClosesEachJdbcType() {
+        CloseTracker rsTracker = new CloseTracker();
+        CloseTracker stmtTracker = new CloseTracker();
+        CloseTracker connTracker = new CloseTracker();
+
+        ResultSet rs = newJdbcProxy(ResultSet.class, rsTracker);
+        Statement stmt = newJdbcProxy(Statement.class, stmtTracker);
+        Connection conn = newJdbcProxy(Connection.class, connTracker);
+
+        EgovResourceReleaser.closeDBObjects(rs, stmt, conn);
+
+        assertTrue(rsTracker.closed, "ResultSet 은 close 되어야 한다");
+        assertTrue(stmtTracker.closed, "Statement 는 close 되어야 한다");
+        assertTrue(connTracker.closed, "Connection 은 close 되어야 한다");
+    }
+
+    /**
+     * closeDBObjects(Wrapper...) - null 요소는 예외 없이 건너뛴다.
+     */
+    @Test
+    public void testCloseDBObjectsIsNullSafe() {
+        CloseTracker rsTracker = new CloseTracker();
+        ResultSet rs = newJdbcProxy(ResultSet.class, rsTracker);
+
+        assertDoesNotThrow(() -> EgovResourceReleaser.closeDBObjects(rs, null));
+        assertTrue(rsTracker.closed);
+        assertDoesNotThrow(() -> EgovResourceReleaser.closeDBObjects((Wrapper) null));
+    }
+
+    /**
+     * closeDBObjects(Wrapper...) - close 중 SQLException 이 발생해도 전파되지 않고 무시.
+     */
+    @Test
+    public void testCloseDBObjectsSwallowsSQLException() {
+        CloseTracker tracker = new CloseTracker();
+        tracker.throwOnClose = true;
+        ResultSet rs = newJdbcProxy(ResultSet.class, tracker);
+
+        assertDoesNotThrow(() -> EgovResourceReleaser.closeDBObjects(rs));
+    }
+
+    /**
+     * closeDBObjects(Wrapper...) - ResultSet/Statement/Connection 이 아닌 Wrapper 는 IllegalArgumentException.
+     */
+    @Test
+    public void testCloseDBObjectsThrowsOnUnsupportedWrapper() {
+        Wrapper unsupported = (Wrapper) Proxy.newProxyInstance(
+                getClass().getClassLoader(),
+                new Class<?>[]{Wrapper.class},
+                (proxy, method, args) -> {
+                    if ("toString".equals(method.getName())) {
+                        return "unsupportedWrapper";
+                    }
+                    return defaultReturn(method);
+                });
+
+        assertThrows(IllegalArgumentException.class,
+                () -> EgovResourceReleaser.closeDBObjects(unsupported));
+    }
+
+    /**
+     * closeSockets(Socket...) - 각 소켓의 shutdownOutput/close 가 호출되는지 확인.
+     */
+    @Test
+    public void testCloseSocketsClosesEachSocket() {
+        StubSocket s1 = new StubSocket();
+        StubSocket s2 = new StubSocket();
+
+        EgovResourceReleaser.closeSockets(s1, s2);
+
+        assertTrue(s1.shutdownOutputCalled && s1.closed);
+        assertTrue(s2.shutdownOutputCalled && s2.closed);
+    }
+
+    /**
+     * closeSockets(Socket...) - null 요소는 예외 없이 건너뛴다.
+     */
+    @Test
+    public void testCloseSocketsIsNullSafe() {
+        StubSocket s1 = new StubSocket();
+
+        assertDoesNotThrow(() -> EgovResourceReleaser.closeSockets(s1, null));
+        assertTrue(s1.closed);
+        assertDoesNotThrow(() -> EgovResourceReleaser.closeSockets((Socket) null));
+    }
+
+    /**
+     * closeSocketObjects(Socket, ServerSocket) - Socket 과 ServerSocket 이 모두 close 되는지 확인.
+     */
+    @Test
+    public void testCloseSocketObjectsClosesBoth() throws IOException {
+        StubSocket socket = new StubSocket();
+        StubServerSocket server = new StubServerSocket();
+
+        EgovResourceReleaser.closeSocketObjects(socket, server);
+
+        assertTrue(socket.shutdownOutputCalled && socket.closed);
+        assertTrue(server.closed);
+    }
+
+    /**
+     * closeSocketObjects(Socket, ServerSocket) - null 인자는 예외 없이 처리.
+     */
+    @Test
+    public void testCloseSocketObjectsIsNullSafe() {
+        assertDoesNotThrow(() -> EgovResourceReleaser.closeSocketObjects(null, null));
+    }
+
+    /**
+     * exceptionHandling(Socket) - shutdownOutput/close 시 IOException 이 발생해도 무시.
+     */
+    @Test
+    public void testExceptionHandlingSwallowsIOException() {
+        StubSocket socket = new StubSocket();
+        socket.throwOnShutdown = true;
+        socket.throwOnClose = true;
+
+        assertDoesNotThrow(() -> EgovResourceReleaser.exceptionHandling(socket));
+    }
+
+    // ---------------------------------------------------------------------
+    // 순수 Java 스텁/헬퍼
+    // ---------------------------------------------------------------------
+
+    /** close 호출 여부를 기록하는 간단한 Closeable 스텁. */
+    private static final class FlagCloseable implements Closeable {
+        boolean closed;
+
+        @Override
+        public void close() {
+            closed = true;
+        }
+    }
+
+    /** JDBC Proxy 의 close 호출 여부 및 예외 발생을 제어하는 트래커. */
+    private static final class CloseTracker {
+        boolean closed;
+        boolean throwOnClose;
+    }
+
+    /** JDBC 인터페이스(ResultSet/Statement/Connection)용 동적 Proxy 생성. */
+    @SuppressWarnings("unchecked")
+    private static <T> T newJdbcProxy(Class<T> jdbcType, CloseTracker tracker) {
+        InvocationHandler handler = (proxy, method, args) -> {
+            if ("close".equals(method.getName()) && method.getParameterCount() == 0) {
+                if (tracker.throwOnClose) {
+                    throw new SQLException("boom");
+                }
+                tracker.closed = true;
+                return null;
+            }
+            if ("toString".equals(method.getName())) {
+                return jdbcType.getSimpleName() + "Proxy";
+            }
+            return defaultReturn(method);
+        };
+        return (T) Proxy.newProxyInstance(
+                EgovResourceReleaserTest.class.getClassLoader(),
+                new Class<?>[]{jdbcType},
+                handler);
+    }
+
+    /** Proxy 메서드 기본 반환값(primitive 안전값 포함). */
+    private static Object defaultReturn(Method method) {
+        Class<?> returnType = method.getReturnType();
+        if (returnType == boolean.class) {
+            return Boolean.FALSE;
+        }
+        if (returnType == int.class || returnType == short.class || returnType == byte.class) {
+            return 0;
+        }
+        if (returnType == long.class) {
+            return 0L;
+        }
+        if (returnType == double.class) {
+            return 0.0d;
+        }
+        if (returnType == float.class) {
+            return 0.0f;
+        }
+        if (returnType == char.class) {
+            return '\0';
+        }
+        return null;
+    }
+
+    /** shutdownOutput/close 호출을 기록하는 Socket 스텁. */
+    private static class StubSocket extends Socket {
+        boolean shutdownOutputCalled;
+        boolean closed;
+        boolean throwOnShutdown;
+        boolean throwOnClose;
+
+        @Override
+        public void shutdownOutput() throws IOException {
+            shutdownOutputCalled = true;
+            if (throwOnShutdown) {
+                throw new IOException("shutdown boom");
+            }
+        }
+
+        @Override
+        public synchronized void close() throws IOException {
+            closed = true;
+            if (throwOnClose) {
+                throw new IOException("close boom");
+            }
+        }
+    }
+
+    /** close 호출을 기록하는 ServerSocket 스텁. */
+    private static class StubServerSocket extends ServerSocket {
+        boolean closed;
+
+        StubServerSocket() throws IOException {
+            super();
+        }
+
+        @Override
+        public void close() throws IOException {
+            closed = true;
+        }
+    }
+}


### PR DESCRIPTION
## 내용

테스트가 없던 Foundation 유틸에 단위 테스트를 추가합니다(소스 무변경).

- `EgovResourceReleaser`(12): `close`/`closeDBObjects`/`closeSockets`/`closeSocketObjects`/`exceptionHandling`의 null 안전, 정상 close 호출, 미지원 Wrapper의 `IllegalArgumentException`, IOException/SQLException 무시 분기. 순수 Java 스텁(익명 클래스·`Proxy`).
- `EgovIdGnrStrategyImpl`(7): `fillString` 패딩 정상·경계·오버플로(null 반환), `makeId` 조합 현행 동작.

순수 Java·결정적, `mvn test`로 green.