### PR TITLE
test: 고정길이/고정바이트 토크나이저·FieldExtractor 단위 테스트 추가

### DIFF
--- a/Batch/org.egovframe.rte.bat.core/src/test/java/org/egovframe/rte/bat/core/item/file/transform/EgovFieldExtractorTest.java
+++ b/Batch/org.egovframe.rte.bat.core/src/test/java/org/egovframe/rte/bat/core/item/file/transform/EgovFieldExtractorTest.java
@@ -1,0 +1,87 @@
+package org.egovframe.rte.bat.core.item.file.transform;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+
+/**
+ * EgovFieldExtractor JUnit Test 클래스
+ *
+ * <p>extract(item)이 리플렉션 getter 호출로 VO 필드를 추출하여 Object 배열로
+ * 반환하는지 검증한다. names 순서에 따른 추출 순서와 null 필드 처리를 확인한다.</p>
+ *
+ * @version 1.0
+ * <p>
+ * == 개정이력(Modification Information) ==
+ * <p>
+ * 수정일        수정자           수정내용
+ * -------      -------------  ----------------------
+ * 2026.07.28  eGovFrame        최초 생성
+ * @since 2026.07.28
+ */
+public class EgovFieldExtractorTest {
+
+    /**
+     * 리플렉션 getter 추출 검증을 위한 단순 VO 픽스처.
+     */
+    public static class SampleVO {
+        private String id;
+        private String name;
+        private Integer amount;
+
+        public SampleVO(String id, String name, Integer amount) {
+            this.id = id;
+            this.name = name;
+            this.amount = amount;
+        }
+
+        public String getId() {
+            return id;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public Integer getAmount() {
+            return amount;
+        }
+    }
+
+    private EgovFieldExtractor<SampleVO> newExtractor(String... names) {
+        EgovFieldExtractor<SampleVO> extractor = new EgovFieldExtractor<>();
+        extractor.setNames(names);
+        extractor.afterPropertiesSet();
+        return extractor;
+    }
+
+    @Test
+    public void testExtractReturnsFieldsInNamesOrder() {
+        EgovFieldExtractor<SampleVO> extractor = newExtractor("id", "name", "amount");
+
+        Object[] actual = extractor.extract(new SampleVO("A001", "홍길동", 1000));
+
+        assertArrayEquals(new Object[]{"A001", "홍길동", 1000}, actual);
+    }
+
+    @Test
+    public void testExtractRespectsCustomNamesOrder() {
+        // names 배열 순서대로 추출되어야 한다.
+        EgovFieldExtractor<SampleVO> extractor = newExtractor("amount", "id");
+
+        Object[] actual = extractor.extract(new SampleVO("A001", "홍길동", 1000));
+
+        assertArrayEquals(new Object[]{1000, "A001"}, actual);
+    }
+
+    @Test
+    public void testExtractHandlesNullField() {
+        // getter 가 null 을 반환하는 필드는 결과 배열에도 null 로 담긴다.
+        EgovFieldExtractor<SampleVO> extractor = newExtractor("id", "name", "amount");
+
+        Object[] actual = extractor.extract(new SampleVO("A001", null, null));
+
+        assertArrayEquals(new Object[]{"A001", null, null}, actual);
+    }
+
+}

--- a/Batch/org.egovframe.rte.bat.core/src/test/java/org/egovframe/rte/bat/core/item/file/transform/EgovFixedByteLengthTokenizerTest.java
+++ b/Batch/org.egovframe.rte.bat.core/src/test/java/org/egovframe/rte/bat/core/item/file/transform/EgovFixedByteLengthTokenizerTest.java
@@ -1,0 +1,121 @@
+package org.egovframe.rte.bat.core.item.file.transform;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.batch.item.file.transform.IncorrectLineLengthException;
+import org.springframework.batch.item.file.transform.Range;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * EgovFixedByteLengthTokenizer JUnit Test 클래스
+ *
+ * <p>인코딩을 적용한 byte 기준 고정길이 절단(doTokenize)을 검증한다.
+ * ASCII 정상 분할, UTF-8/EUC-KR 멀티바이트(한글) 경계, open range,
+ * 라인 길이 경계(byte 길이 0/미만/초과)의 IncorrectLineLengthException 분기를 포함한다.</p>
+ *
+ * @version 1.0
+ * <p>
+ * == 개정이력(Modification Information) ==
+ * <p>
+ * 수정일        수정자           수정내용
+ * -------      -------------  ----------------------
+ * 2026.07.28  eGovFrame        최초 생성
+ * @since 2026.07.28
+ */
+public class EgovFixedByteLengthTokenizerTest {
+
+    private EgovFixedByteLengthTokenizer newTokenizer(Range... ranges) {
+        EgovFixedByteLengthTokenizer tokenizer = new EgovFixedByteLengthTokenizer();
+        tokenizer.setColumns(ranges);
+        return tokenizer;
+    }
+
+    @Test
+    public void testDoTokenizeAsciiWithExplicitEncoding() throws Exception {
+        // ASCII 는 UTF-8 에서 1byte 이므로 byte 절단이 문자 절단과 동일하다.
+        EgovFixedByteLengthTokenizer tokenizer =
+                newTokenizer(new Range(1, 3), new Range(4, 6), new Range(7, 10));
+
+        List<String> actual = tokenizer.doTokenize("ABCDEFGHIJ", "UTF-8");
+
+        assertEquals(Arrays.asList("ABC", "DEF", "GHIJ"), actual);
+    }
+
+    @Test
+    public void testDoTokenizeAsciiWithDefaultEncoding() throws Exception {
+        // 인코딩 미지정 시 byteEncoding(기본 charset)이 사용된다. ASCII 라 charset 에 무관하게 안전하다.
+        EgovFixedByteLengthTokenizer tokenizer =
+                newTokenizer(new Range(1, 2), new Range(3, 4));
+
+        List<String> actual = tokenizer.doTokenize("WXYZ");
+
+        assertEquals(Arrays.asList("WX", "YZ"), actual);
+    }
+
+    @Test
+    public void testDoTokenizeUtf8KoreanBoundary() throws Exception {
+        // UTF-8 에서 한글은 각 3byte. "가나다" = 9byte, range 도 byte 기준으로 지정한다.
+        EgovFixedByteLengthTokenizer tokenizer =
+                newTokenizer(new Range(1, 3), new Range(4, 6), new Range(7, 9));
+
+        List<String> actual = tokenizer.doTokenize("가나다", "UTF-8");
+
+        assertEquals(Arrays.asList("가", "나", "다"), actual);
+    }
+
+    @Test
+    public void testDoTokenizeEucKrKoreanBoundary() throws Exception {
+        // EUC-KR 에서 한글은 각 2byte. "가나다" = 6byte, range 도 byte 기준으로 지정한다.
+        EgovFixedByteLengthTokenizer tokenizer =
+                newTokenizer(new Range(1, 2), new Range(3, 4), new Range(5, 6));
+
+        List<String> actual = tokenizer.doTokenize("가나다", "EUC-KR");
+
+        assertEquals(Arrays.asList("가", "나", "다"), actual);
+    }
+
+    @Test
+    public void testDoTokenizeOpenRangeTakesRemainderBytes() throws Exception {
+        // 마지막 range 가 open 이면 나머지 byte 를 인코딩에 맞춰 취한다. (EUC-KR 2byte/한글)
+        EgovFixedByteLengthTokenizer tokenizer =
+                newTokenizer(new Range(1, 2), new Range(3));
+
+        List<String> actual = tokenizer.doTokenize("가나다", "EUC-KR");
+
+        assertEquals(Arrays.asList("가", "나다"), actual);
+    }
+
+    @Test
+    public void testDoTokenizeThrowsWhenLineEmpty() {
+        // byte 길이 0 → IncorrectLineLengthException
+        EgovFixedByteLengthTokenizer tokenizer =
+                newTokenizer(new Range(1, 3), new Range(4, 6));
+
+        assertThrows(IncorrectLineLengthException.class, () -> tokenizer.doTokenize("", "UTF-8"));
+    }
+
+    @Test
+    public void testDoTokenizeThrowsWhenShorterThanMaxRange() {
+        // byte 길이 < maxRange(9) → IncorrectLineLengthException
+        // "가나" UTF-8 = 6byte < 9
+        EgovFixedByteLengthTokenizer tokenizer =
+                newTokenizer(new Range(1, 3), new Range(4, 6), new Range(7, 9));
+
+        assertThrows(IncorrectLineLengthException.class, () -> tokenizer.doTokenize("가나", "UTF-8"));
+    }
+
+    @Test
+    public void testDoTokenizeThrowsWhenLongerThanMaxRange() {
+        // open = false 이고 byte 길이 > maxRange(6) → IncorrectLineLengthException
+        // "가나다" UTF-8 = 9byte > 6
+        EgovFixedByteLengthTokenizer tokenizer =
+                newTokenizer(new Range(1, 3), new Range(4, 6));
+
+        assertThrows(IncorrectLineLengthException.class, () -> tokenizer.doTokenize("가나다", "UTF-8"));
+    }
+
+}

--- a/Batch/org.egovframe.rte.bat.core/src/test/java/org/egovframe/rte/bat/core/item/file/transform/EgovFixedLengthTokenizerTest.java
+++ b/Batch/org.egovframe.rte.bat.core/src/test/java/org/egovframe/rte/bat/core/item/file/transform/EgovFixedLengthTokenizerTest.java
@@ -1,0 +1,96 @@
+package org.egovframe.rte.bat.core.item.file.transform;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.batch.item.file.transform.IncorrectLineLengthException;
+import org.springframework.batch.item.file.transform.Range;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * EgovFixedLengthTokenizer JUnit Test 클래스
+ *
+ * <p>Range 기반 고정길이 파싱(doTokenize)의 정상 분할, 라인 길이 경계
+ * (maxRange 미만/일치/초과), open range, IncorrectLineLengthException 분기를 검증한다.</p>
+ *
+ * @version 1.0
+ * <p>
+ * == 개정이력(Modification Information) ==
+ * <p>
+ * 수정일        수정자           수정내용
+ * -------      -------------  ----------------------
+ * 2026.07.28  eGovFrame        최초 생성
+ * @since 2026.07.28
+ */
+public class EgovFixedLengthTokenizerTest {
+
+    private EgovFixedLengthTokenizer newTokenizer(Range... ranges) {
+        EgovFixedLengthTokenizer tokenizer = new EgovFixedLengthTokenizer();
+        tokenizer.setColumns(ranges);
+        return tokenizer;
+    }
+
+    @Test
+    public void testDoTokenizeClosedRanges() {
+        // maxRange = 10, open = false, 라인 길이가 정확히 maxRange 와 일치하는 정상 케이스
+        EgovFixedLengthTokenizer tokenizer =
+                newTokenizer(new Range(1, 3), new Range(4, 6), new Range(7, 10));
+
+        List<String> actual = tokenizer.doTokenize("ABCDEFGHIJ");
+
+        assertEquals(Arrays.asList("ABC", "DEF", "GHIJ"), actual);
+    }
+
+    @Test
+    public void testDoTokenizeLineLengthEqualsMaxRange() {
+        // 라인 길이 == maxRange 경계값에서 정상 분할되는지 확인
+        EgovFixedLengthTokenizer tokenizer =
+                newTokenizer(new Range(1, 2), new Range(3, 4));
+
+        List<String> actual = tokenizer.doTokenize("WXYZ");
+
+        assertEquals(Arrays.asList("WX", "YZ"), actual);
+    }
+
+    @Test
+    public void testDoTokenizeOpenRangeTakesRemainder() {
+        // 마지막 range 가 max 값이 없으면(open) 나머지 문자열을 모두 취한다.
+        EgovFixedLengthTokenizer tokenizer =
+                newTokenizer(new Range(1, 3), new Range(4));
+
+        assertEquals(Arrays.asList("ABC", "DEFG"), tokenizer.doTokenize("ABCDEFG"));
+        // open 이므로 maxRange 를 초과하는 더 긴 라인도 예외 없이 나머지를 취한다.
+        assertEquals(Arrays.asList("ABC", "DEFGHIJKL"), tokenizer.doTokenize("ABCDEFGHIJKL"));
+    }
+
+    @Test
+    public void testDoTokenizeThrowsWhenLineEmpty() {
+        // 라인 길이 0 → IncorrectLineLengthException
+        EgovFixedLengthTokenizer tokenizer =
+                newTokenizer(new Range(1, 3), new Range(4, 6));
+
+        assertThrows(IncorrectLineLengthException.class, () -> tokenizer.doTokenize(""));
+    }
+
+    @Test
+    public void testDoTokenizeThrowsWhenLineShorterThanMaxRange() {
+        // 라인 길이 < maxRange(10) → IncorrectLineLengthException
+        EgovFixedLengthTokenizer tokenizer =
+                newTokenizer(new Range(1, 3), new Range(4, 6), new Range(7, 10));
+
+        assertThrows(IncorrectLineLengthException.class, () -> tokenizer.doTokenize("ABCDEFGHI"));
+    }
+
+    @Test
+    public void testDoTokenizeThrowsWhenLineLongerThanMaxRange() {
+        // open = false 이고 라인 길이 > maxRange(10) → IncorrectLineLengthException
+        EgovFixedLengthTokenizer tokenizer =
+                newTokenizer(new Range(1, 3), new Range(4, 6), new Range(7, 10));
+
+        assertThrows(IncorrectLineLengthException.class, () -> tokenizer.doTokenize("ABCDEFGHIJK"));
+    }
+
+}


### PR DESCRIPTION
## 내용

테스트가 없던 Batch 파일 처리 클래스에 단위 테스트를 추가합니다(소스 무변경).

- `EgovFixedLengthTokenizer`(6): closed/open range 분할, 라인 길이 경계, `IncorrectLineLengthException` 분기.
- `EgovFixedByteLengthTokenizer`(8): ASCII·UTF-8/EUC-KR 한글 멀티바이트 경계, open range, byte 길이 예외.
- `EgovFieldExtractor`(3): 리플렉션 필드 추출 순서·null 필드.

JUnit5·순수 Java 픽스처, `mvn test`로 green.