### PR TITLE
test: CalendarTypeHandler·RteGenericValidator 단위 테스트 추가

### DIFF
--- a/Persistence/org.egovframe.rte.psl.dataaccess/src/test/java/org/egovframe/rte/psl/dataaccess/typehandler/CalendarTypeHandlerTest.java
+++ b/Persistence/org.egovframe.rte.psl.dataaccess/src/test/java/org/egovframe/rte/psl/dataaccess/typehandler/CalendarTypeHandlerTest.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2008-2024 MOIS(Ministry of the Interior and Safety).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.egovframe.rte.psl.dataaccess.typehandler;
+
+import com.ibatis.sqlmap.client.extensions.ParameterSetter;
+import com.ibatis.sqlmap.client.extensions.ResultGetter;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Proxy;
+import java.sql.Timestamp;
+import java.sql.Types;
+import java.util.Calendar;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * {@link CalendarTypeHandler} 단위 테스트.
+ * <p>
+ * iBatis 의 {@link ResultGetter} / {@link ParameterSetter} 를
+ * (Mockito 미사용) JDK {@link Proxy} 로 대체하여 필요한 메서드만 구현하고,
+ * {@code java.util.Calendar} 와 {@code java.sql.Timestamp} 간 변환 경로를 검증한다.
+ * 형제 테스트 {@code StringTimestampTypeHandlerTest} 와 동일한 스타일을 따른다.
+ * </p>
+ */
+public class CalendarTypeHandlerTest {
+
+    private static final Timestamp EXPECTED_TS = Timestamp.valueOf("2024-01-02 03:04:05");
+
+    /** 지정한 wasNull/Timestamp 를 반환하는 ResultGetter 프록시 (필요 메서드만 구현). */
+    private ResultGetter resultGetter(final boolean wasNull, final Timestamp ts) {
+        return (ResultGetter) Proxy.newProxyInstance(
+                getClass().getClassLoader(),
+                new Class<?>[]{ResultGetter.class},
+                (proxy, method, args) -> {
+                    switch (method.getName()) {
+                        case "wasNull":
+                            return wasNull;
+                        case "getTimestamp":
+                            return ts;
+                        default:
+                            throw new UnsupportedOperationException(method.getName());
+                    }
+                });
+    }
+
+    /** setTimestamp 호출의 첫 인자(Timestamp)를 캡처하는 ParameterSetter 프록시. */
+    private ParameterSetter capturingTimestampSetter(final AtomicReference<Timestamp> captured) {
+        return (ParameterSetter) Proxy.newProxyInstance(
+                getClass().getClassLoader(),
+                new Class<?>[]{ParameterSetter.class},
+                (proxy, method, args) -> {
+                    if ("setTimestamp".equals(method.getName()) && args != null && args.length >= 1) {
+                        captured.set((Timestamp) args[0]);
+                        return null;
+                    }
+                    throw new UnsupportedOperationException(method.getName());
+                });
+    }
+
+    /** setNull 호출의 SQL 타입 인자를 캡처하는 ParameterSetter 프록시. */
+    private ParameterSetter capturingNullSetter(final AtomicInteger capturedType) {
+        return (ParameterSetter) Proxy.newProxyInstance(
+                getClass().getClassLoader(),
+                new Class<?>[]{ParameterSetter.class},
+                (proxy, method, args) -> {
+                    if ("setNull".equals(method.getName()) && args != null && args.length == 1) {
+                        capturedType.set((Integer) args[0]);
+                        return null;
+                    }
+                    throw new UnsupportedOperationException(method.getName());
+                });
+    }
+
+    @Test
+    public void getResultReturnsNullWhenWasNull() throws Exception {
+        CalendarTypeHandler handler = new CalendarTypeHandler();
+        // wasNull=true 이면 getTimestamp 는 호출되지 않고 null 을 반환해야 한다.
+        assertNull(handler.getResult(resultGetter(true, null)));
+    }
+
+    @Test
+    public void getResultConvertsTimestampToCalendar() throws Exception {
+        CalendarTypeHandler handler = new CalendarTypeHandler();
+        Object result = handler.getResult(resultGetter(false, EXPECTED_TS));
+
+        assertInstanceOf(Calendar.class, result);
+        Calendar cal = (Calendar) result;
+        // Calendar 의 시각은 조회된 Timestamp 와 밀리초 단위로 동일해야 한다.
+        assertEquals(EXPECTED_TS.getTime(), cal.getTimeInMillis());
+    }
+
+    @Test
+    public void setParameterUsesSetNullForNullParameter() throws Exception {
+        CalendarTypeHandler handler = new CalendarTypeHandler();
+        AtomicInteger capturedType = new AtomicInteger(Integer.MIN_VALUE);
+
+        handler.setParameter(capturingNullSetter(capturedType), null);
+
+        // null 파라미터는 Types.DATE 로 setNull 되어야 한다.
+        assertEquals(Types.DATE, capturedType.get());
+    }
+
+    @Test
+    public void setParameterConvertsCalendarToTimestamp() throws Exception {
+        CalendarTypeHandler handler = new CalendarTypeHandler();
+        Calendar cal = Calendar.getInstance();
+        cal.setTimeInMillis(EXPECTED_TS.getTime());
+
+        AtomicReference<Timestamp> captured = new AtomicReference<>();
+        handler.setParameter(capturingTimestampSetter(captured), cal);
+
+        // Calendar 의 밀리초로 만든 Timestamp 가 세팅되어야 한다.
+        assertEquals(new Timestamp(cal.getTimeInMillis()), captured.get());
+        assertEquals(EXPECTED_TS.getTime(), captured.get().getTime());
+    }
+
+    @Test
+    public void valueOfReturnsInputString() {
+        CalendarTypeHandler handler = new CalendarTypeHandler();
+        // 현재 구현은 입력 문자열을 그대로 반환한다.
+        assertEquals("20240102", handler.valueOf("20240102"));
+    }
+}

