### PR TITLE
fix: EgovCrnCheckValidation의 체크디지트 가중치 적용 범위와 개행 입력 처리 수정

### DIFF
--- a/Presentation/org.egovframe.rte.ptl.reactive/src/main/java/org/egovframe/rte/ptl/reactive/validation/EgovCrnCheckValidation.java
+++ b/Presentation/org.egovframe.rte.ptl.reactive/src/main/java/org/egovframe/rte/ptl/reactive/validation/EgovCrnCheckValidation.java
@@ -54,7 +54,7 @@ public class EgovCrnCheckValidation implements ConstraintValidator<EgovCrnCheck,
         }
 
         int sum = 0;
-        int[] weightArray = {1, 3, 7, 1, 3, 7, 1, 3, 5, 1};
+        int[] weightArray = {1, 3, 7, 1, 3, 7, 1, 3, 5};
         for (int i = 0; i < weightArray.length; i++) {
             sum += weightArray[i] * Integer.parseInt(mValue.substring(i, i + 1));
         }

--- a/Presentation/org.egovframe.rte.ptl.reactive/src/main/java/org/egovframe/rte/ptl/reactive/validation/EgovCrnCheckValidation.java
+++ b/Presentation/org.egovframe.rte.ptl.reactive/src/main/java/org/egovframe/rte/ptl/reactive/validation/EgovCrnCheckValidation.java
@@ -48,7 +48,7 @@ public class EgovCrnCheckValidation implements ConstraintValidator<EgovCrnCheck,
         }
         String mValue = value.replaceAll("-", "");
         Matcher matcher = CRN_PATTERN.matcher(mValue);
-        boolean check = matcher.find();
+        boolean check = matcher.matches();
         if (!check) {
             return false;
         }

