### PR TITLE
fix: TypedList·TypedMap이 저장 형태와 다른 기준으로 조회·삭제하는 문제 수정

### DIFF
--- a/Integration/org.egovframe.rte.itl.integration/src/main/java/org/egovframe/rte/itl/integration/message/typed/TypedList.java
+++ b/Integration/org.egovframe.rte.itl.integration/src/main/java/org/egovframe/rte/itl/integration/message/typed/TypedList.java
@@ -147,6 +147,43 @@ public class TypedList implements List<Object> {
         return newCollection;
     }
 
+    /**
+     * 조회·삭제 인자를 저장 형태와 같은 값으로 맞춘다.
+     *
+     * <p>{@link #add(Object)}·{@link #set(int, Object)}는 값을 element type으로 변환해 담으므로,
+     * 조회할 때도 같은 변환을 거쳐야 넣은 값을 찾을 수 있다. element type에 담을 수 없는 값은
+     * 애초에 목록에 들어있을 수 없으므로 예외를 던지지 않고 원본을 그대로 돌려준다.
+     * {@link java.util.List#contains(Object)} 계약이 이종 타입 인자에 대해 예외가 아닌
+     * <code>false</code>를 요구하기 때문이다.</p>
+     *
+     * @param value 조회·삭제 대상 값
+     * @return 변환된 값, 변환할 수 없으면 원본 값
+     */
+    protected Object toLookupValue(final Object value) {
+        try {
+            return convertToTypedObject(value);
+        } catch (RuntimeException e) {
+            return value;
+        }
+    }
+
+    /**
+     * Collection 인자의 각 요소를 조회용 값으로 맞춘다.
+     *
+     * @param c 조회·삭제 대상 값을 담고 있는 Collection 객체
+     * @return 변환된 값을 담고 있는 Collection 객체
+     */
+    protected Collection<Object> toLookupValues(final Collection<?> c) {
+        if (c == null) {
+            return null;
+        }
+        Collection<Object> newCollection = new ArrayList<Object>();
+        for (Object object : c) {
+            newCollection.add(toLookupValue(object));
+        }
+        return newCollection;
+    }
+
     public void add(int index, Object element) {
         inner.add(index, convertToTypedObject(element));
     }
