### PR TITLE
fix: EgovStringUtil.alignLeft 생략 표기 시 원본 전체가 앞에 붙는 문제 수정

### DIFF
--- a/Foundation/org.egovframe.rte.fdl.string/src/main/java/org/egovframe/rte/fdl/string/EgovStringUtil.java
+++ b/Foundation/org.egovframe.rte.fdl.string/src/main/java/org/egovframe/rte/fdl/string/EgovStringUtil.java
@@ -393,8 +393,9 @@ public final class EgovStringUtil {
      * 문자열의 뒷쪽에 지정한 길이만큼 공백으로 채움
      */
     public static String alignLeft(String str, int length, boolean isEllipsis) {
-        StringBuilder result = new StringBuilder(str);
+        StringBuilder result = new StringBuilder(length);
         if (str.length() <= length) {
+            result.append(str);
             for (int i = 0; i < (length - str.length()); i++) {
                 result.append(WHITE_SPACE);
             }

--- a/Foundation/org.egovframe.rte.fdl.string/src/test/java/org/egovframe/rte/fdl/string/EgovStringUtilTest.java
+++ b/Foundation/org.egovframe.rte.fdl.string/src/test/java/org/egovframe/rte/fdl/string/EgovStringUtilTest.java
@@ -234,6 +234,42 @@ public class EgovStringUtilTest {
         assertEquals(i, result.length());
     }
 
+    /**
+     * 생략 표기(isEllipsis) 옵션이 alignLeft/alignRight/alignCenter에서 동일하게 동작하는지 검사한다.
+     */
+    @Test
+    public void testAlignStringWithEllipsis() {
+        String source = "abcdefghij";
+
+        // 지정한 길이를 넘으면 뒷부분을 "..."으로 대체하고, 결과 길이는 지정한 길이와 같다
+        assertEquals("ab...", EgovStringUtil.alignLeft(source, 5, true));
+        assertEquals("ab...", EgovStringUtil.alignRight(source, 5, true));
+        assertEquals("ab...", EgovStringUtil.alignCenter(source, 5, true));
+
+        // isEllipsis가 false이면 지정한 길이만큼 자른다
+        assertEquals("abcde", EgovStringUtil.alignLeft(source, 5, false));
+        assertEquals("abcde", EgovStringUtil.alignRight(source, 5, false));
+        assertEquals("abcde", EgovStringUtil.alignCenter(source, 5, false));
+
+        // 길이가 정확히 같으면 원본을 그대로 반환한다
+        assertEquals("abcde", EgovStringUtil.alignLeft("abcde", 5, true));
+        assertEquals("abcde", EgovStringUtil.alignRight("abcde", 5, true));
+
+        // 길이가 미달이면 isEllipsis와 무관하게 공백으로 채운다
+        assertEquals("abc   ", EgovStringUtil.alignLeft("abc", 6, true));
+        assertEquals("abc   ", EgovStringUtil.alignLeft("abc", 6, false));
+        assertEquals("   abc", EgovStringUtil.alignRight("abc", 6, true));
+
+        // 빈 문자열은 지정한 길이만큼의 공백이 된다
+        assertEquals("   ", EgovStringUtil.alignLeft("", 3, true));
+        assertEquals("   ", EgovStringUtil.alignRight("", 3, true));
+
+        // null은 세 메서드 모두 NullPointerException을 발생시킨다
+        assertThrows(NullPointerException.class, () -> EgovStringUtil.alignLeft(null, 3, true));
+        assertThrows(NullPointerException.class, () -> EgovStringUtil.alignRight(null, 3, true));
+        assertThrows(NullPointerException.class, () -> EgovStringUtil.alignCenter(null, 3, true));
+    }
+
     @Test
     public void testEncodePassword() {
         // 1. try to encode password and compare


### PR DESCRIPTION
## 변경 이유

`EgovStringUtil.alignLeft(str, length, true)`는 원본이 지정 길이보다 길 때 결과 길이가 지정 길이를 넘습니다. 결과 버퍼를 `new StringBuilder(str)`로 만들어 원본 전체를 이미 담은 상태에서, 잘라낸 앞부분과 `"..."`를 뒤에 다시 붙이기 때문입니다.

```java
EgovStringUtil.alignLeft("abcdefghij", 5, true);   // "abcdefghijab..." (15자)
```

같은 클래스의 `alignRight`, `alignCenter`는 버퍼를 `new StringBuilder(length)`로 시작해 생략 표기가 지정 길이 안에 들어갑니다. 위와 같은 입력에 `"ab..."`를 반환합니다. 세 메서드는 정렬 방향만 다를 뿐 생략 표기 규칙은 같아야 하므로, 형제 메서드의 동작을 기준으로 `alignLeft`를 맞췄습니다.

`str = "abcdefghij"` 기준 실측 대조입니다.

| length | 수정 전 alignLeft | 수정 후 alignLeft | alignRight (참고) |
|---|---|---|---|
| 3 | `abcdefghij...` | `...` | `...` |
| 5 | `abcdefghijab...` | `ab...` | `ab...` |
| 10 | `abcdefghij` | `abcdefghij` | `abcdefghij` |

수정 후에는 `alignLeft`의 출력이 전 구간에서 `alignRight`, `alignCenter`와 일치합니다.

## 변경 내용

- `alignLeft(String, int, boolean)`의 버퍼 초기화를 `new StringBuilder(str)`에서 `new StringBuilder(length)`로 바꾸고 패딩 경로에서 원본을 `append(str)`로 붙입니다. `alignRight`와 같은 형태입니다.
- `EgovStringUtilTest`에 `testAlignStringWithEllipsis`를 추가했습니다. 세 메서드의 생략 표기, 자르기, 패딩, 빈 문자열, `null` 입력을 한자리에서 검증합니다.

## 테스트 방법

```bash
mvn -pl Foundation/org.egovframe.rte.fdl.string test
```

`Tests run: 55, Failures: 0, Errors: 0`으로 통과했습니다. 수정 전 코드로 되돌리면 새 테스트가 아래와 같이 실패해, 결함을 그대로 잡아냅니다.

```
testAlignStringWithEllipsis
expected: <ab...> but was: <abcdefghijab...>
```

## 영향 범위

- 출력이 달라지는 경우는 `isEllipsis`가 `true`이면서 원본이 지정 길이보다 긴 경로뿐입니다. `isEllipsis`가 `false`인 경로는 `length`가 0 이상인 전 구간에서 출력이 같습니다. 패딩 경로와 빈 문자열, 길이가 정확히 같거나 미달인 경우도 그대로입니다.
- 실행환경과 공통컴포넌트를 훑어보면 `alignLeft`, `alignRight`, `alignCenter`를 호출하는 곳이 유틸 자신 외에는 없습니다. 기존 출력에 기대어 동작하는 코드는 발견되지 않았습니다.
- `length`에 음수를 넘기면 예외 타입이 `StringIndexOutOfBoundsException`에서 `NegativeArraySizeException`으로 바뀝니다. `alignRight`, `alignCenter`가 이미 같은 예외를 내던 자리라 세 메서드의 동작이 맞춰지는 방향입니다.