--- a/Presentation/org.egovframe.rte.ptl.reactive/src/test/java/org/egovframe/rte/ptl/reactive/validation/ReactiveValidatorsSemanticTest.java
+++ b/Presentation/org.egovframe.rte.ptl.reactive/src/test/java/org/egovframe/rte/ptl/reactive/validation/ReactiveValidatorsSemanticTest.java
@@ -1,0 +1,118 @@
+package org.egovframe.rte.ptl.reactive.validation;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ReactiveValidatorsSemanticTest {
+
+    @Test
+    void crnCheck_validatesBusinessRegistrationNumberChecksum() {
+        EgovCrnCheckValidation validator = new EgovCrnCheckValidation();
+
+        // 가중치는 앞 9자리에만 적용된다(국세청 규격).
+        assertTrue(validator.isValid("124-81-00998", null), "사업자등록번호는 유효한 체크디지트를 true로 판정해야 한다");
+        assertTrue(validator.isValid("220-81-62517", null), "사업자등록번호는 유효한 체크디지트를 true로 판정해야 한다");
+        assertTrue(validator.isValid("101-81-16293", null), "사업자등록번호는 유효한 체크디지트를 true로 판정해야 한다");
+        assertTrue(validator.isValid("1248100998", null), "사업자등록번호는 하이픈 없는 유효 번호를 true로 판정해야 한다");
+
+        assertFalse(validator.isValid("124-81-00990", null), "사업자등록번호는 체크디지트 오류를 false로 판정해야 한다");
+        assertFalse(validator.isValid("220-81-62510", null), "사업자등록번호는 체크디지트 오류를 false로 판정해야 한다");
+        assertFalse(validator.isValid("124-81-0099", null), "사업자등록번호는 9자리 입력을 false로 판정해야 한다");
+        assertFalse(validator.isValid("124-81-009989", null), "사업자등록번호는 11자리 입력을 false로 판정해야 한다");
+        assertFalse(validator.isValid("12481abcde", null), "사업자등록번호는 숫자가 아닌 입력을 false로 판정해야 한다");
+        assertFalse(validator.isValid("", null), "사업자등록번호는 빈 문자열을 false로 판정해야 한다");
+    }
+
+    @Test
+    void cnCheck_validatesCorporateRegistrationNumberChecksum() {
+        EgovCnCheckValidation validator = new EgovCnCheckValidation();
+
+        assertTrue(validator.isValid("110111-0000002", null), "법인등록번호는 유효한 체크디지트를 true로 판정해야 한다");
+        assertTrue(validator.isValid("134211-0123458", null), "법인등록번호는 유효한 체크디지트를 true로 판정해야 한다");
+
+        assertFalse(validator.isValid("110111-0000000", null), "법인등록번호는 체크디지트 오류를 false로 판정해야 한다");
+        assertFalse(validator.isValid("134211-0123450", null), "법인등록번호는 체크디지트 오류를 false로 판정해야 한다");
+        assertFalse(validator.isValid("110111-000000", null), "법인등록번호는 12자리 입력을 false로 판정해야 한다");
+    }
+
+    @Test
+    void rrnCheck_validatesResidentRegistrationNumberChecksum() {
+        EgovRrnCheckValidation validator = new EgovRrnCheckValidation();
+
+        // 아래 값은 실제 개인 식별번호가 아니라 존재할 수 없는 날짜로 만든 체크섬 규격 합성값이다.
+        assertTrue(validator.isValid("991332-1123459", null), "주민등록번호는 합성 유효 체크섬 값을 true로 판정해야 한다");
+        assertTrue(validator.isValid("001332-2123452", null), "주민등록번호는 합성 유효 체크섬 값을 true로 판정해야 한다");
+
+        assertFalse(validator.isValid("991332-1123450", null), "주민등록번호는 체크디지트 오류를 false로 판정해야 한다");
+        assertFalse(validator.isValid("991332-5123459", null), "주민등록번호는 성별코드 패턴 위반을 false로 판정해야 한다");
+        assertFalse(validator.isValid("991332-112345", null), "주민등록번호는 12자리 입력을 false로 판정해야 한다");
+    }
+
+    @Test
+    void mobilePhoneCheck_validatesMobilePhonePattern() {
+        EgovMobilePhoneCheckValidation validator = new EgovMobilePhoneCheckValidation();
+
+        // 검증기가 하이픈을 먼저 제거하므로 하이픈 위치가 아닌 국번·자리수만 판정된다.
+        assertTrue(validator.isValid("010-1234-5678", null), "휴대전화번호는 010 국번의 유효 번호를 true로 판정해야 한다");
+        assertTrue(validator.isValid("011-123-4567", null), "휴대전화번호는 011 국번의 유효 번호를 true로 판정해야 한다");
+        assertTrue(validator.isValid("016-1234-5678", null), "휴대전화번호는 016 국번의 유효 번호를 true로 판정해야 한다");
+
+        assertFalse(validator.isValid("012-1234-5678", null), "휴대전화번호는 국번 규칙 위반을 false로 판정해야 한다");
+        assertFalse(validator.isValid("02-1234-5678", null), "휴대전화번호는 일반전화 형식을 false로 판정해야 한다");
+        assertFalse(validator.isValid("010-1234-56789", null), "휴대전화번호는 12자리 입력을 false로 판정해야 한다");
+        assertFalse(validator.isValid("010-123-456", null), "휴대전화번호는 9자리 입력을 false로 판정해야 한다");
+    }
+
+    @Test
+    void phoneCheck_validatesPhonePattern() {
+        EgovPhoneCheckValidation validator = new EgovPhoneCheckValidation();
+
+        assertTrue(validator.isValid("02-1234-5678", null), "일반전화번호는 02 지역번호의 유효 번호를 true로 판정해야 한다");
+        assertTrue(validator.isValid("031-123-4567", null), "일반전화번호는 031 지역번호의 유효 번호를 true로 판정해야 한다");
+
+        assertFalse(validator.isValid("1234", null), "일반전화번호는 너무 짧은 입력을 false로 판정해야 한다");
+        assertFalse(validator.isValid("02-1234-56789012", null), "일반전화번호는 너무 긴 입력을 false로 판정해야 한다");
+    }
+
+    @Test
+    void englishCheck_validatesEnglishOnlyPattern() {
+        EgovEnglishCheckValidation validator = new EgovEnglishCheckValidation();
+
+        assertTrue(validator.isValid("abc", null), "영문 검증기는 소문자 영문만 있는 입력을 true로 판정해야 한다");
+        assertTrue(validator.isValid("ABCdef", null), "영문 검증기는 대소문자 영문 입력을 true로 판정해야 한다");
+        // 빈 문자열 허용 계약은 유지하며, 필수값 여부는 @EgovNullCheck가 담당한다.
+        assertTrue(validator.isValid("", null), "영문 검증기는 빈 문자열을 true로 판정해야 한다");
+
+        assertFalse(validator.isValid("한글", null), "영문 검증기는 한글 입력을 false로 판정해야 한다");
+        assertFalse(validator.isValid("abc123", null), "영문 검증기는 숫자가 포함된 입력을 false로 판정해야 한다");
+        assertFalse(validator.isValid("abc def", null), "영문 검증기는 공백이 포함된 입력을 false로 판정해야 한다");
+    }
+
+    @Test
+    void koreanCheck_validatesKoreanOnlyPattern() {
+        EgovKoreanCheckValidation validator = new EgovKoreanCheckValidation();
+
+        assertTrue(validator.isValid("한글", null), "한글 검증기는 완성형 한글 입력을 true로 판정해야 한다");
+        assertTrue(validator.isValid("ㄱㄴㄷ", null), "한글 검증기는 한글 자음 입력을 true로 판정해야 한다");
+
+        assertFalse(validator.isValid("abc", null), "한글 검증기는 영문 입력을 false로 판정해야 한다");
+        assertFalse(validator.isValid("한글abc", null), "한글 검증기는 한글과 영문이 섞인 입력을 false로 판정해야 한다");
+        assertFalse(validator.isValid("한 글", null), "한글 검증기는 공백이 포함된 입력을 false로 판정해야 한다");
+    }
+
+    @Test
+    void pwdCheck_validatesPasswordRules() {
+        EgovPwdCheckValidation validator = new EgovPwdCheckValidation();
+
+        assertTrue(validator.isValid("Egov!2xk", null), "비밀번호는 길이와 문자 조합 규칙을 만족하면 true로 판정해야 한다");
+        assertTrue(validator.isValid("Pa$5wOrd9", null), "비밀번호는 길이와 문자 조합 규칙을 만족하면 true로 판정해야 한다");
+
+        assertFalse(validator.isValid("Egov!2x", null), "비밀번호는 8자 미만 입력을 false로 판정해야 한다");
+        assertFalse(validator.isValid("Egovxxkq", null), "비밀번호는 숫자와 특수문자가 없으면 false로 판정해야 한다");
+        assertFalse(validator.isValid("Egov!2aaa", null), "비밀번호는 동일문자 3회 반복을 false로 판정해야 한다");
+        assertFalse(validator.isValid("Egov!2abc", null), "비밀번호는 오름차순 연속 3자를 false로 판정해야 한다");
+        assertFalse(validator.isValid("Egov!2123", null), "비밀번호는 연속 숫자 3자를 false로 판정해야 한다");
+    }
+}

