### PR TITLE
fix: EgovEscapableDelimitedLineTokenizer의 후행 빈 컬럼 유실과 생성자 구분자 초기화 누락 수정

### DIFF
--- a/Batch/org.egovframe.rte.bat.core/src/main/java/org/egovframe/rte/bat/core/item/file/transform/EgovEscapableDelimitedLineTokenizer.java
+++ b/Batch/org.egovframe.rte.bat.core/src/main/java/org/egovframe/rte/bat/core/item/file/transform/EgovEscapableDelimitedLineTokenizer.java
@@ -83,7 +83,7 @@ public class EgovEscapableDelimitedLineTokenizer extends EgovAbstractLineTokeniz
      */
     public EgovEscapableDelimitedLineTokenizer(String delimiter) {
         Assert.state(!delimiter.equals(DEFAULT_QUOTE_CHARACTER), "[" + DEFAULT_QUOTE_CHARACTER + "] is not allowed as delimiter for tokenizers.");
-        this.delimiter = delimiter;
+        initDelimiter(delimiter);
         setQuoteCharacter(DEFAULT_QUOTE_CHARACTER);
     }
 
@@ -93,6 +93,10 @@ public class EgovEscapableDelimitedLineTokenizer extends EgovAbstractLineTokeniz
      * @param delimiter : delimiter로 사용 할 문자열
      */
     public void setDelimiter(String delimiter) {
+        initDelimiter(delimiter);
+    }
+
+    private void initDelimiter(String delimiter) {
         this.delimiter = delimiter;
         // regex 정규식에서 특수문자로 인식하는 것에 대한 처리
         this.regexDelimiter = getRegexDelimiter(delimiter);
@@ -133,7 +137,7 @@ public class EgovEscapableDelimitedLineTokenizer extends EgovAbstractLineTokeniz
         int closeIndex = 0;
         boolean flagEndQuote = true;
         String incompleteToken = "";
-        String[] arrLine = line.split(this.regexDelimiter);
+        String[] arrLine = line.split(this.regexDelimiter, -1);
 
         for (int ii = 0; ii < arrLine.length; ii++) {
             if (this.escape) {
@@ -153,9 +157,10 @@ public class EgovEscapableDelimitedLineTokenizer extends EgovAbstractLineTokeniz
                         tokens.add(arrLine[ii]);
                     }
                 } else {
-                    closeIndex = findCloseIndex(arrLine[ii], quoteCharacter, quoteIndex + 1);
+                    // 이어붙이는 셀에서는 닫는 따옴표가 0번에 올 수 있으므로 셀 처음부터 찾는다.
+                    closeIndex = findCloseIndex(arrLine[ii], quoteCharacter, 0);
                     incompleteToken += this.delimiter + arrLine[ii];
-                    if (closeIndex > 0) {
+                    if (closeIndex >= 0) {
                         tokens.add(incompleteToken);
                         flagEndQuote = true;
                     } else {

--- a/Batch/org.egovframe.rte.bat.core/src/test/java/org/egovframe/rte/bat/core/item/file/transform/EgovEscapableDelimitedLineTokenizerEmptyColumnTest.java
+++ b/Batch/org.egovframe.rte.bat.core/src/test/java/org/egovframe/rte/bat/core/item/file/transform/EgovEscapableDelimitedLineTokenizerEmptyColumnTest.java
@@ -1,0 +1,119 @@
+package org.egovframe.rte.bat.core.item.file.transform;
+
+import org.egovframe.rte.bat.core.item.file.mapping.EgovObjectMapper;
+import org.egovframe.rte.bat.mapper.EmpVO2;
+import org.junit.jupiter.api.Test;
+import org.springframework.batch.item.file.transform.DelimitedLineTokenizer;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * {@link EgovEscapableDelimitedLineTokenizer}가 CSV 후행 빈 컬럼을 보존하는지,
+ * 따옴표 필드가 구분자로 끝나는 행을 정확히 자르는지,
+ * 그리고 생성자만으로 구분자가 초기화되는지 검증한다.
+ */
+class EgovEscapableDelimitedLineTokenizerEmptyColumnTest {
+
+    private final EgovEscapableDelimitedLineTokenizer tokenizer = createCommaTokenizer();
+
+    private EgovEscapableDelimitedLineTokenizer createCommaTokenizer() {
+        EgovEscapableDelimitedLineTokenizer tokenizer = new EgovEscapableDelimitedLineTokenizer();
+        tokenizer.setDelimiter(",");
+        return tokenizer;
+    }
+
+    @Test
+    void doTokenize_trailingEmptyColumns_keepsColumns() {
+        Object[][] cases = {
+                {"a,b,c,d", List.of("a", "b", "c", "d")},
+                {"a,b,,", List.of("a", "b", "", "")},
+                {"a,,,", List.of("a", "", "", "")},
+                {",,,", List.of("", "", "", "")},
+                {"a,b,c,", List.of("a", "b", "c", "")},
+                {"a,b,,d", List.of("a", "b", "", "d")}
+        };
+
+        for (Object[] testCase : cases) {
+            String line = (String) testCase[0];
+            @SuppressWarnings("unchecked")
+            List<String> expected = (List<String>) testCase[1];
+            assertEquals(expected, tokenizer.doTokenize(line), line + "의 빈 컬럼이 유지되어야 한다");
+        }
+    }
+
+    @Test
+    void doTokenize_trailingEmptyColumns_matchesSpringBatchTokenizer() throws Exception {
+        DelimitedLineTokenizer springTokenizer = new DelimitedLineTokenizer();
+        springTokenizer.setNames("col1", "col2", "col3", "col4");
+        springTokenizer.afterPropertiesSet();
+
+        List<String> lines = List.of("a,b,c,d", "a,b,,", "a,,,", ",,,", "a,b,c,", "a,b,,d");
+
+        for (String line : lines) {
+            List<String> expected = Arrays.asList(springTokenizer.tokenize(line).getValues());
+            List<String> actual = tokenizer.doTokenize(line);
+
+            assertEquals(expected.size(), actual.size(), line + "의 토큰 수가 Spring Batch 표준과 같아야 한다");
+            assertEquals(expected, actual, line + "의 토큰 값이 Spring Batch 표준과 같아야 한다");
+        }
+    }
+
+    @Test
+    void doTokenize_trailingEmptyColumn_mapsWithEgovObjectMapper() {
+        EgovObjectMapper<EmpVO2> mapper = new EgovObjectMapper<>();
+        mapper.setType(EmpVO2.class);
+        mapper.setNames(new String[]{"empNo", "empName", "job", "mgr"});
+        mapper.afterPropertiesSet();
+
+        List<String> tokens = tokenizer.doTokenize("a,b,c,");
+        EmpVO2 vo = assertDoesNotThrow(() -> mapper.mapObject(tokens),
+                "EgovObjectMapper는 names 4개와 토큰 4개가 일치하면 IncorrectTokenCountException을 던지면 안 된다");
+
+        assertEquals("a", vo.getEmpNo());
+        assertEquals("b", vo.getEmpName());
+        assertEquals("c", vo.getJob());
+        assertEquals("", vo.getMgr());
+    }
+
+    @Test
+    void doTokenize_constructorInitializedDelimiter_doesNotThrow() {
+        EgovEscapableDelimitedLineTokenizer commaTokenizer = new EgovEscapableDelimitedLineTokenizer();
+        assertEquals(List.of("a", "b", "c"), commaTokenizer.doTokenize("a,b,c"),
+                "기본 생성자 직후에도 콤마 구분자로 토큰화되어야 한다");
+
+        EgovEscapableDelimitedLineTokenizer pipeTokenizer = new EgovEscapableDelimitedLineTokenizer("|");
+        assertEquals(List.of("a", "b", "c"), pipeTokenizer.doTokenize("a|b|c"),
+                "구분자 생성자 직후에도 지정 구분자로 토큰화되어야 한다");
+    }
+
+    @Test
+    void doTokenize_escapeColumns_keepsEscapedDelimiterAndQuote() {
+        assertEquals(List.of("\"customer5,c6\"", "90"), tokenizer.doTokenize("\"customer5,c6\",90"),
+                "따옴표 안의 구분자는 컬럼을 나누면 안 된다");
+        assertEquals(List.of("\"customer8 is \"\"Tom\"\"\"", "70"), tokenizer.doTokenize("\"customer8 is \"\"Tom\"\"\",70"),
+                "따옴표 안의 이중 따옴표는 컬럼을 나누면 안 된다");
+    }
+
+    @Test
+    void doTokenize_quotedTrailingDelimiter_keepsFollowingColumns() {
+        Object[][] cases = {
+                {"a,\"b,\",", List.of("a", "\"b,\"", "")},
+                {"\"b,\",", List.of("\"b,\"", "")},
+                {"\"a,b,\",", List.of("\"a,b,\"", "")},
+                // 따옴표 필드가 구분자로 끝나도 뒤 컬럼을 삼키지 않는다.
+                {"\"b,\",c", List.of("\"b,\"", "c")}
+        };
+
+        for (Object[] testCase : cases) {
+            String line = (String) testCase[0];
+            @SuppressWarnings("unchecked")
+            List<String> expected = (List<String>) testCase[1];
+            assertEquals(expected, tokenizer.doTokenize(line),
+                    line + "의 따옴표 필드와 뒤 컬럼이 정확히 보존되어야 한다");
+        }
+    }
+}


### PR DESCRIPTION
## 변경 이유

`EgovEscapableDelimitedLineTokenizer`에서 결함 세 가지를 확인해 한 커밋으로 묶었습니다. 셋 다 `doTokenize`의 같은 구간에서 나오고 수정 범위도 서로 겹칩니다. 따로 올리면 오히려 리뷰가 어려워집니다.

### 결함 A — 후행 빈 컬럼 유실

`line.split(this.regexDelimiter)`가 limit을 지정하지 않아 자바 `split`의 기본 동작대로 후행 빈 문자열이 잘려나갑니다. 토큰이 줄어든 채로 넘어가면 `EgovObjectMapper.mapObject`가 토큰 수와 `names` 길이가 다르다며 `IncorrectTokenCountException`을 던집니다. 마지막 컬럼이 빈 CSV 한 행 때문에 배치 스텝이 실패합니다. `split(regex, -1)`로 고쳤습니다.

### 결함 B — 생성자 구분자 초기화 누락

`EgovEscapableDelimitedLineTokenizer(String delimiter)` 생성자가 `this.delimiter`에 값만 넣고 `setDelimiter()`를 거치지 않아 `regexDelimiter`가 null인 채 남습니다. 생성 직후 `doTokenize`를 호출하면 곧바로 `NullPointerException`입니다. 생성자 javadoc은 "기본 delimiter로 콤마를 사용하도록 설정한다"고 적혀 있어 의도와도 어긋납니다. 저장소 안 모든 사용처가 생성 직후 `setDelimiter()`를 다시 호출하고 있어서 그동안 결함이 가려져 있었습니다. 초기화 로직을 private `initDelimiter()`로 빼고 생성자와 `setDelimiter()`가 함께 쓰도록 했습니다. 생성자에서 오버라이드 가능한 `setDelimiter()`를 부르지 않으려고 분리했습니다.

### 결함 C — 따옴표 필드가 뒤 컬럼을 삼킴

escape 상태머신이 따옴표 필드를 여러 셀에 걸쳐 이어붙일 때, 닫는 따옴표 검색 시작점으로 직전 셀에서 구한 `quoteIndex + 1`을 씁니다. 따옴표 필드의 내용이 구분자로 끝나면(`"b,"`를 콤마로 나누면 `"b`와 `"`가 됩니다) 닫는 따옴표가 셀의 0번에 오는데 시작점이 1이라 닫힘을 찾지 못합니다. 그래서 `"b,",c`가 한 토큰으로 뒤 컬럼을 삼켰습니다. 검색 시작점을 셀 처음으로 바꿔 `["b,", "c"]`로 나뉩니다. 후행 빈 컬럼 보존과 같은 지점의 결함이라 함께 고쳤습니다.

## 변경 내용

`Batch/org.egovframe.rte.bat.core/src/main/java/org/egovframe/rte/bat/core/item/file/transform/EgovEscapableDelimitedLineTokenizer.java` (13줄)

- `doTokenize`의 `line.split(this.regexDelimiter)`를 `line.split(this.regexDelimiter, -1)`로 바꿔 후행 빈 컬럼을 남깁니다.
- `setDelimiter()`의 본문을 private `initDelimiter()`로 옮겼습니다. 생성자와 `setDelimiter()`가 같은 초기화를 씁니다.
- 이어붙이는 셀에서 닫는 따옴표를 찾을 때 시작 위치를 `quoteIndex + 1`에서 셀 처음으로 바꿨습니다. 그에 맞춰 판정 조건도 `closeIndex > 0`에서 `closeIndex >= 0`으로 맞췄습니다.

`Batch/org.egovframe.rte.bat.core/src/test/java/org/egovframe/rte/bat/core/item/file/transform/EgovEscapableDelimitedLineTokenizerEmptyColumnTest.java` (신규 119줄)

- 후행 빈 컬럼 보존, Spring Batch `DelimitedLineTokenizer`와의 결과 비교, `EgovObjectMapper` 매핑 성공, 생성자 직후 토큰화, escape 컬럼 처리, 따옴표 필드가 구분자로 끝나는 경우까지 6건입니다.

## 동작 변경(하위 호환성)

후행 빈 컬럼을 보존하면서 토큰 개수가 달라집니다.

| 입력 | 수정 전 | 수정 후 |
|---|---|---|
| `a,b,c,` | 3개 | 4개 |
| `a,b,,` | 2개 | 4개 |
| `,,,` | 0개 | 4개 |

지금까지 잘려나간 개수에 맞춰 `names`를 설정해 둔 잡은 이제 `IncorrectTokenCountException`을 만납니다. 기준은 Spring Batch 표준 `DelimitedLineTokenizer`와 같은 패키지의 `EgovDelimitedLineTokenizer`이며, 둘 다 후행 빈 컬럼을 보존하므로 이번 수정으로 세 구현의 동작이 일치합니다. 빈 라인은 수정 전후 모두 토큰 1개로 같습니다. `setEscape(false)` 경로는 후행 빈 컬럼 보존 말고 달라지는 것이 없습니다.

## 테스트 방법

```bash
mvn -o -pl Batch/org.egovframe.rte.bat.core test
```

- 모듈 전체 67건 통과했습니다.
- 정상 CSV 28행(따옴표 안 구분자, 이스케이프 이중따옴표, 빈 따옴표 필드, 따옴표가 마지막 셀에만 있는 행, 전체가 한 따옴표 필드인 행 등 조합)으로 대조하면 컬럼 수가 정확한 행이 12/28에서 28/28로 늘었습니다. 정상 행에서 나빠진 경우는 없습니다.
- `setEscape(false)` 경로는 입력 9,841건 전수 대조에서 차이가 전부 후행 빈 컬럼 보존이며 값이 바뀌거나 토큰이 줄어든 사례는 없습니다.

테스트 변별력도 확인했습니다. 수정 hunk를 하나씩 되돌리면 각각 다른 테스트가 실패합니다. `split(..., -1)`만 되돌리면 4건, 닫는 따옴표 검색 시작점만 되돌리면 `quotedTrailingDelimiter` 1건, 생성자 초기화만 되돌리면 `constructorInitializedDelimiter` 1건이 깨져 세 결함이 따로 잡힙니다.

## 영향 범위

- 배치 실행환경의 `EgovEscapableDelimitedLineTokenizer` 한 클래스입니다. 공개 API 시그니처는 그대로이고 `initDelimiter()`는 private입니다.
- 구분자로 끝나는 행이나 마지막 컬럼이 빈 행을 읽는 CSV 배치 잡의 토큰 개수가 달라집니다. 위 하위 호환성 항목을 함께 봐 주십시오.
- 다른 모듈의 코드는 건드리지 않았습니다.
