### PR TITLE
fix: reactive 검증기 6종이 행종결자로 끝나는 입력을 통과시키는 문제 수정

### DIFF
--- a/Presentation/org.egovframe.rte.ptl.reactive/src/main/java/org/egovframe/rte/ptl/reactive/validation/EgovCnCheckValidation.java
+++ b/Presentation/org.egovframe.rte.ptl.reactive/src/main/java/org/egovframe/rte/ptl/reactive/validation/EgovCnCheckValidation.java
@@ -48,7 +48,7 @@ public class EgovCnCheckValidation implements ConstraintValidator<EgovCnCheck, S
         }
         String mValue = value.replaceAll("-", "");
         Matcher matcher = CN_PATTERN.matcher(mValue);
-        boolean check = matcher.find();
+        boolean check = matcher.matches();
         if (!check) {
             return false;
         }

--- a/Presentation/org.egovframe.rte.ptl.reactive/src/main/java/org/egovframe/rte/ptl/reactive/validation/EgovEnglishCheckValidation.java
+++ b/Presentation/org.egovframe.rte.ptl.reactive/src/main/java/org/egovframe/rte/ptl/reactive/validation/EgovEnglishCheckValidation.java
@@ -47,7 +47,7 @@ public class EgovEnglishCheckValidation implements ConstraintValidator<EgovEngli
             return false;
         }
         Matcher matcher = ENGLISH_PATTERN.matcher(value);
-        return matcher.find();
+        return matcher.matches();
     }
 
 }

--- a/Presentation/org.egovframe.rte.ptl.reactive/src/main/java/org/egovframe/rte/ptl/reactive/validation/EgovKoreanCheckValidation.java
+++ b/Presentation/org.egovframe.rte.ptl.reactive/src/main/java/org/egovframe/rte/ptl/reactive/validation/EgovKoreanCheckValidation.java
@@ -47,7 +47,7 @@ public class EgovKoreanCheckValidation implements ConstraintValidator<EgovKorean
             return false;
         }
         Matcher matcher = KOREAN_PATTERN.matcher(value);
-        return matcher.find();
+        return matcher.matches();
     }
 
 }

--- a/Presentation/org.egovframe.rte.ptl.reactive/src/main/java/org/egovframe/rte/ptl/reactive/validation/EgovMobilePhoneCheckValidation.java
+++ b/Presentation/org.egovframe.rte.ptl.reactive/src/main/java/org/egovframe/rte/ptl/reactive/validation/EgovMobilePhoneCheckValidation.java
@@ -48,7 +48,7 @@ public class EgovMobilePhoneCheckValidation implements ConstraintValidator<EgovM
         }
         String mValue = value.replaceAll("-", "");
         Matcher matcher = MOBILE_PHONE_PATTERN.matcher(mValue);
-        return matcher.find();
+        return matcher.matches();
     }
 
 }

--- a/Presentation/org.egovframe.rte.ptl.reactive/src/main/java/org/egovframe/rte/ptl/reactive/validation/EgovPhoneCheckValidation.java
+++ b/Presentation/org.egovframe.rte.ptl.reactive/src/main/java/org/egovframe/rte/ptl/reactive/validation/EgovPhoneCheckValidation.java
@@ -48,7 +48,7 @@ public class EgovPhoneCheckValidation implements ConstraintValidator<EgovPhoneCh
         }
         String mValue = value.replaceAll("-", "");
         Matcher matcher = PHONE_PATTERN.matcher(mValue);
-        return matcher.find();
+        return matcher.matches();
     }
 
 }

--- a/Presentation/org.egovframe.rte.ptl.reactive/src/main/java/org/egovframe/rte/ptl/reactive/validation/EgovRrnCheckValidation.java
+++ b/Presentation/org.egovframe.rte.ptl.reactive/src/main/java/org/egovframe/rte/ptl/reactive/validation/EgovRrnCheckValidation.java
@@ -48,7 +48,7 @@ public class EgovRrnCheckValidation implements ConstraintValidator<EgovRrnCheck,
         }
         String mValue = value.replaceAll("-", "");
         Matcher matcher = RRN_PATTERN.matcher(mValue);