--- a/Presentation/org.egovframe.rte.ptl.reactive/src/test/java/org/egovframe/rte/ptl/reactive/validation/ReactiveValidatorsSemanticTest.java
+++ b/Presentation/org.egovframe.rte.ptl.reactive/src/test/java/org/egovframe/rte/ptl/reactive/validation/ReactiveValidatorsSemanticTest.java
@@ -23,6 +23,8 @@ class ReactiveValidatorsSemanticTest {
         assertFalse(validator.isValid("124-81-009989", null), "사업자등록번호는 11자리 입력을 false로 판정해야 한다");
         assertFalse(validator.isValid("12481abcde", null), "사업자등록번호는 숫자가 아닌 입력을 false로 판정해야 한다");
         assertFalse(validator.isValid("", null), "사업자등록번호는 빈 문자열을 false로 판정해야 한다");
+        assertFalse(validator.isValid("1248100998\n", null), "사업자등록번호는 뒤에 개행이 붙은 입력을 예외 없이 false로 판정해야 한다");
+        assertFalse(validator.isValid("1248100998\r\n", null), "사업자등록번호는 뒤에 CRLF가 붙은 입력을 예외 없이 false로 판정해야 한다");
     }
 
     @Test
@@ -42,8 +44,9 @@ class ReactiveValidatorsSemanticTest {
         EgovRrnCheckValidation validator = new EgovRrnCheckValidation();
 
         // 아래 값은 실제 개인 식별번호가 아니라 존재할 수 없는 날짜로 만든 체크섬 규격 합성값이다.
-        assertTrue(validator.isValid("991332-1123459", null), "주민등록번호는 합성 유효 체크섬 값을 true로 판정해야 한다");
-        assertTrue(validator.isValid("001332-2123452", null), "주민등록번호는 합성 유효 체크섬 값을 true로 판정해야 한다");
+        // 이 검증기는 패턴과 체크섬만 검증하며 날짜 유효성은 검증하지 않는다.
+        assertTrue(validator.isValid("991332-1123459", null), "주민등록번호 검증기는 날짜를 검증하지 않고 체크섬만 검증하므로 존재할 수 없는 날짜라도 true로 판정한다");
+        assertTrue(validator.isValid("001332-2123452", null), "주민등록번호 검증기는 날짜를 검증하지 않고 체크섬만 검증하므로 존재할 수 없는 날짜라도 true로 판정한다");
 
         assertFalse(validator.isValid("991332-1123450", null), "주민등록번호는 체크디지트 오류를 false로 판정해야 한다");
         assertFalse(validator.isValid("991332-5123459", null), "주민등록번호는 성별코드 패턴 위반을 false로 판정해야 한다");


### PR DESCRIPTION
## 문제

`EgovCrnCheckValidation`의 가중치 배열이 `{1, 3, 7, 1, 3, 7, 1, 3, 5, 1}` 열 개로 선언되어 있어 반복문이 열 번째 자리까지 순회합니다. 열 번째 자리는 검증 대상인 체크디지트 자신이므로 검증해야 할 값이 가중합에 섞여 들어갑니다. 공통컴포넌트 `EgovNumberCheckUtil.checkCompNumber`(2009년부터 운영)는 앞 아홉 자리에만 가중치를 적용합니다.

그래서 판정이 규격과 어긋납니다. 유효한 사업자등록번호 1만 건 중 9,026건이 거부되고 무효 번호 8,960건이 승인됩니다(규격 대비 일치율 82%). 체크디지트가 가중합에 한 번 더 더해지므로 유효한 번호는 체크디지트가 0인 경우에만 통과합니다.

패턴 검사에도 결함이 있습니다. `matcher.find()`가 최종 개행 앞의 매치를 허용하므로 `"1248100998\n"`이 열 자리 검사를 통과합니다. 이후 `Integer.parseInt`가 `"8\n"`을 파싱하며 `NumberFormatException`을 던집니다. 검증기가 false를 돌려주는 대신 예외가 그대로 전파되므로 400이 아닌 500으로 응답합니다.

## 수정

가중치 배열을 `{1, 3, 7, 1, 3, 7, 1, 3, 5}` 아홉 개로 줄여 앞 아홉 자리에만 적용했습니다. 체크디지트는 마지막 비교 대상으로만 남습니다. 이어서 `matcher.find()`를 `matcher.matches()`로 바꿔 문자열 전체가 열 자리 숫자와 일치할 때만 통과시키도록 했습니다. 커밋은 가중치 수정·테스트 추가·개행 수정 세 개로 나눠 두었습니다.

## 검증

- 수정본은 `EgovNumberCheckUtil.checkCompNumber`와 알고리즘이 같습니다. 무작위 20만 건을 대조한 결과 판정이 완전히 일치했습니다.
- `matches()`로 바꾼 뒤에도 정상 입력의 판정은 달라지지 않았습니다. 대조 집합의 승인 건수가 10,132건·10,000건으로 전환 전후 같았습니다.
- `mvn -o clean test`로 해당 모듈 테스트 20건이 실패 없이 끝납니다. 이 가운데 8건이 이번에 추가한 reactive 검증기 8종의 시맨틱 테스트입니다.
- 가중치 배열이나 `matches()`를 수정 전으로 되돌리면 추가한 테스트가 각각 실패합니다.

## 영향 범위

- 수정 범위는 `EgovCrnCheckValidation` 한 파일입니다. `@EgovCrnCheck`의 판정 결과는 바뀝니다. 기존에 통과했던 무효 번호는 거부되고 거부됐던 유효 번호는 통과합니다. 판정이 규격에 맞게 바로잡히는 변화이므로 호출부는 손대지 않아도 됩니다.
- `EgovCnCheckValidation`·`EgovRrnCheckValidation`도 `find()`를 쓰고 있어 개행이 붙은 입력에서 같은 `NumberFormatException`이 납니다. 휴대전화·일반전화·영문·한글 검증기는 개행이 붙은 입력을 예외 없이 통과시킵니다. 이 PR은 사업자등록번호로 범위를 한정했고 나머지는 별도 PR로 분리하겠습니다.
- 주민등록번호 테스트는 실제 개인 식별번호를 쓰지 않기 위해 존재할 수 없는 날짜(13월 32일)에 체크섬만 맞춘 합성값을 씁니다. 이 검증기는 패턴과 체크섬만 검증하고 날짜 유효성은 보지 않으므로 이 값을 유효로 판정합니다.
- 날짜 유효성 검사가 없다는 점은 공통컴포넌트 `checkJuminNumber`와의 차이입니다. 동작이 바뀌는 범위가 넓어 이 PR에서는 다루지 않았습니다.
