### PR TITLE
fix: EgovStringUtil.containsInvalidChars(String, String) null 처리가 자기 문서·형제 오버로드와 반대로 동작하는 문제 수정

### DIFF
--- a/Foundation/org.egovframe.rte.fdl.string/src/main/java/org/egovframe/rte/fdl/string/EgovStringUtil.java
+++ b/Foundation/org.egovframe.rte.fdl.string/src/main/java/org/egovframe/rte/fdl/string/EgovStringUtil.java
@@ -846,7 +846,7 @@ public final class EgovStringUtil {
      */
     public static boolean containsInvalidChars(String str, String invalidChars) {
         if (str == null || invalidChars == null) {
-            return true;
+            return false;
         }
         return containsInvalidChars(str, invalidChars.toCharArray());
     }

--- a/Foundation/org.egovframe.rte.fdl.string/src/test/java/org/egovframe/rte/fdl/string/EgovStringUtilTest.java
+++ b/Foundation/org.egovframe.rte.fdl.string/src/test/java/org/egovframe/rte/fdl/string/EgovStringUtilTest.java
@@ -380,6 +380,13 @@ public class EgovStringUtilTest {
     }
 
     @Test
+    public void testContainsInvalidCharsNullString() {
+        // String-overload null cases must match the javadoc's own example table.
+        assertFalse(EgovStringUtil.containsInvalidChars(null, "xyz"));
+        assertFalse(EgovStringUtil.containsInvalidChars("abc", (String) null));
+    }
+
+    @Test
     public void testIsNumeric() {
         // 1. string is empty
         String str = "";


### PR DESCRIPTION
## 수정 사유

- [x] 버그수정
- [ ] 기능개선
- [ ] 리팩터링

## 변경 이유

`EgovStringUtil`에는 문자열이 특정 금지 문자를 포함하는지 검사하는 오버로드가 두 개 있습니다(`containsInvalidChars(String, char[])`와 `containsInvalidChars(String, String)`). 두 메서드의 Javadoc은 예시 표까지 완전히 같습니다.

```
StringUtil.containsInvalidChars(null, *) = false
StringUtil.containsInvalidChars(*, null) = false
```

`char[]` 오버로드는 이 계약을 그대로 지킵니다.

```java
public static boolean containsInvalidChars(String str, char[] invalidChars) {
    if (str == null || invalidChars == null) {
        return false;
    }
    ...
}
```

그런데 `String` 오버로드는 같은 Javadoc을 그대로 복사해 두고도 반대로 동작합니다.

```java
public static boolean containsInvalidChars(String str, String invalidChars) {
    if (str == null || invalidChars == null) {
        return true;
    }
    return containsInvalidChars(str, invalidChars.toCharArray());
}
```

`invalidChars`가 `null`이면(예: 설정값이 아직 세팅되지 않은 경우) 어떤 입력을 넣어도 "금지 문자를 포함한다"는 결과가 나옵니다. 형제 오버로드와 자기 문서 둘 다에 어긋나는 동작입니다.

## 변경 내용

`String` 오버로드의 `null` 처리 분기만 형제 오버로드·자기 문서와 일치하도록 바로잡습니다.

AS-IS
```java
public static boolean containsInvalidChars(String str, String invalidChars) {
    if (str == null || invalidChars == null) {
        return true;
    }
    return containsInvalidChars(str, invalidChars.toCharArray());
}
```

TO-BE
```java
public static boolean containsInvalidChars(String str, String invalidChars) {
    if (str == null || invalidChars == null) {
        return false;
    }
    return containsInvalidChars(str, invalidChars.toCharArray());
}
```

## 영향 범위

- `EgovStringUtil.containsInvalidChars(String, String)`의 `null` 처리 분기만 바뀝니다. `char[]` 오버로드, 그리고 `String` 오버로드의 비-`null` 경로(형제 오버로드로의 위임)는 그대로입니다.
- 저장소 전체에서 이 오버로드를 부르는 곳은 자기 자신의 테스트 파일뿐이라(코드 검색으로 확인) 다른 호출부에 미치는 영향은 없습니다.

## 테스트 방법

가설: 미수정 코드는 `containsInvalidChars(null, "xyz")`와 `containsInvalidChars("abc", (String) null)`에 대해 `true`를 반환하지만(문서와 모순), 수정본은 문서·형제 오버로드와 일치하는 `false`를 반환한다.

검증 방법: `EgovStringUtilTest`에 `testContainsInvalidCharsNullString`을 추가해 두 경우를 확인했습니다.

```java
@Test
public void testContainsInvalidCharsNullString() {
    // String-overload null cases must match the javadoc's own example table.
    assertFalse(EgovStringUtil.containsInvalidChars(null, "xyz"));
    assertFalse(EgovStringUtil.containsInvalidChars("abc", (String) null));
}
```

미수정(RED) — `mvn -Dtest=EgovStringUtilTest#testContainsInvalidCharsNullString test`(새 테스트 1개만 지정)

```
[INFO] Running org.egovframe.rte.fdl.string.EgovStringUtilTest
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.295 s <<< FAILURE! -- in org.egovframe.rte.fdl.string.EgovStringUtilTest
[ERROR]   EgovStringUtilTest.testContainsInvalidCharsNullString:385 expected: <false> but was: <true>
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0
[INFO] BUILD FAILURE
```

수정본(GREEN) — 같은 명령

```
[INFO] Running org.egovframe.rte.fdl.string.EgovStringUtilTest
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.255 s -- in org.egovframe.rte.fdl.string.EgovStringUtilTest
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```

모듈 전체(`mvn -pl Foundation/org.egovframe.rte.fdl.string test`)도 회귀 없이 전부 통과합니다.

```
[INFO] Tests run: 32, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.373 s -- in org.egovframe.rte.fdl.string.EgovStringUtilTest
[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.016 s -- in org.egovframe.rte.fdl.string.EgovObjectUtilTest
[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.027 s -- in org.egovframe.rte.fdl.string.EgovNumericUtilTest
[INFO] Tests run: 13, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.043 s -- in org.egovframe.rte.fdl.string.EgovDateUtilTest
[INFO] Tests run: 56, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```