@@ -168,11 +205,11 @@ public class TypedList implements List<Object> {
     }
 
     public boolean contains(Object o) {
-        return inner.contains(o);
+        return inner.contains(toLookupValue(o));
     }
 
     public boolean containsAll(Collection<?> c) {
-        return inner.containsAll(c);
+        return inner.containsAll(toLookupValues(c));
     }
 
     public Object get(int index) {
@@ -180,7 +217,7 @@ public class TypedList implements List<Object> {
     }
 
     public int indexOf(Object o) {
-        return inner.indexOf(o);
+        return inner.indexOf(toLookupValue(o));
     }
 
     public boolean isEmpty() {
@@ -192,7 +229,7 @@ public class TypedList implements List<Object> {
     }
 
     public int lastIndexOf(Object o) {
-        return inner.lastIndexOf(o);
+        return inner.lastIndexOf(toLookupValue(o));
     }
 
     public ListIterator<Object> listIterator() {
@@ -208,15 +245,15 @@ public class TypedList implements List<Object> {
     }
 
     public boolean remove(Object o) {
-        return inner.remove(o);
+        return inner.remove(toLookupValue(o));
     }
 
     public boolean removeAll(Collection<?> c) {
-        return inner.removeAll(c);
+        return inner.removeAll(toLookupValues(c));
     }
 
     public boolean retainAll(Collection<?> c) {
-        return inner.retainAll(c);
+        return inner.retainAll(toLookupValues(c));
     }
 
     public Object set(int index, Object element) {

--- a/Integration/org.egovframe.rte.itl.integration/src/main/java/org/egovframe/rte/itl/integration/message/typed/TypedMap.java
+++ b/Integration/org.egovframe.rte.itl.integration/src/main/java/org/egovframe/rte/itl/integration/message/typed/TypedMap.java
@@ -143,7 +143,23 @@ public class TypedMap implements Map<String, Object> {
     }
 
     public boolean containsValue(Object arg0) {
-        return inner.containsValue(arg0);
+        if (inner.containsValue(arg0)) {
+            return true;
+        }
+        // put()이 field type으로 변환해 담으므로, 넣은 값 그대로 물어도 찾을 수 있어야 한다.
+        // 어느 field에 해당하는지는 알 수 없으므로 field 별 변환 결과와 차례로 비교한다.
+        for (Entry<String, Object> entry : inner.entrySet()) {
+            Object converted;
+            try {
+                converted = convertToTypedObject(entry.getKey(), arg0);
+            } catch (RuntimeException e) {
+                continue;
+            }
+            if (converted == null ? entry.getValue() == null : converted.equals(entry.getValue())) {
+                return true;
+            }
+        }
+        return false;
     }
 
     public Set<Entry<String, Object>> entrySet() {

--- a/Integration/org.egovframe.rte.itl.integration/src/test/java/org/egovframe/rte/itl/integration/message/typed/TypedLookupConversionTest.java
+++ b/Integration/org.egovframe.rte.itl.integration/src/test/java/org/egovframe/rte/itl/integration/message/typed/TypedLookupConversionTest.java
@@ -1,0 +1,115 @@
+package org.egovframe.rte.itl.integration.message.typed;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.egovframe.rte.itl.integration.type.ListType;
+import org.egovframe.rte.itl.integration.type.PrimitiveType;
+import org.egovframe.rte.itl.integration.type.RecordType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * {@link TypedList}·{@link TypedMap}이 저장할 때와 같은 기준으로 조회·삭제하는지 검증한다.
+ *
+ * <p>두 클래스는 값을 담을 때 element/field type으로 변환한다. 예를 들어 element type이
+ * <code>long</code>이면 {@link PrimitiveType#LONG}이 <code>Integer</code>를 <code>Long</code>으로
+ * 바꿔 담는다. 조회 인자를 변환하지 않으면 방금 넣은 값을 그대로 물어도 찾지 못한다.</p>
+ */
+class TypedLookupConversionTest {
+
+    private final ListType longListType = new ListType("longList", "longList", PrimitiveType.LONG);
+
+    private TypedList longList() {
+        return new TypedList(longListType, Arrays.asList(1, 2, 3));
+    }
+
+    @Test
+    @DisplayName("생성자에 넘긴 값은 저장 시 element type으로 변환된다")
+    void constructorConvertsElements() {
+        assertEquals(Long.class, longList().get(0).getClass());
+    }
+
+    @Test
+    @DisplayName("넣은 값 그대로 contains·indexOf로 찾을 수 있다")
+    void containsAndIndexOfFindOriginalValue() {
+        TypedList list = longList();
+
+        assertTrue(list.contains(Integer.valueOf(1)));
+        assertEquals(0, list.indexOf(Integer.valueOf(1)));
+        assertEquals(2, list.lastIndexOf(Integer.valueOf(3)));
+        // 변환 후 형태로 물어도 결과는 같다
+        assertTrue(list.contains(Long.valueOf(1L)));
+    }
+
+    @Test
+    @DisplayName("넣은 값 그대로 remove로 지울 수 있다")
+    void removeAcceptsOriginalValue() {
+        TypedList list = longList();
+
+        assertTrue(list.remove(Integer.valueOf(1)));
+        assertEquals(2, list.size());
+        assertFalse(list.contains(Integer.valueOf(1)));
+    }
+
+    @Test
+    @DisplayName("Collection 인자를 받는 조회·삭제도 같은 기준으로 동작한다")
+    void collectionArgumentsUseTheSameConversion() {
+        assertTrue(longList().containsAll(Arrays.asList(1, 2)));
+
+        TypedList removeTarget = longList();
+        assertTrue(removeTarget.removeAll(Arrays.asList(1, 2)));
+        assertEquals(1, removeTarget.size());
+
+        TypedList retainTarget = longList();
+        assertTrue(retainTarget.retainAll(Arrays.asList(1)));
+        assertEquals(1, retainTarget.size());
+        assertEquals(Long.valueOf(1L), retainTarget.get(0));
+    }
+
+    @Test
+    @DisplayName("element type에 담을 수 없는 인자는 예외 없이 없는 값으로 처리한다")
+    void foreignArgumentIsTreatedAsAbsent() {
+        TypedList list = longList();
+
+        assertFalse(list.contains("문자열"));
+        assertEquals(-1, list.indexOf("문자열"));
+        assertFalse(list.remove("문자열"));
+        assertFalse(list.containsAll(Arrays.asList("문자열")));
+        assertEquals(3, list.size());
+    }
+
+    @Test
+    @DisplayName("null 인자도 예외 없이 처리한다")
+    void nullArgumentIsHandled() {
+        TypedList list = longList();
+
+        assertFalse(list.contains(null));
+        assertFalse(list.remove(null));
+        assertEquals(3, list.size());
+    }
+
+    @Test
+    @DisplayName("TypedMap도 넣은 값 그대로 containsValue로 찾을 수 있다")
+    void typedMapContainsValueFindsOriginalValue() {
+        Map<String, org.egovframe.rte.itl.integration.type.Type> fieldTypes = new LinkedHashMap<>();
+        fieldTypes.put("count", PrimitiveType.LONG);
+        fieldTypes.put("name", PrimitiveType.STRING);
+        RecordType recordType = new RecordType("record", "record", fieldTypes);
+
+        TypedMap map = new TypedMap(recordType);
+        map.put("count", Integer.valueOf(7));
+        map.put("name", "홍길동");
+
+        assertEquals(Long.class, map.get("count").getClass());
+        assertTrue(map.containsValue(Integer.valueOf(7)));
+        assertTrue(map.containsValue(Long.valueOf(7L)));
+        assertTrue(map.containsValue("홍길동"));
+        assertFalse(map.containsValue(Integer.valueOf(8)));
+    }
+}


### PR DESCRIPTION
## 변경 이유

`TypedList`와 `TypedMap`은 값을 담을 때 element/field type으로 변환합니다.

```java
public boolean add(Object o) {
    return inner.add(convertToTypedObject(o));
}
```

element type이 `long`이면 `PrimitiveType.LONG`이 `((Number) source).longValue()`로 정규화하므로, `Integer`를 넣어도 안에는 `Long`이 담깁니다.

그런데 조회·삭제 메서드는 인자를 변환하지 않고 그대로 내부 컬렉션에 넘깁니다.

```java
public boolean contains(Object o) {
    return inner.contains(o);
}
```

저장은 변환된 값으로, 조회는 원래 값으로 이뤄지므로 **방금 넣은 값을 그대로 물어도 찾지 못합니다.**

```java
ListType type = new ListType("l", "l", PrimitiveType.LONG);
TypedList list = new TypedList(type, Arrays.asList(1, 2, 3));

list.get(0).getClass()            // class java.lang.Long
list.contains(1)                  // false
list.indexOf(1)                   // -1
list.remove(Integer.valueOf(1))   // false — 목록은 그대로 3건
list.contains(1L)                 // true
```

생성자에 넘긴 값과 조회에 쓰는 값이 같은데도 결과가 갈립니다. 호출자는 자기가 담은 값으로 원소를 지울 수 없습니다.

같은 클래스 안에서 두 경로가 어긋나 있는 것이 원인입니다. 변환하는 쪽은 `add`·`add(int, Object)`·`addAll`·`set`이고, 변환하지 않는 쪽은 `contains`·`containsAll`·`indexOf`·`lastIndexOf`·`remove(Object)`·`removeAll`·`retainAll`입니다. `TypedMap`도 `put`·`putAll`은 변환하고 `containsValue`는 변환하지 않습니다.

이 경로는 실제로 쓰입니다. `ListType.convertToTypedObject()`(114~131행)가 모든 `Collection`과 배열을 `TypedList`로 감싸므로, 연계 메시지의 List 필드는 전부 `TypedList`가 됩니다. `MessageConverterImpl`이 요청·응답 양방향에서 이 변환을 호출합니다.

## 변경 내용

- `TypedList`에 조회·삭제 인자를 저장할 때와 같은 기준으로 맞추는 `toLookupValue(Object)`·`toLookupValues(Collection)`을 두고, 위 7개 메서드가 이를 거치게 했습니다.
- element type에 담을 수 없는 인자는 예외를 던지지 않고 원본을 그대로 사용합니다. 그런 값은 애초에 목록에 들어있을 수 없어 결과가 `false`·`-1`로 나옵니다. `List.contains(Object)` 계약이 이종 타입 인자에 대해 예외가 아닌 `false`를 요구하기 때문입니다.
- `TypedMap.containsValue`는 어느 field의 값인지 알 수 없으므로, 먼저 원본으로 비교한 뒤 field 별 변환 결과와 차례로 대조합니다. 변환할 수 없는 field는 건너뜁니다.
- 저장 경로와 반환 값은 손대지 않았습니다. 목록에 담기는 값과 `get`이 돌려주는 값은 그대로입니다.

## 테스트 방법

```
mvn -B -pl Integration/org.egovframe.rte.itl.integration test
```

모듈 전체 74건이 통과합니다(신규 7건 포함, 실패·오류 0건). main 기준 67건입니다.

신규 테스트는 생성자가 element type으로 변환해 담는지, 넣은 값 그대로 `contains`·`indexOf`·`lastIndexOf`·`remove`로 찾고 지울 수 있는지, Collection 인자를 받는 `containsAll`·`removeAll`·`retainAll`도 같은 기준인지, element type에 담을 수 없는 인자와 `null`이 예외 없이 처리되는지, `TypedMap.containsValue`가 같은지 확인합니다.

본문 수정만 되돌리고 테스트만 적용하면 7건 중 4건이 실패합니다.

이 모듈을 쓰는 `Integration/org.egovframe.rte.itl.webservice`도 함께 돌려 15건이 그대로 통과하는 것을 확인했습니다.

## 영향 범위

- 수정 파일은 `TypedList.java`(본문 51줄, 대부분 헬퍼와 javadoc)와 `TypedMap.java`(본문 18줄), 신규 테스트 1개입니다.
- 지금까지 `false`·`-1`을 돌려주던 조회가 값을 찾게 됩니다. 원래 찾던 형태(변환 후 값)로 묻는 호출은 결과가 그대로입니다.
- 공개 API 시그니처, 설정, 의존성 변경은 없습니다.
