### PR TITLE
fix: ARIA 파일 암호화 결과를 append 대신 덮어쓰기

### DIFF
--- a/Foundation/org.egovframe.rte.fdl.crypto/src/main/java/org/egovframe/rte/fdl/crypto/impl/EgovARIACryptoServiceImpl.java
+++ b/Foundation/org.egovframe.rte.fdl.crypto/src/main/java/org/egovframe/rte/fdl/crypto/impl/EgovARIACryptoServiceImpl.java
@@ -95,7 +95,7 @@ public class EgovARIACryptoServiceImpl implements EgovARIACryptoService {
                 fileString = new String(Base64.encodeBase64(fileArray));
                 byte[] enc = cipher.encrypt(fileString.getBytes(StandardCharsets.UTF_8));
                 String encString = Base64.encodeBase64String(enc);
-                FileUtils.writeStringToFile(trgtFile, encString, "UTF-8", true);
+                FileUtils.writeStringToFile(trgtFile, encString, "UTF-8");
             } catch (IOException e) {
                 ReflectionUtils.handleReflectionException(e);
             }

--- a/Foundation/org.egovframe.rte.fdl.crypto/src/test/java/org/egovframe/rte/fdl/crypto/impl/EgovARIAFileOverwriteTest.java
+++ b/Foundation/org.egovframe.rte.fdl.crypto/src/test/java/org/egovframe/rte/fdl/crypto/impl/EgovARIAFileOverwriteTest.java
@@ -1,0 +1,87 @@
+package org.egovframe.rte.fdl.crypto.impl;
+
+import jakarta.annotation.Resource;
+import org.egovframe.rte.fdl.crypto.EgovCryptoService;
+import org.egovframe.rte.fdl.crypto.config.EgovCryptoTestConfig;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * {@link EgovARIACryptoServiceImpl}의 encrypt(File, String, File)가 대상 파일을 덮어쓰는지 검증한다.
+ *
+ * <p>암호화 결과를 append로 기록하면 대상 파일이 이미 존재할 때 Base64 문자열이 누적된다.
+ * 이 경우 복호화는 Base64 패딩 이후를 무시하므로 앞서 기록된 암호문이 복원되고, 새로 기록한
+ * 암호문은 조용히 버려진다. decrypt(File, String, File)와 동일하게 덮어쓰도록 맞춘다.</p>
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = EgovCryptoTestConfig.class)
+public class EgovARIAFileOverwriteTest {
+
+    @Resource(name = "egov.ariaCryptoService")
+    private EgovCryptoService cryptoService;
+
+    /**
+     * properties 설정 파일의 algorithmKey 값을 주입받는 password
+     */
+    @Resource(name = "password")
+    private String password;
+
+    @TempDir
+    private Path tempDir;
+
+    @Test
+    public void encryptShouldOverwriteExistingTargetFile() throws Exception {
+        File firstFile = writeTempFile("first.txt", "first content");
+        File secondFile = writeTempFile("second.txt", "second content");
+        File encryptedFile = tempDir.resolve("encrypted.txt").toFile();
+        File decryptedFile = tempDir.resolve("decrypted.txt").toFile();
+
+        cryptoService.encrypt(firstFile, password, encryptedFile);
+        cryptoService.encrypt(secondFile, password, encryptedFile);
+        cryptoService.decrypt(encryptedFile, password, decryptedFile);
+
+        assertArrayEquals(Files.readAllBytes(secondFile.toPath()), Files.readAllBytes(decryptedFile.toPath()));
+    }
+
+    @Test
+    public void encryptShouldNotAccumulateTargetFileSize() throws Exception {
+        File sourceFile = writeTempFile("source.txt", "first content");
+        File encryptedFile = tempDir.resolve("encrypted.txt").toFile();
+
+        cryptoService.encrypt(sourceFile, password, encryptedFile);
+        long firstEncryptedLength = encryptedFile.length();
+        cryptoService.encrypt(sourceFile, password, encryptedFile);
+
+        assertEquals(firstEncryptedLength, encryptedFile.length());
+    }
+
+    @Test
+    public void encryptAndDecryptShouldRoundTripFileContent() throws Exception {
+        File sourceFile = writeTempFile("source.txt", "first content");
+        File encryptedFile = tempDir.resolve("encrypted.txt").toFile();
+        File decryptedFile = tempDir.resolve("decrypted.txt").toFile();
+
+        cryptoService.encrypt(sourceFile, password, encryptedFile);
+        cryptoService.decrypt(encryptedFile, password, decryptedFile);
+
+        assertArrayEquals(Files.readAllBytes(sourceFile.toPath()), Files.readAllBytes(decryptedFile.toPath()));
+    }
+
+    private File writeTempFile(String fileName, String content) throws Exception {
+        Path path = tempDir.resolve(fileName);
+        Files.write(path, content.getBytes(StandardCharsets.UTF_8));
+        return path.toFile();
+    }
+
+}


