### PR TITLE
fix: SecuredObjectServiceImpl의 requestMatcherType 기본값 'ant'가 DAO 미지원이라 ClassCastException을 내는 문제 수정

### DIFF
--- a/Foundation/org.egovframe.rte.fdl.security/src/main/java/org/egovframe/rte/fdl/security/secureobject/impl/SecuredObjectServiceImpl.java
+++ b/Foundation/org.egovframe.rte.fdl.security/src/main/java/org/egovframe/rte/fdl/security/secureobject/impl/SecuredObjectServiceImpl.java
@@ -46,7 +46,7 @@ public class SecuredObjectServiceImpl implements EgovSecuredObjectService {
 
     private final EgovSecurityConfig config;
     private SecuredObjectDAO securedObjectDAO;
-    private String requestMatcherType = "ant";    // default
+    private String requestMatcherType = "regex";    // default
 
     public SecuredObjectServiceImpl(EgovSecurityConfig config) {
         this.config = config;

--- a/Foundation/org.egovframe.rte.fdl.security/src/test/java/org/egovframe/rte/fdl/security/secureobject/impl/SecuredObjectServiceImplTest.java
+++ b/Foundation/org.egovframe.rte.fdl.security/src/test/java/org/egovframe/rte/fdl/security/secureobject/impl/SecuredObjectServiceImplTest.java
@@ -1,0 +1,48 @@
+package org.egovframe.rte.fdl.security.secureobject.impl;
+
+import org.egovframe.rte.fdl.security.config.EgovSecurityConfig;
+import org.egovframe.rte.fdl.security.config.EgovSecurityConfiguration;
+import org.egovframe.rte.fdl.security.config.EgovSecurityTestConfig;
+import org.egovframe.rte.fdl.security.config.EgovSecurityTestDatasource;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import javax.sql.DataSource;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+@ExtendWith(SpringExtension.class)
+// EgovSecurityServiceTest와 동일한 컨텍스트 클래스 조합을 써서 Spring 테스트 컨텍스트 캐시를 공유한다.
+// 다른 조합을 쓰면 같은 in-memory HSQLDB URL에 두 번째 DataSource가 만들어져 testdb.sql의
+// CREATE TABLE이 "object name already exists"로 실패한다.
+@ContextConfiguration(classes = { EgovSecurityTestDatasource.class, EgovSecurityConfiguration.class, EgovSecurityTestConfig.class })
+public class SecuredObjectServiceImplTest {
+
+    @Autowired
+    private DataSource dataSource;
+
+    @Test
+    public void testGetRolesAndUrlWithDefaultRequestMatcherType() {
+        // requestMatcherType을 지정하지 않은 EgovSecurityConfig — properties 파일에
+        // 이 키를 안 적으면 SecuredObjectServiceImpl 자신의 필드 기본값("ant")이 그대로 쓰인다.
+        EgovSecurityConfig config = new EgovSecurityConfig();
+
+        SecuredObjectDAO dao = new SecuredObjectDAO(config);
+        dao.setDataSource(dataSource);
+        dao.setSqlRolesAndUrl(
+                "SELECT r.ROLE_PTTRN AS url, a.AUTHOR_CODE AS authority "
+                        + "FROM ROLES r INNER JOIN AUTHROLES a ON r.ROLE_CODE = a.ROLE_CODE ORDER BY r.ROLE_SORT");
+
+        SecuredObjectServiceImpl service = new SecuredObjectServiceImpl(config);
+        service.setSecuredObjectDAO(dao);
+
+        // SecuredObjectDAO는 "regex"/"ciRegex"만 RequestMatcher를 만들고 그 외("ant" 포함)엔
+        // 순수 String을 반환하는데, SecuredObjectServiceImpl.getRolesAndUrl()은 무조건
+        // (RequestMatcher) key로 캐스팅해 ClassCastException이 난다.
+        assertDoesNotThrow(service::getRolesAndUrl);
+    }
+
+}


### PR DESCRIPTION
## 수정 사유

- [x] 버그수정
- [ ] 기능개선
- [ ] 리팩터링

## 변경 이유

`SecuredObjectServiceImpl`의 `requestMatcherType` 필드 기본값은 `"ant"`이지만 실제 조회를 수행하는 형제 클래스 `SecuredObjectDAO.getRolesAndResources()`는 `"regex"`/`"ciRegex"`만 실제 `RequestMatcher`(`SelfRegexRequestMatcher`)를 만들고 그 외 값은 순수 `String`을 반환합니다.

```java
// SecuredObjectServiceImpl.java
private String requestMatcherType = "ant";    // default
```

```java
// SecuredObjectDAO.getRolesAndResources()
if (requestMatcherType != null && requestMatcherType.equalsIgnoreCase("regex")) {
    presentResource = new SelfRegexRequestMatcher(presentResourceStr, null);
} else if (requestMatcherType != null && requestMatcherType.equalsIgnoreCase("ciRegex")) {
    presentResource = new SelfRegexRequestMatcher(presentResourceStr, null, true);
} else {
    presentResource = presentResourceStr;   // "ant"를 포함해 이 분기로 떨어짐
}
```

```java
// SecuredObjectServiceImpl.getRolesAndUrl()
for (Object key : keys) {
    ret.put((RequestMatcher) key, data.get(key));   // String을 RequestMatcher로 무조건 캐스팅
}
```

`requestMatcherType`은 `config.getRequestMatcherType()`이 null이 아닐 때만 그 값으로 덮입니다(60~61줄). properties 파일에 이 키를 명시하지 않았거나 `EgovSecurityConfig`를 직접 만들어 쓰면 기본값 `"ant"`가 그대로 쓰여 `ClassCastException`이 발생합니다.

이 값이 예전엔 실제로 지원됐습니다. v4.1.0(`1da6c02`)의 구 `SecuredObjectDAO`(당시 패키지 `securedobject`)는 `AntPathRequestMatcher`를 import해 else 분기에서 `new AntPathRequestMatcher(presentResourceStr)`를 만들었습니다. v5.0.0 FINAL(`4d97ab5`)에서 패키지가 `securedobject`→`secureobject`로 재편되며 Spring Security 6.x 대응 과정에서 이 분기가 사라졌는데 `SecuredObjectServiceImpl`의 기본값은 `"ant"`로 남았습니다. DAO 상단 주석 "Only resourceType 'url' is supported in Spring Security 6.x"이 그 흔적입니다.

## 변경 내용

`requestMatcherType` 기본값을 DAO가 실제 지원하는 `"regex"`로 바꿨습니다. 같은 모듈의 `EgovAccessConfigReader.createDefaultConfig()`·`EgovSecurityConfigReader.createDefaultConfig()`(#312) 둘 다 `requestMatcherType`을 `"regex"`로 설정합니다. 이 값이 이 모듈의 사실상 표준 기본값입니다.

AS-IS
```java
private String requestMatcherType = "ant";    // default
```

TO-BE
```java
private String requestMatcherType = "regex";    // default
```

명시적으로 `requestMatcherType=ant`를 지정하는 경우는 이번 수정 범위 밖입니다(그 경우 여전히 `ClassCastException`이 납니다) — 다만 `"ant"`를 유효한 값으로 문서화한 곳이 없어(README는 `RequestMatcherTypeFactoryBean`이라는 무관한 빈을 설명하며 "ant/regex 등"이라는 일반론적 예시만 남아있음) 별도 이슈로 다룰 사안입니다.

## 영향 범위

`SecuredObjectServiceImpl.java`와 신규 테스트 파일만 변경했습니다. `codegraph callers`로 확인한 실사용 경로는 `EgovReloadableFilterInvocationSecurityMetadataSource.reload()`와 `UrlResourcesMapFactoryBean.init()` 두 곳입니다. `UrlResourcesMapFactoryBean`은 `FactoryBean`이라 Spring이 기본적으로 즉시(eager) 초기화하므로 `requestMatcherType`이 미설정인 배포는 컨텍스트 기동 시점에 이미 100% `ClassCastException`으로 죽어 있었습니다. `"regex"`로 바꾼다고 새로운 위험이 생기는 게 아니라, 항상 죽어 있던 경로가 되살아나는 방향입니다. 명시적으로 `"regex"`나 `"ciRegex"`를 지정한 배포는 이번 수정으로 영향받지 않습니다.

## 테스트 방법

가설: `requestMatcherType`을 지정하지 않은 `EgovSecurityConfig`로 `SecuredObjectServiceImpl.getRolesAndUrl()`을 호출하면, 미수정 상태는 `ClassCastException`이 나고 수정본은 정상적으로 완료된다.

검증 방법: `SecuredObjectServiceImplTest`는 기존 `EgovSecurityServiceTest`와 동일한 Spring 테스트 컨텍스트 조합(`EgovSecurityTestDatasource`+`EgovSecurityConfiguration`+`EgovSecurityTestConfig`, in-memory HSQLDB에 `testdb.sql`로 ROLES/AUTHROLES 데이터 적재)을 재사용합니다. 여기서 `new EgovSecurityConfig()`(requestMatcherType 미설정)로 `SecuredObjectDAO`+`SecuredObjectServiceImpl`을 직접 구성하고 `getRolesAndUrl()`을 호출합니다. 수정 전/후 상태를 소스 라인만 토글해 같은 테스트를 각각 실행했습니다.

미수정(RED)
```
[ERROR] SecuredObjectServiceImplTest.testGetRolesAndUrlWithDefaultRequestMatcherType:40 Unexpected exception thrown: java.lang.ClassCastException: class java.lang.String cannot be cast to class org.springframework.security.web.util.matcher.RequestMatcher (java.lang.String is in module java.base of loader 'bootstrap'; org.springframework.security.web.util.matcher.RequestMatcher is in unnamed module of loader 'app')
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0
```

수정본(GREEN, 신규 테스트만 격리 실행)
```
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.734 s -- in org.egovframe.rte.fdl.security.secureobject.impl.SecuredObjectServiceImplTest
```

수정본(GREEN, 모듈 전체 회귀)
```
[INFO] Tests run: 24, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```

