### PR TITLE
fix: EgovSecurityConfigReader가 형제 EgovAccessConfigReader와 달리 안전 기본값을 덮어쓰지 않는 문제 수정

### DIFF
--- a/Foundation/org.egovframe.rte.fdl.security/src/main/java/org/egovframe/rte/fdl/security/config/EgovSecurityConfigReader.java
+++ b/Foundation/org.egovframe.rte.fdl.security/src/main/java/org/egovframe/rte/fdl/security/config/EgovSecurityConfigReader.java
@@ -94,7 +94,9 @@ public class EgovSecurityConfigReader {
                 try (InputStreamReader reader = new InputStreamReader(inputStream, StandardCharsets.UTF_8)) {
                     props.load(reader);
                 }
-                return mapPropertiesToBean(props, EgovSecurityConfig.class);
+                // 파일에 명시되지 않은 키(sniff, xssProtection 등)는 안전한 기본값을 유지하도록
+                // 빈 인스턴스가 아니라 createDefaultConfig()를 베이스로 덮어쓴다.
+                return mapPropertiesToBean(props, createDefaultConfig());
             }
         } catch (IOException e) {
             LOGGER.debug("Failed to read security configuration file, use default config. tried: {} - {}", triedPath, e.getMessage());
@@ -115,22 +117,15 @@ public class EgovSecurityConfigReader {
     }
 
     // 2026.02.28 KISA 보안취약점 조치
-    // properties 설정 파일을 읽어 EgovCryptoConfig 객체로 변환
-    private static EgovSecurityConfig mapPropertiesToBean(Properties props, Class<EgovSecurityConfig> beanClass) {
-        EgovSecurityConfig bean;
-        // 2026.02.28 KISA 보안취약점 조치
-        try {
-            bean = beanClass.getDeclaredConstructor().newInstance();
-        } catch (NoSuchMethodException | InvocationTargetException | InstantiationException | IllegalAccessException e) {
-            throw new RuntimeException("Failed to create config instance: " + e.getMessage(), e);
-        }
+    // properties 설정 파일을 읽어 기존 bean(기본값이 채워진 상태) 위에 덮어쓴다.
+    private static EgovSecurityConfig mapPropertiesToBean(Properties props, EgovSecurityConfig bean) {
         for (String key : props.stringPropertyNames()) {
             String value = props.getProperty(key);
             if (value == null) continue;
             String setterName = "set" + key.substring(0, 1).toUpperCase() + key.substring(1);
             // 2026.02.28 KISA 보안취약점 조치
             try {
-                Method setter = findSetter(beanClass, setterName);
+                Method setter = findSetter(bean.getClass(), setterName);
                 if (setter != null) {
                     Object arg = convertValue(value, setter.getParameterTypes()[0]);
                     setter.invoke(bean, arg);

--- a/Foundation/org.egovframe.rte.fdl.security/src/test/java/org/egovframe/rte/fdl/security/config/EgovSecurityConfigReaderTest.java
+++ b/Foundation/org.egovframe.rte.fdl.security/src/test/java/org/egovframe/rte/fdl/security/config/EgovSecurityConfigReaderTest.java
@@ -11,6 +11,7 @@ import java.nio.file.Path;
 import java.util.Properties;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class EgovSecurityConfigReaderTest {
@@ -34,6 +35,24 @@ public class EgovSecurityConfigReaderTest {
         assertTrue(config.isSniff());
         assertTrue(config.isXssProtection());
         assertEquals("SAMEORIGIN", config.getXframeOptions());
+    }
+
+    @Test
+    public void testReadConfigHonorsExplicitOverrideOfDefaultValue(@TempDir Path tempDir) throws IOException {
+        // 사용자가 sniff를 명시적으로 false로 끈 경우, 안전 기본값(true)에 밀려서는 안 된다.
+        Path propsFile = tempDir.resolve("egov-security-config.properties");
+        Properties props = new Properties();
+        props.setProperty("sniff", "false");
+        try (BufferedWriter writer = Files.newBufferedWriter(propsFile, StandardCharsets.UTF_8)) {
+            props.store(writer, null);
+        }
+
+        EgovSecurityConfigReader reader = new EgovSecurityConfigReader("file:" + propsFile, null);
+        EgovSecurityConfig config = reader.readConfig();
+
+        assertFalse(config.isSniff());
+        // 명시 안 한 다른 키는 여전히 안전 기본값을 유지해야 한다.
+        assertTrue(config.isXssProtection());
     }
 
 }

--- a/Foundation/org.egovframe.rte.fdl.security/src/test/java/org/egovframe/rte/fdl/security/config/EgovSecurityConfigReaderTest.java
+++ b/Foundation/org.egovframe.rte.fdl.security/src/test/java/org/egovframe/rte/fdl/security/config/EgovSecurityConfigReaderTest.java
@@ -1,0 +1,39 @@
+package org.egovframe.rte.fdl.security.config;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Properties;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class EgovSecurityConfigReaderTest {
+
+    @Test
+    public void testReadConfigKeepsSafeDefaultsForOmittedKeys(@TempDir Path tempDir) throws IOException {
+        // loginUrl만 지정하고 sniff/xssProtection/xframeOptions는 생략한 부분 설정 파일.
+        Path propsFile = tempDir.resolve("egov-security-config.properties");
+        Properties props = new Properties();
+        props.setProperty("loginUrl", "/custom/login.do");
+        try (BufferedWriter writer = Files.newBufferedWriter(propsFile, StandardCharsets.UTF_8)) {
+            props.store(writer, null);
+        }
+
+        EgovSecurityConfigReader reader = new EgovSecurityConfigReader("file:" + propsFile, null);
+        EgovSecurityConfig config = reader.readConfig();
+
+        assertEquals("/custom/login.do", config.getLoginUrl());
+        // 형제 구현체 EgovAccessConfigReader와 동일하게, 파일에 명시되지 않은 키는
+        // createDefaultConfig()의 안전 기본값(sniff=true, xssProtection=true, xframeOptions=SAMEORIGIN)을 유지해야 한다.
+        assertTrue(config.isSniff());
+        assertTrue(config.isXssProtection());
+        assertEquals("SAMEORIGIN", config.getXframeOptions());
+    }
+
+}


### PR DESCRIPTION
## 수정 사유

- [x] 버그수정
- [ ] 기능개선
- [ ] 리팩터링

## 변경 이유

`EgovAccessConfigReader`와 `EgovSecurityConfigReader`는 v5.0.0 Java Config 전면 재작성 커밋에서 동일한 패턴(`mapPropertiesToBean(props, XxxConfig.class)`으로 **빈 인스턴스** 위에 properties를 덮어씀)으로 함께 도입된 형제 클래스입니다. 이후 보안점검 커밋("보안점검 적용")이 `EgovAccessConfigReader`만 고쳐 파일에 없는 키가 안전 기본값을 유지하도록 `createDefaultConfig()`가 만든 기본값 빈 위에 properties를 덮어쓰게 바꿨는데, `EgovSecurityConfigReader`는 그대로 남았습니다. 둘 다 "properties 파일을 읽어 설정 빈으로 변환"하는 동일한 역할입니다.

```java
// EgovAccessConfigReader.readConfig()
// 파일에 명시되지 않은 키(globalAuthen, excludeList 등)는 안전한 기본값을 유지하도록
// 빈 인스턴스가 아니라 createDefaultConfig()를 베이스로 덮어쓴다.
return mapPropertiesToBean(props, createDefaultConfig());
```

`EgovSecurityConfigReader`는 같은 상황에서 빈 인스턴스 위에 덮어씁니다.

```java
// EgovSecurityConfigReader.readConfig() (수정 전)
return mapPropertiesToBean(props, EgovSecurityConfig.class);
// mapPropertiesToBean 내부에서 beanClass.getDeclaredConstructor().newInstance()로 빈 인스턴스 생성
```

`EgovSecurityConfig.sniff`/`xssProtection`은 초기화 없는 `boolean` 필드라 빈 인스턴스의 기본값은 `false`이고 `createDefaultConfig()`는 이 둘을 `true`로 설정합니다. `EgovSecurityConfiguration`의 `http.headers(...)` 블록은 이 값이 `false`일 때 Spring Security의 기본 동작에 기대는 게 아니라 `headers.contentTypeOptions(...disable)`/`headers.xssProtection(...disable)`을 **직접 호출**해 보호 헤더를 끕니다.

```java
// EgovSecurityConfiguration.securityFilterChain()
if (securityConfig.isSniff()) {
    headers.contentTypeOptions(Customizer.withDefaults());
} else {
    headers.contentTypeOptions(HeadersConfigurer.ContentTypeOptionsConfig::disable);
}
```

즉 properties 파일이 존재하지만 `sniff`/`xssProtection` 키를 적지 않은 배포(다른 값만 커스터마이즈하고 나머지는 기본값에 맡기는 흔한 시나리오)에서 X-Content-Type-Options·X-XSS-Protection 응답 헤더가 조용히 꺼집니다.

## 변경 내용

`EgovSecurityConfigReader.readConfig()`가 빈 인스턴스 대신 `createDefaultConfig()`를 `mapPropertiesToBean`에 넘기도록 바꿨습니다. `mapPropertiesToBean`의 시그니처도 `EgovAccessConfigReader`와 동일하게 `Class<EgovSecurityConfig>` 대신 이미 만들어진 `EgovSecurityConfig bean`을 받도록 바꿔 리플렉션으로 빈 인스턴스를 만들던 코드를 제거했습니다.

AS-IS
```java
if (inputStream != null) {
    Properties props = new Properties();
    try (InputStreamReader reader = new InputStreamReader(inputStream, StandardCharsets.UTF_8)) {
        props.load(reader);
    }
    return mapPropertiesToBean(props, EgovSecurityConfig.class);
}
```
```java
private static EgovSecurityConfig mapPropertiesToBean(Properties props, Class<EgovSecurityConfig> beanClass) {
    EgovSecurityConfig bean;
    try {
        bean = beanClass.getDeclaredConstructor().newInstance();
    } catch (NoSuchMethodException | InvocationTargetException | InstantiationException | IllegalAccessException e) {
        throw new RuntimeException("Failed to create config instance: " + e.getMessage(), e);
    }
    for (String key : props.stringPropertyNames()) {
        ...
        Method setter = findSetter(beanClass, setterName);
        ...
```

TO-BE
```java
if (inputStream != null) {
    Properties props = new Properties();
    try (InputStreamReader reader = new InputStreamReader(inputStream, StandardCharsets.UTF_8)) {
        props.load(reader);
    }
    // 파일에 명시되지 않은 키(sniff, xssProtection 등)는 안전한 기본값을 유지하도록
    // 빈 인스턴스가 아니라 createDefaultConfig()를 베이스로 덮어쓴다.
    return mapPropertiesToBean(props, createDefaultConfig());
}
```
```java
private static EgovSecurityConfig mapPropertiesToBean(Properties props, EgovSecurityConfig bean) {
    for (String key : props.stringPropertyNames()) {
        ...
        Method setter = findSetter(bean.getClass(), setterName);
        ...
```

## 영향 범위

`EgovSecurityConfigReader.java`와 신규 테스트 파일만 변경했습니다. properties 파일에 값을 명시적으로 적은 키는 그 값을 그대로 덮어쓰므로(테스트로 확인) 사용자가 의도적으로 설정한 값은 영향받지 않습니다. 영향받는 것은 "파일이 존재하지만 특정 키를 아예 안 적은" 경우뿐이며 이 경우 값이 `false`/`null`(빈 인스턴스) 대신 `createDefaultConfig()`의 값으로 바뀝니다.

- `sniff`/`xssProtection`: 빈 인스턴스 기본값이 `false`라 지금까지 `headers.contentTypeOptions(...disable)`/`headers.xssProtection(...disable)`이 명시적으로 호출되어 헤더가 꺼져 있었습니다. 실질적인 동작 변경(보안 강화 방향)입니다.
- `xframeOptions`: 빈 인스턴스 기본값이 `null`이라 `ObjectUtils.isEmpty(xfo)`가 참이 되어 `headers.frameOptions(...)` 호출 자체를 건너뛰고 Spring Security 프레임워크 자체 기본값(DENY)에 맡겨져 있었습니다. 즉 이 필드는 지금까지도 조용히 꺼진 상태가 아니었고 이번 수정은 형제 리더와의 일관성을 맞추는 정리에 가깝습니다.
- `alwaysUseDefaultTargetUrl`만 `false`→`true`로 바뀌는데, 이는 보안 헤더가 아니라 로그인 성공 후 리다이렉트 동작이라 안전 방향에 반하지 않습니다.

## 테스트 방법

가설: `sniff`를 적지 않은(또는 명시적으로 지정한) properties 파일로 `readConfig()`를 호출하면, 미수정 상태는 생략된 키뿐 아니라 다른 키(`xssProtection` 등)까지 전부 `false`가 되고 수정본은 명시된 키만 반영되고 나머지는 `createDefaultConfig()`의 안전 기본값을 유지한다.

검증 방법: `EgovSecurityConfigReaderTest`에 `@TempDir`로 임시 properties 파일을 만들어 `EgovSecurityConfigReader(path, null)`로 직접 `readConfig()`를 호출하는 테스트 2개를 추가했습니다. 하나는 "일부 키만 지정 → 나머지는 안전 기본값 유지", 다른 하나는 "명시적으로 `sniff=false`를 지정 → 그 설정은 그대로 반영되고, 명시 안 한 `xssProtection`은 안전 기본값 유지"를 검증합니다. 수정 전/후 상태를 소스 라인만 토글해 같은 테스트를 각각 실행했습니다.

미수정(RED)
```
[ERROR] Tests run: 2, Failures: 2, Errors: 0, Skipped: 0, Time elapsed: 0.232 s <<< FAILURE! -- in org.egovframe.rte.fdl.security.config.EgovSecurityConfigReaderTest
[ERROR]   EgovSecurityConfigReaderTest.testReadConfigHonorsExplicitOverrideOfDefaultValue:55 expected: <true> but was: <false>
[ERROR]   EgovSecurityConfigReaderTest.testReadConfigKeepsSafeDefaultsForOmittedKeys:35 expected: <true> but was: <false>
[ERROR] Tests run: 2, Failures: 2, Errors: 0, Skipped: 0
```

수정본(GREEN, 신규 테스트만 격리 실행)
```
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.221 s -- in org.egovframe.rte.fdl.security.config.EgovSecurityConfigReaderTest
```

수정본(GREEN, 모듈 전체 회귀)
```
[INFO] Tests run: 25, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```