### PR DESCRIPTION
## 변경 이유

`EgovARIACryptoServiceImpl.encrypt(File, String, File)`는 암호화 결과를 `append=true`로 기록합니다. 대상 파일에 내용이 남아 있으면 Base64 암호문이 뒤에 덧붙습니다. 복호화 쪽 `Base64.decodeBase64`는 첫 패딩 뒤를 버리므로 앞서 기록된 암호문만 복원됩니다. 새로 암호화한 내용은 예외도 경고도 없이 사라집니다.

수정 전 상태를 신규 테스트로 실측한 결과입니다.

- 첫 번째 파일을 암호화한 대상 파일에 두 번째 파일을 다시 암호화하고 복호화하면 첫 번째 파일 내용이 나옵니다. `array lengths differ, expected: <14> but was: <13>`
- 같은 파일을 두 번 암호화하면 대상 파일 길이가 44바이트에서 88바이트로 늘어납니다. `expected: <44> but was: <88>`

같은 인터페이스를 구현한 다른 지점은 모두 대상 파일을 덮어씁니다. 같은 클래스의 `decrypt(File, String, File)`는 `FileUtils.writeByteArrayToFile`을 쓰고 `EgovGeneralCryptoServiceImpl`은 `FileWriter`(암호화)와 `FileOutputStream`(복호화)을 기본 모드로 씁니다. `EgovCryptoService.encrypt(File, String, File)`의 javadoc에도 이어쓰기 계약은 없고 저장소 안의 호출처 세 곳은 모두 한 번만 암호화합니다. 누적 동작에 의존하는 코드는 없으며 append 인자는 ARIA 구현에만 남아 있습니다.

## 변경 내용

`EgovARIACryptoServiceImpl` 98행에서 append 인자를 지웠습니다.

```java
-FileUtils.writeStringToFile(trgtFile, encString, "UTF-8", true);
+FileUtils.writeStringToFile(trgtFile, encString, "UTF-8");
```

3-인자 오버로드는 commons-io 2.18.0에서 4-인자 메서드에 `append=false`로 위임합니다. deprecated 대상도 아닙니다(바이트코드 확인). charsetName을 문자열로 넘기는 형태는 같은 클래스의 `readFileToString(encryptedFile, "UTF-8")`과 동일합니다.

원본과 대상이 같은 파일인 제자리 암호화도 함께 정상화됩니다. 수정 전에는 평문 16바이트 뒤에 암호문 44바이트가 붙어 60바이트가 됐고 왕복이 깨졌습니다. 수정 후에는 44바이트만 기록돼 원본이 그대로 복원됩니다. 원본 바이트는 쓰기 시점 전에 전량 메모리로 읽힌 상태라 덮어써도 잃을 데이터가 없습니다.

## 테스트 방법

```bash
cd Foundation/org.egovframe.rte.fdl.crypto
mvn -o clean test
```

신규 `EgovARIAFileOverwriteTest` 3건은 대상 파일 덮어쓰기, 길이 누적 없음, 암복호 왕복을 확인합니다. 수정 전에는 앞의 두 건이 실패하고 왕복 한 건만 통과해 변별력을 확인했습니다. 수정 후 모듈 테스트 22건이 모두 통과합니다. clean 없이 두 번 연속 실행해도 결과가 같습니다. 테스트 파일은 `@TempDir`에 만들어 `target/test-classes`를 건드리지 않습니다.

## 영향 범위

- 변경 지점은 `Foundation/org.egovframe.rte.fdl.crypto` 모듈의 `EgovARIACryptoServiceImpl.encrypt(File, String, File)` 한 곳입니다.
- 대상 파일이 없거나 비어 있으면 기존과 동작이 같습니다. 내용이 남아 있을 때만 이어쓰기 대신 덮어쓰기로 바뀝니다.
- 다른 오버로드와 `decrypt` 계열, `EgovGeneralCryptoServiceImpl`은 손대지 않았습니다.
