### PR TITLE
비밀번호 연속문자 검증의 로케일 의존성 수정 (터키어 로케일 우회 방지)

### DIFF
--- a/Presentation/org.egovframe.rte.ptl.reactive/src/main/java/org/egovframe/rte/ptl/reactive/validation/EgovPwdCheckValidation.java
+++ b/Presentation/org.egovframe.rte.ptl.reactive/src/main/java/org/egovframe/rte/ptl/reactive/validation/EgovPwdCheckValidation.java
@@ -18,6 +18,7 @@ package org.egovframe.rte.ptl.reactive.validation;
 import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;
 
+import java.util.Locale;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -62,7 +63,7 @@ public class EgovPwdCheckValidation implements ConstraintValidator<EgovPwdCheck,
      * 연속된 문자열 3개 이상 (ex: abc, def, 123 등) 체크
      */
     public static boolean consecutivePasswordCheck(String value) {
-        String tmpValue = value.toUpperCase();
+        String tmpValue = value.toUpperCase(Locale.ROOT);
         for (int i = 0; i < tmpValue.length() - 2; i++) {
             if (isConsecutive(tmpValue.charAt(i), tmpValue.charAt(i + 1), tmpValue.charAt(i + 2))) {
                 return true;

--- a/Presentation/org.egovframe.rte.ptl.reactive/src/test/java/org/egovframe/rte/ptl/reactive/validation/ReactiveValidatorsSemanticTest.java
+++ b/Presentation/org.egovframe.rte.ptl.reactive/src/test/java/org/egovframe/rte/ptl/reactive/validation/ReactiveValidatorsSemanticTest.java
@@ -2,6 +2,9 @@ package org.egovframe.rte.ptl.reactive.validation;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.Locale;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -117,5 +120,27 @@ class ReactiveValidatorsSemanticTest {
         assertFalse(validator.isValid("Egov!2aaa", null), "비밀번호는 동일문자 3회 반복을 false로 판정해야 한다");
         assertFalse(validator.isValid("Egov!2abc", null), "비밀번호는 오름차순 연속 3자를 false로 판정해야 한다");
         assertFalse(validator.isValid("Egov!2123", null), "비밀번호는 연속 숫자 3자를 false로 판정해야 한다");
+    }
+
+    @Test
+    void pwdCheck_consecutiveDetectionIsLocaleIndependent() {
+        // 터키어 로케일에서는 'i'가 대문자 'İ'(U+0130)로 변환되어,
+        // toUpperCase()가 로케일에 의존하면 'ghi'·'hij' 같은 연속열이 탐지되지 않고
+        // 약한 비밀번호가 통과되는 우회가 발생할 수 있다. Locale.ROOT 고정으로 방지한다.
+        Locale original = Locale.getDefault();
+        try {
+            Locale.setDefault(Locale.forLanguageTag("tr-TR"));
+            assertTrue(EgovPwdCheckValidation.consecutivePasswordCheck("ghi"),
+                    "터키어 로케일에서도 'ghi' 오름차순 연속 3자는 탐지되어야 한다");
+
+            EgovPwdCheckValidation validator = new EgovPwdCheckValidation();
+            boolean turkish = validator.isValid("Egov!2ghi", null);
+            Locale.setDefault(Locale.ENGLISH);
+            boolean english = validator.isValid("Egov!2ghi", null);
+            assertFalse(turkish, "터키어 로케일에서 'ghi' 연속을 포함한 비밀번호는 거부되어야 한다");
+            assertEquals(english, turkish, "연속 문자 검증 결과는 JVM 기본 로케일과 무관해야 한다");
+        } finally {
+            Locale.setDefault(original);
+        }
     }
 }


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes (보안, CWE-176 Improper Handling of Unicode Encoding / locale-dependent case mapping)
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

`EgovPwdCheckValidation.consecutivePasswordCheck()`가 연속 문자열(예: abc, hij)을 검사하기 전에 `value.toUpperCase()`를 **로케일 인자 없이** 호출합니다.

```java
String tmpValue = value.toUpperCase();   // JVM 기본 로케일 의존
```

JVM 기본 로케일이 터키어(tr)/아제르바이잔어(az)이면 소문자 `i`가 `I`(U+0049)가 아니라 **`İ`(U+0130)**로 변환됩니다. 그 결과 `isConsecutive()`의 코드포인트 비교가 어긋나, `ghi`·`hij`처럼 **'i'를 포함한 연속 3자**가 탐지되지 않습니다. 연속 문자 검사는 약한 비밀번호를 **거부**하기 위한 규칙이므로, 탐지 실패는 곧 **약한 비밀번호가 통과되는 검증 우회**가 됩니다. 같은 비밀번호가 서버의 JVM 로케일에 따라 다르게 판정되는 문제이기도 합니다.

**수정 내용**: 대문자 변환을 로케일 독립적으로 고정합니다.

```java
String tmpValue = value.toUpperCase(Locale.ROOT);
```

변경 범위는 한 줄(+import)이며 기존 검증 로직·계약은 그대로입니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests

`ReactiveValidatorsSemanticTest`에 `pwdCheck_consecutiveDetectionIsLocaleIndependent`를 추가했습니다. 터키어 로케일을 설정하고 `ghi` 연속 3자가 탐지되는지, 그리고 `isValid` 결과가 영어 로케일과 동일한지 검증하며, 종료 시 원래 로케일을 복원합니다.

**실측 (JDK 21, `mvn test -Dtest=ReactiveValidatorsSemanticTest`)**

| 구분 | 결과 |
|---|---|
| 수정 전 (`toUpperCase()`) | 신규 테스트 **실패** — 터키어 로케일에서 `ghi` 미탐지 (`expected: <true> but was: <false>`) |
| 수정 후 (`Locale.ROOT`) | 스위트 9건 전부 통과 (Failures 0) |

즉 패치 없이는 테스트가 실패해 결함을 재현하고, 패치 적용 시 통과합니다(TDD).

## 테스트 브라우저 Test Browser

- [X] 기타 Others — 서버측 검증 로직만 수정. UI 변경 없음.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

UI 변경이 없어 해당 없음. 위 JUnit 실측으로 대신합니다.