### PR TITLE
fix: LeaveaTrace의 PathMatcher 주입 조건 극성 수정

### DIFF
--- a/Foundation/org.egovframe.rte.fdl.cmmn/src/main/java/org/egovframe/rte/fdl/cmmn/trace/LeaveaTrace.java
+++ b/Foundation/org.egovframe.rte.fdl.cmmn/src/main/java/org/egovframe/rte/fdl/cmmn/trace/LeaveaTrace.java
@@ -139,7 +139,7 @@ public class LeaveaTrace {
         }
 
         for (TraceHandlerService traceHandlerService : traceHandlerServices) {
-            if (traceHandlerService.hasReqExpMatcher()) {
+            if (!traceHandlerService.hasReqExpMatcher()) {
                 traceHandlerService.setReqExpMatcher(pm);
             }
             traceHandlerService.setPackageName(clazz.getCanonicalName());

--- a/Foundation/org.egovframe.rte.fdl.cmmn/src/test/java/org/egovframe/rte/fdl/cmmn/trace/LeaveaTraceMatcherInjectionTest.java
+++ b/Foundation/org.egovframe.rte.fdl.cmmn/src/test/java/org/egovframe/rte/fdl/cmmn/trace/LeaveaTraceMatcherInjectionTest.java
@@ -1,0 +1,98 @@
+package org.egovframe.rte.fdl.cmmn.trace;
+
+import org.egovframe.rte.fdl.cmmn.trace.handler.TraceHandler;
+import org.egovframe.rte.fdl.cmmn.trace.manager.DefaultTraceHandleManager;
+import org.egovframe.rte.fdl.cmmn.trace.manager.TraceHandlerService;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.support.StaticMessageSource;
+import org.springframework.util.AntPathMatcher;
+
+import java.util.Locale;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class LeaveaTraceMatcherInjectionTest {
+
+    // matcher가 주입되지 않은 매니저에는 LeaveaTrace 의 기본 matcher 를 주입해야 후처리 핸들러가 실행된다.
+    @Test
+    public void testInjectDefaultMatcherWhenManagerHasNone() {
+        LeaveaTrace trace = new LeaveaTrace();
+        SpyTraceHandler handler = new SpyTraceHandler();
+        DefaultTraceHandleManager manager = new DefaultTraceHandleManager();
+        manager.setPatterns(new String[]{"**"});
+        manager.setHandlers(new TraceHandler[]{handler});
+        trace.setTraceHandlerServices(new TraceHandlerService[]{manager});
+
+        trace.trace(LeaveaTraceMatcherInjectionTest.class, messageSource(), "trace.message", new Object[]{"test"}, Locale.KOREA, null);
+
+        assertEquals(1, handler.callCount);
+        assertEquals("trace test message", handler.lastMessage);
+    }
+
+    // 사용자가 명시 주입한 matcher 는 기본 matcher 로 덮어쓰지 않는다.
+    @Test
+    public void testKeepUserDefinedMatcher() {
+        LeaveaTrace trace = new LeaveaTrace();
+        SpyTraceHandler handler = new SpyTraceHandler();
+        RecordingPathMatcher customPathMatcher = new RecordingPathMatcher();
+        DefaultTraceHandleManager manager = new DefaultTraceHandleManager();
+        manager.setPatterns(new String[]{"**"});
+        manager.setHandlers(new TraceHandler[]{handler});
+        manager.setReqExpMatcher(customPathMatcher);
+        trace.setTraceHandlerServices(new TraceHandlerService[]{manager});
+
+        trace.trace(LeaveaTraceMatcherInjectionTest.class, messageSource(), "trace.message", new Object[]{"custom"}, Locale.KOREA, null);
+
+        assertTrue(customPathMatcher.matchCalled);
+        assertEquals(1, handler.callCount);
+        assertEquals("trace custom message", handler.lastMessage);
+    }
+
+    // 패턴이 일치하지 않으면 matcher 주입 여부와 무관하게 핸들러를 호출하지 않는다.
+    @Test
+    public void testHandlerNotCalledWhenPatternMismatch() {
+        LeaveaTrace trace = new LeaveaTrace();
+        SpyTraceHandler handler = new SpyTraceHandler();
+        DefaultTraceHandleManager manager = new DefaultTraceHandleManager();
+        manager.setPatterns(new String[]{"com.example.*"});
+        manager.setHandlers(new TraceHandler[]{handler});
+        trace.setTraceHandlerServices(new TraceHandlerService[]{manager});
+
+        trace.trace(LeaveaTraceMatcherInjectionTest.class, messageSource(), "trace.message", new Object[]{"miss"}, Locale.KOREA, null);
+
+        assertEquals(0, handler.callCount);
+    }
+
+    private StaticMessageSource messageSource() {
+        StaticMessageSource messageSource = new StaticMessageSource();
+        messageSource.addMessage("trace.message", Locale.KOREA, "trace {0} message");
+        return messageSource;
+    }
+
+    private static class SpyTraceHandler implements TraceHandler {
+
+        private int callCount;
+        private String lastMessage;
+
+        @Override
+        public void todo(Class<?> clazz, String message) {
+            callCount++;
+            lastMessage = message;
+        }
+
+    }
+
+    private static class RecordingPathMatcher extends AntPathMatcher {
+
+        private boolean matchCalled;
+
+        @Override
+        public boolean match(String pattern, String path) {
+            matchCalled = true;
+            return super.match(pattern, path);
+        }
+
+    }
+
+}


### PR DESCRIPTION
## 문제

`LeaveaTrace.trace()`는 등록된 `TraceHandlerService`에 기본 `PathMatcher`(필드 `pm`, `AntPathMatcher`)를 넘겨줍니다. 그런데 조건이 `if (traceHandlerService.hasReqExpMatcher())`로 되어 있어 matcher가 **이미 있을 때** 덮어쓰고 **없을 때는 넣지 않습니다**. 판정이 뒤집혀 있어 결함이 두 갈래로 나타납니다.

- matcher를 설정하지 않은 경우: `pm`이 계속 null이므로 `DefaultTraceHandleManager.trace()`가 첫 줄 `if (!enableMatcher()) return false;`에서 바로 돌아옵니다. 패턴 매칭에 도달하지 못해 등록한 `TraceHandler`가 한 번도 호출되지 않습니다.
- matcher를 직접 설정한 경우: `setReqExpMatcher()`는 조건 없이 대입하는 setter입니다. `trace()`를 호출할 때마다 사용자가 넣은 matcher를 기본 `AntPathMatcher`로 덮어씁니다.

같은 모듈의 `ExceptionTransfer.processHandling()`은 동일한 자리에서 `if (!ehm.hasReqExpMatcher())`를 씁니다. 예외 처리 쪽 코드가 원래 의도를 그대로 보여줍니다.

## 수정

조건을 `if (!traceHandlerService.hasReqExpMatcher())`로 반전했습니다(한 줄). matcher가 없는 매니저에만 기본 matcher를 주입하고 이미 설정된 matcher는 건드리지 않습니다. 위 두 결함이 함께 해소됩니다.

## 검증

`LeaveaTraceMatcherInjectionTest` 3건을 추가했습니다.

- matcher 미설정 매니저: 기본 matcher가 주입되어 핸들러가 1회 호출되고 메시지가 전달되는지 확인
- 사용자 matcher 설정: 그 matcher의 `match()`가 실제로 호출되고 교체되지 않는지 확인(`AntPathMatcher`를 상속한 스파이로 기록)
- 패턴 불일치: 핸들러 미호출

`LeaveaTrace`의 한 줄만 되돌리면 앞의 두 건이 실패합니다. 사용자 matcher가 덮어써지는 쪽은 핸들러 호출 횟수만으로는 드러나지 않아 스파이의 `match()` 호출 여부를 함께 검증했습니다. 모듈 전체 `mvn test` 29건 green입니다.

## 영향 범위

변경은 `org.egovframe.rte.fdl.cmmn` 안으로 한정되고 공개 API 시그니처는 그대로입니다.

다만 한 가지 덧붙입니다. matcher를 명시하지 않은 기존 설정에서는 지금까지 leaveaTrace 후처리 핸들러가 조용히 실행되지 않았습니다. 이 수정 이후에는 설정대로 실행됩니다. 버전을 올릴 때 없던 핸들러 동작·로그가 새로 나타나는 형태로 관찰됩니다.