--- a/Presentation/org.egovframe.rte.ptl.mvc/src/test/java/org/egovframe/rte/ptl/mvc/validation/RteGenericValidatorCoverageTest.java
+++ b/Presentation/org.egovframe.rte.ptl.mvc/src/test/java/org/egovframe/rte/ptl/mvc/validation/RteGenericValidatorCoverageTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2008-2024 MOIS(Ministry of the Interior and Safety).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.egovframe.rte.ptl.mvc.validation;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * {@link RteGenericValidator} 미커버 public static 검증 메서드에 대한 커버리지 테스트.
+ * <p>
+ * 기존 {@code PasswordValidationTest} 가 다루지 않는
+ * {@code isKorean}, {@code isEnglish}, {@code isHtmlTag},
+ * {@code isMoreThan2CharTypeComb}, {@code isRepeatedNTimes} 를 결정적으로 검증하고,
+ * {@code isValidIdIhNum} 의 정규식 가드(\d{13}) 동작을 확인한다. 소스는 변경하지 않는다.
+ * </p>
+ */
+public class RteGenericValidatorCoverageTest {
+
+    @Test
+    public void isKoreanReturnsTrueOnlyForHangul() {
+        assertTrue(RteGenericValidator.isKorean("한글"));
+        assertTrue(RteGenericValidator.isKorean("가나다라"));
+        // 영문/숫자/혼합은 한글이 아니다.
+        assertFalse(RteGenericValidator.isKorean("abc"));
+        assertFalse(RteGenericValidator.isKorean("한a"));
+        assertFalse(RteGenericValidator.isKorean("한글123"));
+    }
+
+    @Test
+    public void isEnglishReturnsTrueOnlyForLetters() {
+        assertTrue(RteGenericValidator.isEnglish("abcDEF"));
+        assertTrue(RteGenericValidator.isEnglish("Hello"));
+        // 숫자/한글/공백이 섞이면 영문이 아니다.
+        assertFalse(RteGenericValidator.isEnglish("abc1"));
+        assertFalse(RteGenericValidator.isEnglish("ab cd"));
+        assertFalse(RteGenericValidator.isEnglish("한글"));
+    }
+
+    @Test
+    public void isHtmlTagReturnsFalseWhenTagPresent() {
+        // 태그가 존재하면 false(=태그 미포함 아님), 없으면 true 를 반환한다.
+        assertFalse(RteGenericValidator.isHtmlTag("<div>hello</div>"));
+        assertFalse(RteGenericValidator.isHtmlTag("text <b> bold"));
+        assertTrue(RteGenericValidator.isHtmlTag("plain text without tag"));
+        // '<'...'>' 쌍이 없으면(부등호만 존재) 태그로 보지 않는다.
+        assertTrue(RteGenericValidator.isHtmlTag("2 > 1 and 3 > 2"));
+    }
+
+    @Test
+    public void isMoreThan2CharTypeCombRequiresLetterDigitSpecial() {
+        // 영문 + 숫자 + 특수문자(~!@#$%^&*?) 조합.
+        assertTrue(RteGenericValidator.isMoreThan2CharTypeComb("abc12!"));
+        assertTrue(RteGenericValidator.isMoreThan2CharTypeComb("a1@"));
+        // 세 종류 미충족 또는 허용되지 않는 문자(한글/공백) 포함 시 false.
+        assertFalse(RteGenericValidator.isMoreThan2CharTypeComb("abcdef"));
+        assertFalse(RteGenericValidator.isMoreThan2CharTypeComb("abc123"));
+        assertFalse(RteGenericValidator.isMoreThan2CharTypeComb("한글1!a"));
+        assertFalse(RteGenericValidator.isMoreThan2CharTypeComb("abc 1 !"));
+    }
+
+    @Test
+    public void isRepeatedNTimesDetectsConsecutiveRepeats() {
+        // (.)\1{n,} : 같은 문자가 최초 1 + n 회 이상 연속되면 true.
+        assertTrue(RteGenericValidator.isRepeatedNTimes("aaa", 2));
+        assertTrue(RteGenericValidator.isRepeatedNTimes("xy1111z", 2));
+        // 반복 길이가 부족하면 false.
+        assertFalse(RteGenericValidator.isRepeatedNTimes("aa", 2));
+        assertFalse(RteGenericValidator.isRepeatedNTimes("ababab", 2));
+    }
+
+    @Test
+    public void isValidIdIhNumRejectsMalformedByRegexGuard() {
+        // \d{13} 가드: 13자리 숫자가 아니면 즉시 false.
+        assertFalse(RteGenericValidator.isValidIdIhNum("123"));
+        assertFalse(RteGenericValidator.isValidIdIhNum("abcdefghijklm"));
+        assertFalse(RteGenericValidator.isValidIdIhNum("12345678901234"));
+        // 형식은 통과해도 날짜/검증코드가 유효하지 않으면 false.
+        assertFalse(RteGenericValidator.isValidIdIhNum("0000000000000"));
+    }
+}


### PR DESCRIPTION
## 내용

테스트가 없거나 부족했던 Persistence/Presentation 클래스에 단위 테스트를 추가합니다(소스 무변경).

- `CalendarTypeHandler`(5): `getResult`(wasNull→null·Timestamp→Calendar), `setParameter`(null→setNull·Calendar→setTimestamp), `valueOf`. 형제 `StringTimestampTypeHandlerTest`의 JDK `Proxy` 스타일 준수.
- `RteGenericValidator`(6): 미커버 `isKorean`·`isEnglish`·`isHtmlTag`·`isMoreThan2CharTypeComb`·`isRepeatedNTimes`·`isValidIdIhNum` 결정적 검증.

`mvn test`로 green.