### PR TITLE
fix: EgovCommandLineRunner -next 옵션에서 병합한 JobParameters가 버려지는 문제 수정

### DIFF
--- a/Batch/org.egovframe.rte.bat.core/src/main/java/org/egovframe/rte/bat/core/launch/support/EgovCommandLineRunner.java
+++ b/Batch/org.egovframe.rte.bat.core/src/main/java/org/egovframe/rte/bat/core/launch/support/EgovCommandLineRunner.java
@@ -272,9 +272,9 @@ public class EgovCommandLineRunner {
             // 다음 Batch Job을 실행하기 위한 Job Parameters를 생성한다.
             if (opts.contains("-next")) {
                 JobParameters nextParameters = getNextJobParameters(job);
-                Map<String, JobParameter> map = new HashMap<>(nextParameters.getParameters());
+                Map<String, JobParameter<?>> map = new HashMap<>(nextParameters.getParameters());
                 map.putAll(jobParameters.getParameters());
-                jobParameters = new JobParameters();
+                jobParameters = new JobParameters(map);
             }
 
             // Batch Job을 실행한다.

--- a/Batch/org.egovframe.rte.bat.core/src/test/java/org/egovframe/rte/bat/core/launch/support/EgovCommandLineRunnerNextJobParametersTest.java
+++ b/Batch/org.egovframe.rte.bat.core/src/test/java/org/egovframe/rte/bat/core/launch/support/EgovCommandLineRunnerNextJobParametersTest.java
@@ -1,0 +1,125 @@
+package org.egovframe.rte.bat.core.launch.support;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.batch.core.ExitStatus;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.JobParametersIncrementer;
+import org.springframework.batch.core.JobParametersValidator;
+import org.springframework.batch.core.explore.JobExplorer;
+import org.springframework.batch.core.job.DefaultJobParametersValidator;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.batch.core.launch.support.RunIdIncrementer;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Proxy;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * {@link EgovCommandLineRunner}의 -next 옵션이 증가 파라미터와 명령행 파라미터를 함께 전달하는지 검증한다.
+ */
+class EgovCommandLineRunnerNextJobParametersTest {
+
+	private static final String JOB_NAME = "nextSampleJob";
+
+	@Test
+	void nextOption_keepsIncrementedAndCommandLineParameters() throws Exception {
+		JobParameters actual = runNext("targetDate=20260101,java.lang.String,false");
+
+		assertFalse(actual.isEmpty(), "-next 실행 시 JobParameters가 비어 있으면 안 된다");
+		assertEquals(1L, actual.getLong("run.id"), "증가 파라미터가 유지되어야 한다");
+		assertEquals("20260101", actual.getString("targetDate"), "명령행 파라미터가 유지되어야 한다");
+		assertEquals(String.class, actual.getParameter("targetDate").getType(), "명령행 파라미터의 타입이 보존되어야 한다");
+		assertFalse(actual.getParameter("targetDate").isIdentifying(), "명령행에서 지정한 identifying 여부가 보존되어야 한다");
+	}
+
+	@Test
+	void nextOption_commandLineParameterOverridesIncrementedParameter() throws Exception {
+		JobParameters actual = runNext("run.id=99,java.lang.Long,true");
+
+		assertEquals(99L, actual.getLong("run.id"), "이름이 같으면 명령행 파라미터가 증가 파라미터를 덮어써야 한다");
+		assertEquals(Long.class, actual.getParameter("run.id").getType(), "덮어쓴 파라미터의 타입이 보존되어야 한다");
+		assertTrue(actual.getParameter("run.id").isIdentifying(), "덮어쓴 파라미터의 identifying 여부가 보존되어야 한다");
+	}
+
+	/** -next 옵션으로 Job을 실행하고 JobLauncher에 실제로 전달된 JobParameters를 반환한다. */
+	private static JobParameters runNext(String... parameters) throws Exception {
+		AtomicReference<JobParameters> captured = new AtomicReference<>();
+		EgovCommandLineRunner runner = new EgovCommandLineRunner();
+		inject(runner, "launcher", stubJobLauncher(captured));
+		inject(runner, "jobExplorer", stubJobExplorer());
+
+		int exit = runner.start("org/egovframe/rte/bat/core/launch/support/next-job-context.xml", JOB_NAME, parameters,
+				Set.of("-next"));
+
+		JobParameters actual = captured.get();
+		assertNotNull(actual, "JobParameters가 전달되어야 한다: " + EgovCommandLineRunner.getErrorMessage());
+		assertEquals(0, exit, "완료 ExitStatus는 0으로 매핑되어야 한다");
+		return actual;
+	}
+
+	private static void inject(EgovCommandLineRunner runner, String fieldName, Object value) throws Exception {
+		Field field = EgovCommandLineRunner.class.getDeclaredField(fieldName);
+		field.setAccessible(true);
+		field.set(runner, value);
+	}
+
+	private static JobLauncher stubJobLauncher(AtomicReference<JobParameters> captured) {
+		return (job, jobParameters) -> {
+			captured.set(jobParameters);
+			JobExecution jobExecution = new JobExecution(1L);
+			jobExecution.setExitStatus(ExitStatus.COMPLETED);
+			return jobExecution;
+		};
+	}
+
+	private static JobExplorer stubJobExplorer() {
+		InvocationHandler handler = (proxy, method, args) -> {
+			if ("getJobInstances".equals(method.getName())) {
+				return List.of();
+			}
+			return null;
+		};
+		return (JobExplorer) Proxy.newProxyInstance(JobExplorer.class.getClassLoader(),
+				new Class<?>[] { JobExplorer.class }, handler);
+	}
+
+	public static class NextSampleJob implements Job {
+
+		private final JobParametersIncrementer incrementer = new RunIdIncrementer();
+		private final JobParametersValidator validator = new DefaultJobParametersValidator();
+
+		@Override
+		public String getName() {
+			return JOB_NAME;
+		}
+
+		@Override
+		public boolean isRestartable() {
+			return true;
+		}
+
+		@Override
+		public JobParametersIncrementer getJobParametersIncrementer() {
+			return incrementer;
+		}
+
+		@Override
+		public JobParametersValidator getJobParametersValidator() {
+			return validator;
+		}
+
+		@Override
+		public void execute(JobExecution execution) {
+		}
+	}
+}

--- a/Batch/org.egovframe.rte.bat.core/src/test/resources/org/egovframe/rte/bat/core/launch/support/next-job-context.xml
+++ b/Batch/org.egovframe.rte.bat.core/src/test/resources/org/egovframe/rte/bat/core/launch/support/next-job-context.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
+
+	<bean id="nextSampleJob" class="org.egovframe.rte.bat.core.launch.support.EgovCommandLineRunnerNextJobParametersTest$NextSampleJob"/>
+
+</beans>


### PR DESCRIPTION
## 문제

`EgovCommandLineRunner.start()`의 `-next` 처리는 `JobParametersIncrementer`가 만든 증분 파라미터와 명령행 파라미터를 map으로 병합한 뒤 그 map을 쓰지 않고 `new JobParameters()`로 빈 파라미터를 만들어 `JobLauncher`에 넘깁니다.

```java
JobParameters nextParameters = getNextJobParameters(job);
Map<String, JobParameter> map = new HashMap<>(nextParameters.getParameters());
map.putAll(jobParameters.getParameters());
jobParameters = new JobParameters();   // 병합한 map이 버려집니다
```

그 결과 `-next`로 실행하면 잡이 파라미터 0개로 기동해 증분 파라미터와 명령행 파라미터가 모두 사라집니다. 증분 파라미터가 유실되면 이미 완료된 JobInstance와 같은 파라미터로 재실행되어 `JobInstanceAlreadyCompleteException`이 발생합니다. 명령행으로 넘긴 기준일자가 빠진 채 잘못된 범위의 데이터를 처리하기도 합니다.

## 수정

병합한 map을 `new JobParameters(map)`으로 전달합니다.

병합 순서는 기존 코드 그대로입니다. 증분 파라미터로 map을 채우고 명령행 파라미터를 `putAll`로 덮으므로 이름이 겹치면 명령행 값이 우선합니다. Spring Batch 5.2.3 `JobParametersBuilder.getNextJobParameters`와 대조해 병합 순서가 같음을 확인했습니다. 우선순위 규칙은 바뀌지 않습니다.

map의 raw type도 함께 없앴습니다. 스타일 정리가 아니라 컴파일에 필요한 변경입니다. 생성자 시그니처가 `JobParameters(Map<String, JobParameter<?>>)`이므로 raw `Map<String, JobParameter>`를 그대로 두면 인자를 변환하지 못해 컴파일이 실패합니다(`rawtypes` 경고도 같이 사라집니다).

`new JobParameters(Map)`은 `JobParameter` 객체를 그대로 옮겨 담으므로 각 파라미터의 타입과 identifying 여부가 보존됩니다. 실행해 보면 `run.id`는 `java.lang.Long`·identifying=true를 유지합니다.

증분값을 만드는 `getNextJobParameters` 자체는 이 PR에서 손대지 않았습니다.

## 검증

`JobLauncher`를 스텁으로 바꿔 실제로 전달된 `JobParameters`를 캡처하는 단위 테스트를 추가했습니다. 수정 전에는 파라미터가 0개라 두 케이스 모두 실패하고 수정 후에는 다음을 확인합니다.

- 증분 파라미터(`run.id`)와 명령행 파라미터(`targetDate`)가 함께 전달됩니다.
- 이름이 겹치면(`run.id`) 명령행 값이 증분값을 덮습니다.
- 각 파라미터의 타입과 identifying 여부가 보존됩니다.

`org.egovframe.rte.bat.core` 모듈 `mvn test` 63건 green입니다. 실제 DB `JobRepository`를 붙인 수동 배치 실행은 하지 않았습니다. 파라미터가 `JobLauncher`까지 전달되는 경로를 스텁으로 캡처해 검증했습니다.

## 영향 범위

`-next` 옵션으로 실행하는 경로에만 해당합니다. `-next`를 쓰지 않으면 이 블록에 들어가지 않으므로 기존 동작은 그대로입니다. `-next` 사용 시에는 지금까지 빈 파라미터로 기동했던 잡이 병합된 파라미터를 받으며 기존 이력과 다른 JobInstance가 생성됩니다.
