### PR TITLE
fix: EgovFileUtil.readFile의 문자셋 디코딩 오류와 개행 소실 수정

### DIFF
--- a/Foundation/org.egovframe.rte.fdl.filehandling/src/main/java/org/egovframe/rte/fdl/filehandling/EgovFileUtil.java
+++ b/Foundation/org.egovframe.rte.fdl.filehandling/src/main/java/org/egovframe/rte/fdl/filehandling/EgovFileUtil.java
@@ -25,6 +25,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.*;
 import java.io.FileNotFoundException;
+import java.nio.charset.Charset;
 import java.nio.charset.CharsetDecoder;
 import java.nio.charset.CodingErrorAction;
 import java.nio.charset.StandardCharsets;
@@ -146,32 +147,26 @@ public class EgovFileUtil {
     }
 
     /**
-     * 파일을 읽는다.
+     * 파일을 플랫폼 기본 문자셋({@link Charset#defaultCharset()})으로 읽는다.
+     * 인코딩을 지정하려면 {@link #readFile(File, String)}을 사용한다.
      */
     public static String readFile(File file) throws IOException {
-        BufferedInputStream in = new BufferedInputStream(new FileInputStream(file));
         String sResult = "";
 
-        try {
+        try (BufferedInputStream in = new BufferedInputStream(new FileInputStream(file))) {
             sResult = readFileContent(in);
         } catch (IllegalArgumentException e) {
             LOGGER.debug("[{}] EogvFileUtil : {}", e.getClass().getName(), e.getMessage());
-        } finally {
-            in.close();
         }
 
         return sResult;
     }
 
     /**
-     * String 형으로 파일의 내용을 읽는다.
+     * String 형으로 스트림 전체를 읽어 플랫폼 기본 문자셋으로 디코딩한다.
      */
     public static String readFileContent(InputStream in) throws IOException {
-        StringBuilder buf = new StringBuilder();
-        for (int i = in.read(); i != -1; i = in.read()) {
-            buf.append((char) i);
-        }
-        return buf.toString();
+        return new String(in.readAllBytes(), Charset.defaultCharset());
     }
 
     /**

--- a/Foundation/org.egovframe.rte.fdl.filehandling/src/main/java/org/egovframe/rte/fdl/filehandling/EgovFileUtil.java
+++ b/Foundation/org.egovframe.rte.fdl.filehandling/src/main/java/org/egovframe/rte/fdl/filehandling/EgovFileUtil.java
@@ -170,17 +170,14 @@ public class EgovFileUtil {
     }
 
     /**
-     * String 영으로 파일의 내용을 읽는다.
+     * String 형으로 파일 전체를 읽어 지정한 인코딩으로 디코딩한다. 원본의 개행은 그대로 보존된다.
+     * encoding이 null이면 플랫폼 기본 문자셋을 사용한다.
      */
     public static String readFile(File file, String encoding) throws IOException {
-        StringBuilder sb = new StringBuilder();
-        List<String> lines = readTextLines(file, encoding);
-
-        for (Iterator<String> it = lines.iterator(); it.hasNext(); ) {
-            sb.append(it.next());
+        Charset charset = encoding == null ? Charset.defaultCharset() : Charset.forName(encoding);
+        try (InputStream in = new FileInputStream(file)) {
+            return new String(in.readAllBytes(), charset);
         }
-
-        return sb.toString();
     }
 
     /**

--- a/Foundation/org.egovframe.rte.fdl.filehandling/src/test/java/org/egovframe/rte/fdl/filehandling/FilehandlingServiceTest.java
+++ b/Foundation/org.egovframe.rte.fdl.filehandling/src/test/java/org/egovframe/rte/fdl/filehandling/FilehandlingServiceTest.java
@@ -21,7 +21,9 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.io.*;
 import java.net.URL;
+import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.Iterator;
 import java.util.List;
 
@@ -242,6 +244,44 @@ public class FilehandlingServiceTest {
         String multiPath = tmppath + "/multiline.txt";
         EgovFileUtil.writeFile(multiPath, "line1\nline2\nline3", "UTF-8");
         assertEquals("line1line2line3", EgovFileUtil.readFile(new File(multiPath), "UTF-8"));
+    }
+
+    /**
+     * 파일 읽기 테스트. 플랫폼 기본 문자셋으로 쓴 한글은 그대로 읽혀야 한다.
+     */
+    @Test
+    public void testReadFileKoreanWithDefaultCharset() throws IOException {
+        File file = new File(EgovFileUtil.getTmpDirectory() + "/read-default-korean.txt");
+        String content = "행정안전부 표준프레임워크";
+
+        try {
+            Files.write(file.toPath(), content.getBytes(Charset.defaultCharset()));
+
+            assertEquals(content, EgovFileUtil.readFile(file));
+        } finally {
+            if (file.exists()) {
+                EgovFileUtil.delete(file);
+            }
+        }
+    }
+
+    /**
+     * 빈 파일 읽기 테스트. 내용이 없는 파일은 두 오버로드 모두 빈 문자열을 반환해야 한다.
+     */
+    @Test
+    public void testReadEmptyFileWithDefaultCharsetAndEncoding() throws IOException {
+        File file = new File(EgovFileUtil.getTmpDirectory() + "/read-empty.txt");
+
+        try {
+            Files.write(file.toPath(), new byte[0]);
+
+            assertEquals("", EgovFileUtil.readFile(file));
+            assertEquals("", EgovFileUtil.readFile(file, "UTF-8"));
+        } finally {
+            if (file.exists()) {
+                EgovFileUtil.delete(file);
+            }
+        }
     }
 
     /**

--- a/Foundation/org.egovframe.rte.fdl.filehandling/src/test/java/org/egovframe/rte/fdl/filehandling/FilehandlingServiceTest.java
+++ b/Foundation/org.egovframe.rte.fdl.filehandling/src/test/java/org/egovframe/rte/fdl/filehandling/FilehandlingServiceTest.java
@@ -237,13 +237,13 @@ public class FilehandlingServiceTest {
     }
 
     /**
-     * 여러 줄 파일 읽기 테스트. 줄들이 종전과 동일하게 연결되어야 한다.
+     * 여러 줄 파일 읽기 테스트. 원본의 개행이 보존되어야 한다.
      */
     @Test
-    public void testReadMultiLineFile() throws IOException {
+    public void testReadMultiLineFilePreservesLineSeparator() throws IOException {
         String multiPath = tmppath + "/multiline.txt";
         EgovFileUtil.writeFile(multiPath, "line1\nline2\nline3", "UTF-8");
-        assertEquals("line1line2line3", EgovFileUtil.readFile(new File(multiPath), "UTF-8"));
+        assertEquals("line1\nline2\nline3", EgovFileUtil.readFile(new File(multiPath), "UTF-8"));
     }
 
     /**
@@ -277,6 +277,81 @@ public class FilehandlingServiceTest {
 
             assertEquals("", EgovFileUtil.readFile(file));
             assertEquals("", EgovFileUtil.readFile(file, "UTF-8"));
+        } finally {
+            if (file.exists()) {
+                EgovFileUtil.delete(file);
+            }
+        }
+    }
+
+    /**
+     * 파일 읽기 테스트. 지정 인코딩으로 읽을 때 LF 개행은 보존되어야 한다.
+     */
+    @Test
+    public void testReadFileWithEncodingPreservesLf() throws IOException {
+        File file = new File(EgovFileUtil.getTmpDirectory() + "/read-utf8-lf.txt");
+        String content = "첫째 줄\n둘째 줄\n셋째 줄\n";
+
+        try {
+            Files.write(file.toPath(), content.getBytes(StandardCharsets.UTF_8));
+
+            assertEquals(content, EgovFileUtil.readFile(file, "UTF-8"));
+        } finally {
+            if (file.exists()) {
+                EgovFileUtil.delete(file);
+            }
+        }
+    }
+
+    /**
+     * 파일 읽기 테스트. 지정 인코딩으로 읽을 때 CRLF 개행은 보존되어야 한다.
+     */
+    @Test
+    public void testReadFileWithEncodingPreservesCrLf() throws IOException {
+        File file = new File(EgovFileUtil.getTmpDirectory() + "/read-utf8-crlf.txt");
+        String content = "a\r\nb\r\n";
+
+        try {
+            Files.write(file.toPath(), content.getBytes(StandardCharsets.UTF_8));
+
+            assertEquals(content, EgovFileUtil.readFile(file, "UTF-8"));
+        } finally {
+            if (file.exists()) {
+                EgovFileUtil.delete(file);
+            }
+        }
+    }
+
+    /**
+     * 파일 읽기 테스트. EUC-KR로 쓴 파일은 지정 인코딩으로 그대로 읽혀야 한다.
+     */
+    @Test
+    public void testReadFileWithEucKrEncoding() throws IOException {
+        File file = new File(EgovFileUtil.getTmpDirectory() + "/read-euc-kr.txt");
+        String content = "한글\nEUC-KR\n";
+
+        try {
+            Files.write(file.toPath(), content.getBytes(Charset.forName("EUC-KR")));
+
+            assertEquals(content, EgovFileUtil.readFile(file, "EUC-KR"));
+        } finally {
+            if (file.exists()) {
+                EgovFileUtil.delete(file);
+            }
+        }
+    }
+
+    /**
+     * 파일 읽기 테스트. 잘못된 UTF-8 바이트 시퀀스는 종전과 같이 대체 문자로 처리되어야 한다.
+     */
+    @Test
+    public void testReadFileWithInvalidUtf8BytesReplacesMalformedInput() throws IOException {
+        File file = new File(EgovFileUtil.getTmpDirectory() + "/read-invalid-utf8.txt");
+
+        try {
+            Files.write(file.toPath(), new byte[]{(byte) 0xC3, (byte) 0x28});
+
+            assertEquals("�(", EgovFileUtil.readFile(file, "UTF-8"));
         } finally {
             if (file.exists()) {
                 EgovFileUtil.delete(file);


### PR DESCRIPTION
## 기존 테스트의 기대값을 바꿉니다

이 점을 먼저 확인해 주시기 바랍니다. `testReadMultiLineFile`은 PR #257에서 당시 동작을 그대로 고정해 둔 characterization 테스트입니다. 이번에 그 고정 대상이던 동작 자체가 결함으로 드러나 기대값을 바꾸고 이름도 `testReadMultiLineFilePreservesLineSeparator`로 정리했습니다. 종전 기대값이 규정된 계약이 아니라 구현 부산물이라고 판단한 근거는 다음 세 가지입니다.

1. 개행이 사라진다고 규정한 javadoc이나 문서가 없습니다. `readFile(File, String)`의 javadoc은 "String 형으로 파일의 내용을 읽는다" 한 줄뿐입니다.
2. 형제 API `readTextFile(String, boolean)`은 개행을 붙일지 여부를 호출자가 `newline` 인자로 고르게 하고 붙일 때는 `System.lineSeparator()`를 씁니다. 이 클래스는 개행을 말없이 버리는 설계가 아닙니다.
3. 줄 단위로 읽어 붙이는 구현은 커밋 `c3d1fc7`("Apache common readLines(File) DEPRECATED 대응")에서 들어온 구현 세부입니다.

이 판단에 동의하지 않으시면 개행 부분만 따로 되돌릴 수 있도록 커밋을 나눠 두었습니다(아래 "변경 내용" 참고).

## 변경 이유

`EgovFileUtil`의 파일 읽기 경로에 결함이 두 가지 있습니다.

**멀티바이트 문자가 깨집니다.** `readFileContent(InputStream)`이 `buf.append((char) i)`로 바이트 하나를 char 하나로 캐스팅합니다. UTF-8로 저장한 `행정안전부 표준프레임워크`(13자)를 읽으면 37자짜리 깨진 문자열이 됩니다. public API인 `readFile(File)`이 이 경로를 쓰므로 한글이 든 파일은 이 메서드로 읽어서는 원문을 복원할 수 없습니다.

**개행이 전부 사라집니다.** `readFile(File, String encoding)`이 `readTextLines()`가 돌려준 줄들을 구분자 없이 이어 붙입니다. `line1\nline2\nline3`을 읽으면 `line1line2line3`이 됩니다. 읽은 내용을 다시 파일로 쓰거나 줄 단위로 파싱하면 원본과 달라집니다.

## 변경 내용

주제별로 커밋을 둘로 나눴습니다.

- **`2145063` 인코딩** — `readFileContent`가 `new String(in.readAllBytes(), Charset.defaultCharset())`으로 바이트가 아니라 문자 경계로 디코딩합니다. `readFile(File)`의 스트림 닫기도 try-with-resources로 정리했습니다.
- **`25cb547` 개행** — `readFile(File, String)`이 줄 단위로 읽어 붙이는 대신 파일 전체를 읽어 지정 인코딩으로 디코딩합니다. 원본 개행이 LF든 CRLF든 그대로 남습니다. `encoding`이 null이면 종전처럼 플랫폼 기본 문자셋을 씁니다.

두 커밋은 서로 독립적입니다. HEAD에서 `git revert 25cb547`이 충돌 없이 적용되고 그 상태에서도 테스트 27건이 모두 통과하므로 개행 변경은 보류하고 인코딩 수정만 받으셔도 됩니다.

### 인코딩 미지정 오버로드는 JVM 기본 문자셋에 의존합니다

이 선택도 확인 부탁드립니다. `readFile(File)`은 이제 `Charset.defaultCharset()`으로 디코딩하므로 결과가 배포 JVM의 기본 문자셋에 좌우됩니다. UTF-8을 하드코딩하지 않은 이유는 짝이 되는 `writeFile(File, String)`(`FileWriter`)과 `readTextFile`(`FileReader`)이 모두 플랫폼 기본 문자셋을 쓰기 때문입니다. UTF-8로 고정하면 기본 문자셋이 EUC-KR인 JVM에서 이 클래스 자신의 쓰기·읽기 왕복이 오히려 깨집니다.

`writeFile(File, String)`으로 쓴 한글을 `readFile(File)`로 다시 읽는 왕복을 JDK 21에서 `-Dfile.encoding`을 바꿔가며 측정한 결과입니다(소스는 `javac -encoding UTF-8`로 선컴파일).

| JVM 기본 문자셋 | 수정 전 | 이 PR | UTF-8 하드코딩 |
|---|---|---|---|
| UTF-8 | ✗ | ✓ | ✓ |
| EUC-KR | ✗ | ✓ | ✗ |
| ISO-8859-1 | ✗ | ✗ | ✗ |
| windows-31j | ✗ | ✗ | ✗ |

ISO-8859-1과 windows-31j(일본어 MS932 계열)는 한글 자체를 표현하지 못해 쓰는 시점에 이미 손실됩니다. 읽기 쪽 수정으로 되돌릴 수 있는 범위 밖입니다. 어떤 환경에서도 이 PR이 수정 전보다 나쁘지 않습니다. 인코딩을 고정해야 하는 호출자는 `readFile(File, String)`을 쓰라는 안내를 javadoc에 적어 두었습니다.

### 예외 타입이 바뀌는 경우가 있습니다

존재하지 않는 파일에 UTF-8이 아닌 인코딩을 지정해 `readFile(File, String)`을 호출하면 예외가 `NoSuchFileException`에서 `FileNotFoundException`으로 바뀝니다. 둘 다 `IOException`입니다. 종전에도 UTF-8 경로는 `FileNotFoundException`이었으므로 두 경로가 같아지는 방향입니다. 레포 안에서 이 차이에 영향받는 호출처는 없습니다.

## 테스트 방법

```bash
mvn -B -o -pl Foundation/org.egovframe.rte.fdl.filehandling test
```

- upstream `main` 기준 25건 통과 → 이 브랜치에서 31건 통과입니다. 신규 6건을 추가했습니다. 갱신한 1건은 위에 적은 `testReadMultiLineFile`의 기대값 변경 및 이름 변경입니다.
- 신규 테스트는 기본 문자셋 한글 읽기, 빈 파일, LF 보존, CRLF 보존, EUC-KR 지정 읽기, 잘못된 UTF-8 바이트 처리를 검증합니다. 마지막 항목은 깨진 바이트를 대체 문자로 관대하게 처리하던 종전 동작이 유지되는지 보는 가드라서 수정 전후 모두 통과합니다.
- 개행 커밋의 소스만 되돌리면 4건이 실패합니다. 인코딩 커밋의 소스만 되돌리면 1건이 실패합니다.

## 영향 범위

- 변경 파일은 `EgovFileUtil.java`와 `FilehandlingServiceTest.java` 둘뿐이며 시그니처 변경은 없습니다.
- `readFileContent`와 `readFile(File)`을 호출하는 곳은 `EgovFileUtil` 자신 말고는 레포 전역에 없습니다.
- 부수 효과로 읽기 속도가 빨라졌습니다. 3.10MB 한글 UTF-8 파일 기준(워밍업 3회 후 10회 평균) `readFile(File)`이 150.6ms에서 14.6ms로, `readFile(File, "UTF-8")`이 30.2ms에서 14.3ms로 줄었습니다. 반환 문자열 길이도 바이트 수가 아니라 실제 문자 수로 바로잡힙니다.
