### PR TITLE
fix(batch): EgovPartitionFlatFileItemWriter의 Spring Batch 5 계약 복구

### DIFF
--- a/Batch/org.egovframe.rte.bat.core/src/main/java/org/egovframe/rte/bat/core/item/file/EgovPartitionFlatFileItemWriter.java
+++ b/Batch/org.egovframe.rte.bat.core/src/main/java/org/egovframe/rte/bat/core/item/file/EgovPartitionFlatFileItemWriter.java
@@ -214,6 +214,7 @@ public class EgovPartitionFlatFileItemWriter<T> extends ExecutionContextUserSupp
      */
     @Override
     public void setResource(WritableResource resource) {
+        setResource((Resource) resource);
     }
 
     /**
@@ -224,7 +225,8 @@ public class EgovPartitionFlatFileItemWriter<T> extends ExecutionContextUserSupp
      * @param chunk the chunk of items to be written; must not be null
      */
     @Override
-    public void write(@NonNull Chunk<? extends T> chunk) {
+    public synchronized void write(@NonNull Chunk<? extends T> chunk) {
+        doWrite(chunk.getItems());
     }
 
     /**
@@ -235,6 +237,10 @@ public class EgovPartitionFlatFileItemWriter<T> extends ExecutionContextUserSupp
      * @param items output Stream 에 쓰여실 itmes 리스트
      */
     public synchronized void write(List<? extends T> items) throws Exception {
+        doWrite(items);
+    }
+
+    private void doWrite(List<? extends T> items) {
         if (!getOutputState().isInitialized()) {
             throw new WriterNotOpenException("Writer must be open before it can be written to");
         }

--- a/Batch/org.egovframe.rte.bat.core/src/test/java/org/egovframe/rte/bat/core/item/file/EgovPartitionFlatFileItemWriterTest.java
+++ b/Batch/org.egovframe.rte.bat.core/src/test/java/org/egovframe/rte/bat/core/item/file/EgovPartitionFlatFileItemWriterTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2008-2024 MOIS(Ministry of the Interior and Safety).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.egovframe.rte.bat.core.item.file;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.batch.item.Chunk;
+import org.springframework.batch.item.ExecutionContext;
+import org.springframework.core.io.FileSystemResource;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.WritableResource;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class EgovPartitionFlatFileItemWriterTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void setsWritableResource() throws Exception {
+        Path output = tempDir.resolve("output.txt");
+        WritableResource resource = new FileSystemResource(output);
+        EgovPartitionFlatFileItemWriter<String> writer = createWriter();
+
+        writer.setResource(resource);
+        writer.open(new ExecutionContext());
+        writer.close();
+
+        assertTrue(Files.exists(output));
+    }
+
+    @Test
+    void writesChunk() throws Exception {
+        Path output = tempDir.resolve("output.txt");
+        Resource resource = new FileSystemResource(output);
+        EgovPartitionFlatFileItemWriter<String> writer = createWriter();
+
+        writer.setResource(resource);
+        writer.open(new ExecutionContext());
+        writer.write(new Chunk<>(List.of("first", "second")));
+        writer.close();
+
+        assertEquals("first\nsecond\n", Files.readString(output));
+    }
+
+    private EgovPartitionFlatFileItemWriter<String> createWriter() throws Exception {
+        EgovPartitionFlatFileItemWriter<String> writer = new EgovPartitionFlatFileItemWriter<>();
+        writer.setLineAggregator(item -> item);
+        writer.setLineSeparator("\n");
+        writer.setTransactional(false);
+        writer.afterPropertiesSet();
+        return writer;
+    }
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

### 공식 문서 참고

현재 Batch 모듈의 Spring Batch 의존성은 `5.2.3`입니다.
Spring Batch 5.2.3 공식 API 문서 기준으로 `ItemWriter`의 `write` 메서드는 `List`가 아니라 `Chunk<? extends T>`를 인자로 받습니다.

- Spring Batch `ItemWriter` API: `write(@NonNull Chunk<? extends T> chunk)`
  - https://docs.spring.io/spring-batch/docs/5.2.3/api/org/springframework/batch/item/ItemWriter.html

<img width="1280" height="900" alt="Spring Batch ItemWriter write Chunk API" src="https://github.com/user-attachments/assets/63c2e826-4f68-4120-a43a-fd5e59e34292" />

또한 `ResourceAwareItemWriterItemStream`은 `WritableResource`에 출력하는 `ItemStreamWriter` 계약을 제공하며, `setResource(WritableResource resource)` 메서드를 정의합니다.

- Spring Batch `ResourceAwareItemWriterItemStream` API: `setResource(WritableResource resource)`
  - https://docs.spring.io/spring-batch/docs/5.2.3/api/org/springframework/batch/item/file/ResourceAwareItemWriterItemStream.html

<img width="1280" height="900" alt="Spring Batch ResourceAwareItemWriterItemStream setResource API" src="https://github.com/user-attachments/assets/b17b049e-6d34-412d-bb18-8ac8a918d975" />

따라서 본 PR은 `EgovPartitionFlatFileItemWriter`가 Spring Batch 5의 writer/resource 계약에 맞게 실제 리소스를 설정하고, `Chunk` 기반 쓰기 호출을 기존 파일 쓰기 로직으로 위임하도록 수정한 것입니다.

### AS-IS

Spring Batch 5에서 `ItemWriter#write(List)`가 `ItemWriter#write(Chunk)`로 변경되었으나,
`EgovPartitionFlatFileItemWriter`의 Spring Batch 5 인터페이스 구현이 비어 있습니다.

```java
@Override
public void setResource(WritableResource resource) {
}

@Override
public void write(Chunk<? extends T> chunk) {
}
```

이로 인해 다음 문제가 발생합니다.

- `WritableResource` 인터페이스를 통해 출력 리소스를 설정하면 내부 `resource`가 `null`로 남아
  `open()`에서 `The resource must be set` 예외가 발생합니다.
- Spring Batch의 `SimpleChunkProcessor`가 호출하는 `write(Chunk)`가 아무 작업도 하지 않아
  Step이 전달한 항목이 파일에 기록되지 않습니다.
- 기존 `write(List)`의 실제 파일 쓰기 로직은 남아 있지만 Spring Batch 5의 호출 경로와
  연결되지 않습니다.

Spring Batch 5 마이그레이션 가이드:
https://github.com/spring-projects/spring-batch/wiki/Spring-Batch-5.0-Migration-Guide

### TO-BE

- `setResource(WritableResource)`를 기존 `setResource(Resource)`에 위임합니다.
- `write(Chunk)`와 기존 `write(List)`가 동일한 private `doWrite(List)` 구현을 사용합니다.
- 두 public 쓰기 진입점의 기존 동기화 특성을 유지합니다.
- 기존 파일 인코딩, header/footer, transactional buffer, restart 상태 로직은 변경하지 않습니다.

```java
@Override
public void setResource(WritableResource resource) {
    setResource((Resource) resource);
}

@Override
public synchronized void write(Chunk<? extends T> chunk) {
    doWrite(chunk.getItems());
}
```

### 영향 범위 및 호환성

- 기존 `write(List)` 공개 메서드를 유지합니다.
- 기존 public 메서드의 checked exception 선언을 변경하지 않습니다.
- Maven 의존성과 설정을 변경하지 않습니다.
- Chunk 및 List 쓰기 진입점은 동일한 객체 monitor로 동기화됩니다.
- 운영 코드 변경은 `EgovPartitionFlatFileItemWriter`에 한정됩니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

### 수정 전 재현

`origin/main`에 동일한 회귀 테스트를 실행한 결과입니다.

```text
Tests run: 2, Failures: 1, Errors: 1, Skipped: 0

setsWritableResource:
IllegalArgumentException: The resource must be set

writesChunk:
expected: "first\nsecond\n"
actual:   ""
```

### 수정 후 회귀 테스트

```text
Tests run: 2, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS
```

### Batch 모듈 전체 검증

```text
mvn -B -Dfile.encoding=UTF-8 -Duser.timezone=Asia/Seoul verify

Tests run: 63, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS
```

JAR, sources JAR 및 Javadoc JAR 생성도 완료되었습니다.

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [X] 기타 Others: 브라우저 비대상 Java 라이브러리

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

### AS-IS

Spring Batch 5 인터페이스 경로에서 동일한 회귀 테스트 2개가 실패합니다.

<img width="3374" height="1396" alt="as-is" src="https://github.com/user-attachments/assets/68744c64-8c7c-472e-bc07-06bd3fdc1274" />

### TO-BE

동일한 Java 17 환경에서 같은 회귀 테스트 2개가 모두 통과합니다.

<img width="3456" height="1358" alt="to-be" src="https://github.com/user-attachments/assets/3075539c-992b-468e-9e98-24ae59d15eab" />