-        boolean check = matcher.find();
+        boolean check = matcher.matches();
         if (!check) {
             return false;
         }

--- a/Presentation/org.egovframe.rte.ptl.reactive/src/test/java/org/egovframe/rte/ptl/reactive/validation/ReactiveValidatorsLineTerminatorTest.java
+++ b/Presentation/org.egovframe.rte.ptl.reactive/src/test/java/org/egovframe/rte/ptl/reactive/validation/ReactiveValidatorsLineTerminatorTest.java
@@ -1,0 +1,93 @@
+package org.egovframe.rte.ptl.reactive.validation;
+
+import jakarta.validation.ConstraintValidator;
+import org.junit.jupiter.api.Test;
+
+import java.lang.annotation.Annotation;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * 행종결자로 끝나는 입력을 예외 없이 false로 반환하는지 검증한다.
+ *
+ * <p>대상은 정규식 검사를 matches()로 전환한 검증기 6종(법인등록번호·주민등록번호·
+ * 휴대전화번호·일반전화번호·영문·한국어)이다. 이미 matches()를 사용하는
+ * EgovCrnCheckValidation·EgovPwdCheckValidation·EgovEmailCheckValidation·
+ * EgovIPCheckValidation은 이 테스트의 대상이 아니다.</p>
+ */
+class ReactiveValidatorsLineTerminatorTest {
+
+    @Test
+    void validators_lineTerminatorInput_returnFalseWithoutException() {
+        assertAll(
+                () -> assertLineTerminatorRejected(new EgovCnCheckValidation(), "1101110000002"),
+                () -> assertLineTerminatorRejected(new EgovRrnCheckValidation(), "9913321123459"),
+                () -> assertLineTerminatorRejected(new EgovMobilePhoneCheckValidation(), "01012345678"),
+                () -> assertLineTerminatorRejected(new EgovPhoneCheckValidation(), "0212345678"),
+                () -> assertLineTerminatorRejected(new EgovEnglishCheckValidation(), "abc"),
+                () -> assertLineTerminatorRejected(new EgovKoreanCheckValidation(), "가나다"));
+    }
+
+    @Test
+    void cnAndRrn_lineFeedInput_doNotThrowNumberFormatException() {
+        assertFalse(assertDoesNotThrow(() -> new EgovCnCheckValidation().isValid("1101110000002\n", null),
+                "법인등록번호 검증기는 개행 입력에서 NumberFormatException을 전파하면 안 된다"),
+                "법인등록번호 검증기는 개행으로 끝나는 입력에 false를 반환해야 한다");
+        assertFalse(assertDoesNotThrow(() -> new EgovRrnCheckValidation().isValid("9913321123459\n", null),
+                "주민등록번호 검증기는 개행 입력에서 NumberFormatException을 전파하면 안 된다"),
+                "주민등록번호 검증기는 개행으로 끝나는 입력에 false를 반환해야 한다");
+    }
+
+    @Test
+    void cn_unicodeLineSeparatorInput_returnFalseWithoutException() {
+        boolean result = assertDoesNotThrow(() -> new EgovCnCheckValidation().isValid("1101110000002\u2028", null),
+                "법인등록번호 검증기는 유니코드 행종결자 입력에서 예외를 던지면 안 된다");
+        assertFalse(result, "법인등록번호 검증기는 유니코드 행종결자로 끝나는 입력에 false를 반환해야 한다");
+    }
+
+    @Test
+    void validators_stillValidateNormalInput() {
+        assertTrue(new EgovCnCheckValidation().isValid("1101110000002", null), "법인등록번호 검증기는 정상값에 true");
+        assertTrue(new EgovCnCheckValidation().isValid("110111-0000002", null), "법인등록번호 검증기는 하이픈 포함 정상값에 true");
+        assertFalse(new EgovCnCheckValidation().isValid("1101110000003", null), "법인등록번호 검증기는 체크숫자 오류에 false");
+
+        assertTrue(new EgovRrnCheckValidation().isValid("9913321123459", null), "주민등록번호 검증기는 정상값에 true");
+        assertTrue(new EgovRrnCheckValidation().isValid("991332-1123459", null), "주민등록번호 검증기는 하이픈 포함 정상값에 true");
+        assertFalse(new EgovRrnCheckValidation().isValid("9913321123458", null), "주민등록번호 검증기는 체크숫자 오류에 false");
+
+        assertTrue(new EgovMobilePhoneCheckValidation().isValid("01012345678", null), "휴대전화번호 검증기는 정상값에 true");
+        assertTrue(new EgovMobilePhoneCheckValidation().isValid("010-1234-5678", null), "휴대전화번호 검증기는 하이픈 포함 정상값에 true");
+        assertFalse(new EgovMobilePhoneCheckValidation().isValid("01512345678", null), "휴대전화번호 검증기는 잘못된 식별번호에 false");
+
+        assertTrue(new EgovPhoneCheckValidation().isValid("0212345678", null), "일반전화번호 검증기는 정상값에 true");
+        assertTrue(new EgovPhoneCheckValidation().isValid("02-1234-5678", null), "일반전화번호 검증기는 하이픈 포함 정상값에 true");
+        assertFalse(new EgovPhoneCheckValidation().isValid("021234567890", null), "일반전화번호 검증기는 길이 오류에 false");
+
+        assertTrue(new EgovEnglishCheckValidation().isValid("abc", null), "영문 검증기는 소문자에 true");
+        assertTrue(new EgovEnglishCheckValidation().isValid("ABC", null), "영문 검증기는 대문자에 true");
+        assertFalse(new EgovEnglishCheckValidation().isValid("abc1", null), "영문 검증기는 숫자 포함 값에 false");
+        assertFalse(new EgovEnglishCheckValidation().isValid("한글", null), "영문 검증기는 한글에 false");
+
+        assertTrue(new EgovKoreanCheckValidation().isValid("가나다", null), "한국어 검증기는 완성형 한글에 true");
+        assertTrue(new EgovKoreanCheckValidation().isValid("ㄱㄴㄷ", null), "한국어 검증기는 한글 자모에 true");
+        assertFalse(new EgovKoreanCheckValidation().isValid("가나1", null), "한국어 검증기는 숫자 포함 값에 false");
+        assertFalse(new EgovKoreanCheckValidation().isValid("abc", null), "한국어 검증기는 영문에 false");
+    }
+
+    private static <A extends Annotation> void assertLineTerminatorRejected(
+            ConstraintValidator<A, String> validator, String validValue) {
+        assertRejected(validator, validValue + "\n");
+        assertRejected(validator, validValue + "\r\n");
+    }
+
+    private static <A extends Annotation> void assertRejected(
+            ConstraintValidator<A, String> validator, String value) {
+        boolean result = assertDoesNotThrow(() -> validator.isValid(value, null),
+                validator.getClass().getSimpleName() + "는 행종결자 입력에서 예외를 던지면 안 된다");
+        assertFalse(result, validator.getClass().getSimpleName() + "는 행종결자로 끝나는 입력에 false를 반환해야 한다");
+    }
+
+}


