### PR TITLE
fix: SimpleMessage가 value null을 허용해 인터페이스 문서와 모순되는 문제 수정

### DIFF
--- a/Integration/org.egovframe.rte.itl.integration/src/main/java/org/egovframe/rte/itl/integration/message/simple/SimpleMessage.java
+++ b/Integration/org.egovframe.rte.itl.integration/src/main/java/org/egovframe/rte/itl/integration/message/simple/SimpleMessage.java
@@ -122,6 +122,9 @@ public class SimpleMessage implements EgovIntegrationMessage {
             if (StringUtils.hasText(entry.getKey()) == false) {
                 throw new IllegalArgumentException();
             }
+            if (entry.getValue() == null) {
+                throw new IllegalArgumentException();
+            }
         }
         this.body = body;
     }
@@ -153,12 +156,18 @@ public class SimpleMessage implements EgovIntegrationMessage {
             if (StringUtils.hasText(entry.getKey()) == false) {
                 throw new IllegalArgumentException();
             }
+            if (entry.getValue() == null) {
+                throw new IllegalArgumentException();
+            }
         }
         this.attachments = attachments;
     }
 
     public Object putAttachment(String name, Object attachment) {
         if (StringUtils.hasText(name) == false) {
+            throw new IllegalArgumentException();
+        }
+        if (attachment == null) {
             throw new IllegalArgumentException();
         }
         return attachments.put(name, attachment);

--- a/Integration/org.egovframe.rte.itl.integration/src/test/java/org/egovframe/rte/itl/integration/message/simple/SimpleMessageTest.java
+++ b/Integration/org.egovframe.rte.itl.integration/src/test/java/org/egovframe/rte/itl/integration/message/simple/SimpleMessageTest.java
@@ -1,0 +1,40 @@
+package org.egovframe.rte.itl.integration.message.simple;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class SimpleMessageTest {
+
+    @Test
+    public void testSetBodyRejectsNullValue() {
+        // EgovIntegrationMessage#setBody의 javadoc: body의 value 값 중 null이 있으면 IllegalArgumentException.
+        SimpleMessage message = new SimpleMessage();
+        Map<String, Object> body = new HashMap<String, Object>();
+        body.put("key", null);
+
+        assertThrows(IllegalArgumentException.class, () -> message.setBody(body));
+    }
+
+    @Test
+    public void testSetAttachmentsRejectsNullValue() {
+        // EgovIntegrationMessage#setAttachments의 javadoc: attachments의 value 값 중 null이 있으면 IllegalArgumentException.
+        SimpleMessage message = new SimpleMessage();
+        Map<String, Object> attachments = new HashMap<String, Object>();
+        attachments.put("key", null);
+
+        assertThrows(IllegalArgumentException.class, () -> message.setAttachments(attachments));
+    }
+
+    @Test
+    public void testPutAttachmentRejectsNullValue() {
+        // EgovIntegrationMessage#putAttachment의 javadoc: attachment 값이 null이면 IllegalArgumentException.
+        SimpleMessage message = new SimpleMessage();
+
+        assertThrows(IllegalArgumentException.class, () -> message.putAttachment("key", null));
+    }
+
+}

--- a/Integration/org.egovframe.rte.itl.integration/src/test/java/org/egovframe/rte/itl/integration/message/simple/SimpleMessageTest.java
+++ b/Integration/org.egovframe.rte.itl.integration/src/test/java/org/egovframe/rte/itl/integration/message/simple/SimpleMessageTest.java
@@ -11,7 +11,7 @@ public class SimpleMessageTest {
 
     @Test
     public void testSetBodyRejectsNullValue() {
-        // EgovIntegrationMessage#setBody의 javadoc: body의 value 값 중 null이 있으면 IllegalArgumentException.
+        // SimpleMessage 생성자 javadoc: body의 value 값 중 null이 있으면 IllegalArgumentException.
         SimpleMessage message = new SimpleMessage();
         Map<String, Object> body = new HashMap<String, Object>();
         body.put("key", null);
@@ -35,6 +35,17 @@ public class SimpleMessageTest {
         SimpleMessage message = new SimpleMessage();
 
         assertThrows(IllegalArgumentException.class, () -> message.putAttachment("key", null));
+    }
+
+    @Test
+    public void testSetBodyRejectsNullValueAmongMultipleEntries() {
+        // 여러 entry 중 뒤쪽 하나만 value가 null이어도 검증을 통과해선 안 된다.
+        SimpleMessage message = new SimpleMessage();
+        Map<String, Object> body = new HashMap<String, Object>();
+        body.put("first", "ok");
+        body.put("second", null);
+
+        assertThrows(IllegalArgumentException.class, () -> message.setBody(body));
     }
 
 }


### PR DESCRIPTION
## 수정 사유

- [x] 버그수정
- [ ] 기능개선
- [ ] 리팩터링

## 변경 이유

`EgovIntegrationMessage` 인터페이스는 `setAttachments`/`putAttachment`의 javadoc에서 value(attachment)가 `null`이면 `IllegalArgumentException`을 던진다고 번호를 매겨 명시합니다.

```java
/**
 * @param attachments attachments (not null)
 * @throws IllegalArgumentException 1. Argument <code>attachments</code> 값이 <code>null</code>인 경우 <br>
 *                                  2. Argument <code>attachments</code>의 <code>key</code> 값들 중
 *                                  <code>null</code> 값 또는 공백 문자가 있는 경우 <br>
 *                                  3. Argument <code>attachments</code>의 <code>value</code> 값들 중
 *                                  <code>null</code> 값이 있는 경우
 */
void setAttachments(final Map<String, Object> attachments);
```

`setBody`는 인터페이스 javadoc에 value 관련 조항이 없지만, `SimpleMessage`의 2·3-인자 생성자 javadoc이 body/attachments의 value가 null이면 예외를 던진다고 선언합니다. 그런데 실제 구현(`setBody`/`setAttachments`/`putAttachment`)은 key만 `StringUtils.hasText`로 검사하고 value의 null 여부는 전혀 검사하지 않아 문서가 명시한 예외가 발생하지 않고 null이 그대로 저장됩니다.

이 저장소는 문서화된 계약과 구현이 어긋나는 경우 구현 쪽을 계약에 맞추는 방식을 이미 채택하고 있습니다(#310, `EgovStringUtil.containsInvalidChars`).

## 변경 내용

`setBody`/`setAttachments`/`putAttachment`에 value(attachment) null 검사를 각각 추가했습니다. key 검사와 같은 위치·순서로 넣었습니다. 검증은 필드에 값을 반영하기 전에 끝나므로 예외 발생 시 부분 반영은 없습니다.

AS-IS
```java
public void setBody(Map<String, Object> body) {
    if (body == null) {
        throw new IllegalArgumentException();
    }
    for (Entry<String, Object> entry : body.entrySet()) {
        if (StringUtils.hasText(entry.getKey()) == false) {
            throw new IllegalArgumentException();
        }
    }
    this.body = body;
}
```

TO-BE
```java
public void setBody(Map<String, Object> body) {
    if (body == null) {
        throw new IllegalArgumentException();
    }
    for (Entry<String, Object> entry : body.entrySet()) {
        if (StringUtils.hasText(entry.getKey()) == false) {
            throw new IllegalArgumentException();
        }
        if (entry.getValue() == null) {
            throw new IllegalArgumentException();
        }
    }
    this.body = body;
}
```

`setAttachments`도 동일하게 value 검사를 추가했고, `putAttachment`는 `attachment == null` 검사를 추가했습니다.

## 영향 범위

`SimpleMessage.java`와 신규 테스트 파일만 변경했습니다. 저장소 전체(`codegraph callers`, grep 포함)를 확인한 결과 이 세 메서드를 호출하는 production 코드는 없어 기존 정상 호출자가 이번 검증 강화로 깨질 위험은 없습니다.

같은 인터페이스를 구현하는 `TypedMessage`(`message/typed` 패키지)도 `setBody`/`setAttachments`에 동일한 value null 미검증이 남아있습니다(직접 확인). 같은 패키지의 `TypedList`/`TypedMap`을 다루는 #308이 열려있지만 그 PR은 조회·삭제 키 불일치 문제만 다루고 `TypedMessage.java`는 건드리지 않아 이번 결함과는 무관합니다 — 리뷰 충돌을 피하기 위해 이번 PR 범위에서는 제외했고 별도 PR로 다룰 사안입니다.

## 테스트 방법

가설: 미수정 상태에서 body/attachments의 value(attachment) 자리에 null을 넣어 `setBody`/`setAttachments`/`putAttachment`를 호출하면 예외 없이 통과하고 수정본은 `IllegalArgumentException`을 던진다.

검증 방법: `SimpleMessageTest`에 value/attachment가 null인 Map(또는 인자)을 구성해 각 메서드를 호출하고 `IllegalArgumentException`을 기대하는 테스트 4개를 추가(단일 entry 3개 + 여러 entry 중 하나만 null인 경우 1개)했습니다. 수정 전/후 상태를 소스 라인만 토글해 같은 테스트를 각각 실행했습니다.

미수정(RED)
```
[ERROR] Tests run: 4, Failures: 4, Errors: 0, Skipped: 0, Time elapsed: 0.030 s <<< FAILURE! -- in org.egovframe.rte.itl.integration.message.simple.SimpleMessageTest
[ERROR]   SimpleMessageTest.testPutAttachmentRejectsNullValue:37 Expected java.lang.IllegalArgumentException to be thrown, but nothing was thrown.
[ERROR]   SimpleMessageTest.testSetAttachmentsRejectsNullValue:29 Expected java.lang.IllegalArgumentException to be thrown, but nothing was thrown.
[ERROR]   SimpleMessageTest.testSetBodyRejectsNullValue:19 Expected java.lang.IllegalArgumentException to be thrown, but nothing was thrown.
[ERROR]   SimpleMessageTest.testSetBodyRejectsNullValueAmongMultipleEntries:48 Expected java.lang.IllegalArgumentException to be thrown, but nothing was thrown.
[ERROR] Tests run: 4, Failures: 4, Errors: 0, Skipped: 0
```

수정본(GREEN, 신규 테스트만 격리 실행)
```
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.024 s -- in org.egovframe.rte.itl.integration.message.simple.SimpleMessageTest
```

수정본(GREEN, 모듈 전체 회귀)
```
[INFO] Tests run: 71, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```



