### PR TITLE
fix: EgovBatchException 이 전달받은 원인 예외를 즉시 버리는 문제 수정

### DIFF
--- a/Batch/org.egovframe.rte.bat.core/src/main/java/org/egovframe/rte/bat/exception/EgovBatchException.java
+++ b/Batch/org.egovframe.rte.bat.core/src/main/java/org/egovframe/rte/bat/exception/EgovBatchException.java
@@ -88,7 +88,6 @@ public class EgovBatchException extends BaseRuntimeException {
         this.message = getExceptionMessageSelect(dataSource);
         this.wrappedException = wrappedException;
         this.messageParameters = null;
-        this.wrappedException = null;
     }
 
     /**

--- a/Batch/org.egovframe.rte.bat.core/src/test/java/org/egovframe/rte/bat/exception/EgovBatchExceptionWrappedExceptionTest.java
+++ b/Batch/org.egovframe.rte.bat.core/src/test/java/org/egovframe/rte/bat/exception/EgovBatchExceptionWrappedExceptionTest.java
@@ -1,0 +1,76 @@
+package org.egovframe.rte.bat.exception;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.jdbc.datasource.embedded.EmbeddedDatabase;
+import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseBuilder;
+import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseType;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+/**
+ * EgovBatchException 의 원인 예외 보관 여부를 검증하는 JUnit Test 클래스
+ *
+ * <pre>
+ * == 개정이력(Modification Information) ==
+ *
+ *   수정일        수정자           수정내용
+ *  -------      -------------  ----------------------
+ *   2026.08.03                 최초 생성
+ * </pre>
+ */
+public class EgovBatchExceptionWrappedExceptionTest {
+
+    private static final String MESSAGE_KEY = "EGOVBATCH000001";
+    private static final String EXPECTED_MESSAGE = "배치실행 중 업무 관련 에러가 발생 하였습니다.";
+
+    private EmbeddedDatabase dataSource;
+
+    @BeforeEach
+    public void setUp() {
+        dataSource = new EmbeddedDatabaseBuilder()
+                .setType(EmbeddedDatabaseType.HSQL)
+                .addScript("classpath:META-INF/testdata/testdb.sql")
+                .build();
+    }
+
+    @AfterEach
+    public void tearDown() {
+        if (dataSource != null) {
+            dataSource.shutdown();
+        }
+    }
+
+    @Test
+    @DisplayName("원인 예외를 받는 생성자는 전달된 예외를 그대로 보관한다")
+    public void wrappedExceptionIsRetained() {
+        Exception cause = new IllegalStateException("배치 대상 데이터가 없습니다.");
+
+        EgovBatchException exception = new EgovBatchException(dataSource, MESSAGE_KEY, cause);
+
+        assertNotNull(exception.getWrappedException(), "전달한 원인 예외가 보관되어야 한다.");
+        assertSame(cause, exception.getWrappedException(), "전달한 예외 객체와 동일해야 한다.");
+    }
+
+    @Test
+    @DisplayName("원인 예외를 받지 않는 생성자는 원인 예외를 보관하지 않는다")
+    public void wrappedExceptionIsNullWhenNotSupplied() {
+        EgovBatchException exception = new EgovBatchException(dataSource, MESSAGE_KEY);
+
+        assertEquals(null, exception.getWrappedException(), "원인 예외를 전달하지 않으면 비어 있어야 한다.");
+    }
+
+    @Test
+    @DisplayName("원인 예외를 보관하더라도 메시지키로 조회한 메시지는 그대로 유지된다")
+    public void messageIsResolvedFromMessageKey() {
+        Exception cause = new IllegalStateException("배치 대상 데이터가 없습니다.");
+
+        EgovBatchException exception = new EgovBatchException(dataSource, MESSAGE_KEY, cause);
+
+        assertEquals(EXPECTED_MESSAGE, exception.getMessage(), "메시지키로 조회한 메시지가 유지되어야 한다.");
+    }
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

검토자를 위해 수정된 소스 내용을 설명해 주세요. Please describe the modified source for reviewers.

### 한 줄 요약

`EgovBatchException` 의 원인 예외를 받는 생성자가 전달받은 값을 필드에 대입한 직후 `null` 로 덮어씁니다. 호출 측이 `getWrappedException()` 으로 원인을 되찾을 수 없습니다.

### 1. 현재 코드

```java
// Batch/org.egovframe.rte.bat.core/.../EgovBatchException.java:86-92
public EgovBatchException(DataSource dataSource, String messageKey, Exception wrappedException) {
    this.messageKey = messageKey;
    this.message = getExceptionMessageSelect(dataSource);
    this.wrappedException = wrappedException;
    this.messageParameters = null;
    this.wrappedException = null;      // 두 줄 위에서 대입한 값을 덮어쓴다
}
```

세 번째 줄에서 인자를 필드에 넣고, 다섯 번째 줄에서 다시 `null` 로 만듭니다.

### 2. 어떻게 생겼는가

같은 클래스의 다른 생성자 두 개는 원인 예외를 받지 않으므로 `null` 대입이 정상입니다.

```java
// :57-62  (DataSource, String)
public EgovBatchException(DataSource dataSource, String messageKey) {
    this.messageKey = messageKey;
    this.message = getExceptionMessageSelect(dataSource);
    this.messageParameters = null;
    this.wrappedException = null;      // 원인 예외를 받지 않으므로 정상
}
```

원인 예외를 받는 생성자를 만들 때 위 코드를 바탕으로 작성하면서 마지막 줄을 함께 옮긴 형태로 보입니다.

### 3. 왜 문제가 되는가

`wrappedException` 은 부모 클래스에 있고 공개 접근자를 통해 외부에서 읽습니다.

```java
// Foundation/org.egovframe.rte.fdl.cmmn/.../BaseRuntimeException.java:47
protected Exception wrappedException = null;

// :211-213
public Throwable getWrappedException() {
    return wrappedException;
}
```

따라서 이 생성자로 만든 예외는 **전달한 원인 예외를 되찾을 수 없습니다.**

배치 작업이 실패했을 때 근본 원인을 추적하기 위해 원인 예외를 넘기는 것이 이 생성자의 목적이고, Javadoc 도 `@param wrappedException 에러객체` 로 그 의도를 명시하고 있습니다.

이 저장소 안에서 `EgovBatchException` 을 생성하는 곳은 `CustomerCreditIncreaseProcessor` 한 곳이고, 거기서는 원인 예외를 넘기지 않는 형태(`EgovBatchException(dataSource, messageKey)`)를 쓰고 있어 현재 동작에는 영향이 없습니다. 다만 원인 예외를 받는 생성자도 `public` 이므로, 표준프레임워크로 배치 애플리케이션을 작성하는 쪽에서 호출하는 API 입니다.

### 4. 수정 내용

불필요한 `null` 대입 한 줄을 제거했습니다.

```diff
     this.wrappedException = wrappedException;
     this.messageParameters = null;
-    this.wrappedException = null;
 }
```

### 5. 영향 범위

- 운영 코드 변경은 `EgovBatchException.java` 한 줄 삭제입니다
- 나머지 두 생성자, 메시지 조회(`getExceptionMessageSelect`), 메시지키·메시지 파라미터 처리는 그대로입니다
- 원인 예외를 전달하지 않는 기존 호출부의 동작은 변하지 않습니다. 해당 생성자에서는 여전히 `null` 입니다
- 현재 열려 있는 PR 중 이 파일을 수정하는 건은 없습니다

## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [X] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

JDK 17 환경에서 `org.egovframe.rte.bat.core` 모듈을 대상으로 확인했습니다.

| | 기준선(`main`) | 이 PR |
|---|---|---|
| `mvn clean test` | 61건 통과 | **64건 통과** |
| 실패·오류 | 0 | 0 |

기존 61건에 이 PR 에서 3건을 더했습니다. 회귀는 없습니다.

### 추가한 테스트

`EgovBatchExceptionWrappedExceptionTest` 를 추가했습니다. 세 가지를 확인합니다.

- 원인 예외를 받는 생성자가 전달된 예외를 그대로 보관한다
- 원인 예외를 받지 않는 생성자는 원인 예외를 보관하지 않는다
- 원인 예외를 보관하더라도 메시지키로 조회한 메시지는 유지된다

생성자가 `JdbcTemplate` 으로 `BATCH_EXCEPTION_MESSAGE` 를 조회하므로 `DataSource` 가 필요합니다. 별도 설비를 추가하지 않고 이 모듈의 기존 테스트 스키마를 재사용했습니다.

```java
dataSource = new EmbeddedDatabaseBuilder()
        .setType(EmbeddedDatabaseType.HSQL)
        .addScript("classpath:META-INF/testdata/testdb.sql")
        .build();
```

`testdb.sql` 에 `BATCH_EXCEPTION_MESSAGE` 테이블과 `EGOVBATCH000001` 행이 이미 정의되어 있어 그대로 사용했습니다.

### 수정 전 실패 확인

수정 없이 테스트만 `main` 에 적용해 실행한 결과입니다.

```
EgovBatchExceptionWrappedExceptionTest.wrappedExceptionIsRetained
  전달한 원인 예외가 보관되어야 한다. ==> expected: not <null>

Tests run: 3, Failures: 1, Errors: 0, Skipped: 0
```

나머지 두 건은 수정 전에도 통과합니다. 수정으로 동작이 바뀌는 지점이 첫 번째 한 건임을 확인했습니다.

### 재현 절차

```
cd Batch/org.egovframe.rte.bat.core
mvn clean test -Dtest=EgovBatchExceptionWrappedExceptionTest
```

외부 DB 가 필요 없습니다. 내장 HSQLDB 로 동작합니다.

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

배치 실행환경의 예외 클래스 변경이라 화면이나 브라우저와 무관합니다. 그래서 별도로 선택하지 않았습니다.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

테스트 전과 후의 스크린샷 또는 캡처 영상을 이곳에 첨부해 주세요. Please attach screenshots or video captures of your before and after tests here.

화면 변경이 없어 첨부하지 않았습니다. 위 재현 절차의 테스트 결과로 확인하실 수 있습니다.