### PR DESCRIPTION
## 문제

`Presentation/org.egovframe.rte.ptl.reactive`의 검증기 6종은 `^…$`로 양끝을 고정한 패턴을 컴파일해 두고 `matcher.find()`로 검사합니다. Java 정규식의 `$`는 입력 끝뿐 아니라 마지막 행종결자 바로 앞에서도 매치되므로, 개행으로 끝나는 입력이 패턴 검사를 통과합니다. 통과한 뒤의 동작은 두 갈래로 갈립니다.

법인등록번호(`EgovCnCheckValidation`)와 주민등록번호(`EgovRrnCheckValidation`)는 검사숫자를 `Integer.parseInt(mValue.substring(12))`로 파싱하는데 이때 개행이 함께 넘어가 `NumberFormatException`이 발생합니다. `ConstraintValidator.isValid`에서 던진 예외는 false로 수렴하지 않고 `ValidationException`으로 올라가므로 400이 아닌 500 응답이 나갑니다. 입력 예는 `"1101110000002\n"`, `"9913321123459\n"`입니다.

휴대전화번호·일반전화번호·영문·한국어 검증기(`EgovMobilePhoneCheckValidation`·`EgovPhoneCheckValidation`·`EgovEnglishCheckValidation`·`EgovKoreanCheckValidation`)는 개행이 붙은 입력을 `true`로 판정합니다. `"01012345678\n"`, `"0212345678\n"`, `"abc\n"`, `"\n"`이 모두 검증을 통과합니다.

## 수정

여섯 파일의 `matcher.find()`를 `matcher.matches()`로 바꿨습니다. 파일별 변경은 각 1줄이고 정규식 패턴 문자열은 손대지 않았습니다(`Pattern.compile` 라인 diff 0).

`find()`를 쓰는 곳은 upstream/main 기준으로 이 패키지 전체에서 7곳입니다. 비밀번호·이메일·IP 검증기는 이미 `matches()`를 쓰고 있고 `EgovNullCheckValidation`은 정규식을 쓰지 않아 변경 대상이 아닙니다. 남은 한 곳인 사업자등록번호 검증기는 아래 범위 항목에 적었습니다.

원인과 조치가 동일하고 파일별 변경이 각 1줄이라 6종을 한 PR로 묶었습니다. 나누면 같은 내용의 PR이 여섯 개가 되어 검토 부담만 늘어납니다.

## 하위 호환성

수정 전후 구현을 각각 컴파일해 동일 입력 132,609건을 검증기 7종에 통과시켜 판정을 대조했습니다. 입력은 정상값·하이픈 표기·앞뒤 공백·길이 오류·빈 문자열·행종결자 변형과 고정 시드 무작위 문자열로 구성했습니다.

판정 928,263건 중 달라진 것은 849건(0.09%)이고 전부 하이픈을 제거한 뒤 말미가 행종결자 하나로 끝나는 입력입니다.

| 판정 변화 | 건수 |
| --- | --- |
| `true` → `false` (검증 우회 차단) | 557 |
| `NumberFormatException` 전파 → `false` | 292 |
| `false` → `true` | 0 |

하이픈 표기(`110111-0000002`·`010-1234-5678`)는 기존과 같이 통과하고 앞뒤 공백·길이 오류·빈 문자열 판정도 변화가 없습니다. 영문·한국어 검증기가 빈 문자열을 `true`로 판정하는 기존 계약도 그대로입니다. 기존에 통과하던 값의 집합은 줄지 않고 행종결자로 끝나는 입력만 걸러집니다.

## 범위

사업자등록번호 검증기(`EgovCrnCheckValidation`)도 같은 결함을 갖지만 가중치 배열 오류를 함께 고치는 별도 PR(#292)에서 `matches()`로 바꿉니다. 두 PR은 서로 다른 파일과 테스트를 건드려 머지 순서에 제약이 없고 양방향 병합 시뮬레이션에서 충돌이 없음을 확인했습니다.

## 검증

행종결자로 끝나는 입력을 예외 없이 `false`로 반환하는지 확인하는 `ReactiveValidatorsLineTerminatorTest`를 추가했습니다(4건 통과). `find()`로 되돌리면 3건이 실패하며 6종의 결함이 모두 재현됩니다. 개행 `\n`·`\r\n`과 유니코드 행종결자 `U+2028`을 함께 다룹니다. 정상값·하이픈 표기·체크숫자 오류 판정이 그대로인지도 같은 테스트에서 확인합니다.

모듈 전체 `mvn clean test`는 16건 통과합니다. 위 사업자등록번호 브랜치를 임시로 병합한 상태에서는 24건이 통과합니다.
