### PR TITLE
fix: sqlHierarchicalRoles 미설정 시 roleHierarchy()가 null을 반환해 로그인이 NPE로 죽는 문제 수정

### DIFF
--- a/Foundation/org.egovframe.rte.fdl.security/src/main/java/org/egovframe/rte/fdl/security/config/EgovSecurityConfiguration.java
+++ b/Foundation/org.egovframe.rte.fdl.security/src/main/java/org/egovframe/rte/fdl/security/config/EgovSecurityConfiguration.java
@@ -26,7 +26,6 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.lang.Nullable;
 import org.springframework.security.access.AccessDecisionManager;
 import org.springframework.security.access.ConfigAttribute;
 import org.springframework.security.access.hierarchicalroles.RoleHierarchy;
@@ -296,12 +295,12 @@ public class EgovSecurityConfiguration {
     }
 
     /**
-     * Role Hierarchy
+     * Role Hierarchy.
+     * sqlHierarchicalRoles 미설정 시에도 hierarchyStrings()가(HierarchyStringsFactoryBean 경유)
+     * 안전 기본값("ROLE_ADMIN > ROLE_USER > ROLE_ANONYMOUS")을 반환하므로 null을 반환하지 않는다.
      */
     @Bean
-    @Nullable
     public RoleHierarchy roleHierarchy(EgovSecurityConfig securityConfig) {
-        if (ObjectUtils.isEmpty(securityConfig.getSqlHierarchicalRoles())) return null;
         RoleHierarchyImpl hierarchy = new RoleHierarchyImpl();
         hierarchy.setHierarchy(hierarchyStrings(securityConfig));
         return hierarchy;

--- a/Foundation/org.egovframe.rte.fdl.security/src/test/java/org/egovframe/rte/fdl/security/config/EgovSecurityConfigurationRoleHierarchyTest.java
+++ b/Foundation/org.egovframe.rte.fdl.security/src/test/java/org/egovframe/rte/fdl/security/config/EgovSecurityConfigurationRoleHierarchyTest.java
@@ -1,0 +1,120 @@
+package org.egovframe.rte.fdl.security.config;
+
+import org.apache.commons.dbcp2.BasicDataSource;
+import org.egovframe.rte.fdl.security.userdetails.jdbc.EgovJdbcUserDetailsManager;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.jdbc.datasource.init.ScriptUtils;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import javax.sql.DataSource;
+import java.sql.Connection;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+/**
+ * sqlHierarchicalRoles를 설정하지 않은 배포(DB 기반 role hierarchy 미사용)에서
+ * 로그인 경로가 NPE 없이 동작하는지 검증.
+ *
+ * EgovSecurityTestDatasource(공유 in-memory HSQLDB "testdb")를 그대로 재사용하면
+ * 이 클래스만의 다른 컨텍스트 클래스 조합 때문에 Spring 테스트 컨텍스트 캐시가 갈려
+ * 같은 HSQLDB URL에 testdb.sql이 두 번 실행되어 "object name already exists"로
+ * 깨진다. 그래서 이 테스트 전용의 독립된 in-memory DB를 따로 띄운다.
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = {
+        EgovSecurityConfigurationRoleHierarchyTest.IsolatedTestDatasource.class,
+        EgovSecurityConfiguration.class,
+        EgovSecurityConfigurationRoleHierarchyTest.NoHierarchyConfig.class
+})
+public class EgovSecurityConfigurationRoleHierarchyTest {
+
+    @Autowired
+    private EgovJdbcUserDetailsManager jdbcUserService;
+
+    @Test
+    public void testLoadUserByUsernameWorksWithoutSqlHierarchicalRoles() {
+        // HierarchyStringsFactoryBean.getObject()는 sqlHierarchicalRoles 미설정 시
+        // 안전 기본값("ROLE_ADMIN > ROLE_USER > ROLE_ANONYMOUS")을 반환하도록 이미 구현돼 있다.
+        // roleHierarchy()가 이 기본값을 거치지 않고 조기에 null을 반환하면
+        // EgovJdbcUserDetailsManager.loadUserByUsername()이 NPE로 죽는다.
+        assertDoesNotThrow(() -> jdbcUserService.loadUserByUsername("user"));
+    }
+
+    @Configuration
+    static class IsolatedTestDatasource {
+
+        @Bean(name = "dataSource")
+        public DataSource dataSource() {
+            BasicDataSource ds = new BasicDataSource();
+            ds.setDriverClassName("org.hsqldb.jdbcDriver");
+            ds.setUrl("jdbc:hsqldb:mem:rolehierarchytestdb");
+            ds.setUsername("sa");
+            ds.setPassword("");
+            ds.setDefaultAutoCommit(true);
+            ds.setPoolPreparedStatements(true);
+
+            try (Connection conn = ds.getConnection()) {
+                ScriptUtils.executeSqlScript(conn, new ClassPathResource("META-INF/testdata/testdb.sql"));
+            } catch (Exception e) {
+                throw new IllegalStateException("Isolated test database initialization failed", e);
+            }
+
+            return ds;
+        }
+    }
+
+    @Configuration
+    static class NoHierarchyConfig {
+
+        @Bean
+        @Primary
+        public EgovSecurityConfig egovSecurityConfig() {
+            // src/test/resources/egovframework/conf/egov-security-config.properties와
+            // 동일한 필드 구성(EgovSecurityConfiguration의 securityFilterChain() 전체가
+            // 정상적으로 뜨려면 sqlRolesAndUrl 등도 HSQLDB 테스트 스키마와 맞아야 한다) —
+            // 단 sqlHierarchicalRoles만 의도적으로 비워서 재현 대상 시나리오를 만든다.
+            EgovSecurityConfig config = new EgovSecurityConfig();
+            config.setId("noHierarchyConfig");
+            config.setLoginUrl("/uat/uia/egovLoginUsr.do");
+            config.setLoginProcessUrl("/uat/uia/actionSecurityProcess.do");
+            config.setLogoutUrl("/uat/uia/actionSecurityLogout.do");
+            config.setLogoutSuccessUrl("/uat/uia/egovLoginUsr.do");
+            config.setLoginFailureUrl("/uat/uia/egovLoginUsr.do?login_error=1");
+            config.setAccessDeniedUrl("/sec/ram/accessDenied.do");
+            config.setDataSource("dataSource");
+            config.setJdbcUsersByUsernameQuery(
+                    "SELECT USER_ID, USER_PASSWORD AS PASSWORD, ENABLED, USER_NAME, BIRTH_DAY, SSN FROM USERS WHERE USER_ID = ?");
+            config.setJdbcAuthoritiesByUsernameQuery(
+                    "SELECT USER_ID, AUTHOR_CODE AS AUTHORITY FROM AUTHORITIES WHERE USER_ID = ?");
+            config.setJdbcMapClass("org.egovframe.rte.fdl.security.userdetails.EgovUserDetailsMapping");
+            config.setRequestMatcherType("regex");
+            config.setHash("egov-sha256");
+            config.setHashBase64(true);
+            config.setConcurrentMaxSessons(1);
+            config.setConcurrentExpiredUrl("/EgovContent.do");
+            config.setErrorIfMaximumExceeded(false);
+            config.setDefaultTargetUrl("/EgovContent.do");
+            config.setAlwaysUseDefaultTargetUrl(true);
+            config.setSniff(true);
+            config.setXframeOptions("SAMEORIGIN");
+            config.setXssProtection(true);
+            config.setCacheControl(false);
+            config.setCsrf(false);
+            config.setPermitAllList(
+                    "/css/**,/js/**,/images/**,/resource/**,/public/**,/uat/uia/**,/index.do,/EgovContent.do,/sec/ram/accessDenied.do,/sale/**");
+            config.setSqlRolesAndUrl(
+                    "SELECT r.ROLE_PTTRN AS url, a.AUTHOR_CODE AS authority "
+                            + "FROM ROLES r INNER JOIN AUTHROLES a ON r.ROLE_CODE = a.ROLE_CODE ORDER BY r.ROLE_SORT");
+            // sqlHierarchicalRoles는 의도적으로 미설정 — 재현 대상 시나리오.
+            return config;
+        }
+    }
+
+}


### PR DESCRIPTION
## 수정 사유

- [x] 버그수정
- [ ] 기능개선
- [ ] 리팩터링

## 변경 이유

`EgovSecurityConfiguration.roleHierarchy()`는 `sqlHierarchicalRoles`가 비어있으면 `null`을 조기 반환합니다.

```java
@Bean
@Nullable
public RoleHierarchy roleHierarchy(EgovSecurityConfig securityConfig) {
    if (ObjectUtils.isEmpty(securityConfig.getSqlHierarchicalRoles())) return null;
    RoleHierarchyImpl hierarchy = new RoleHierarchyImpl();
    hierarchy.setHierarchy(hierarchyStrings(securityConfig));
    return hierarchy;
}
```

같은 모듈의 `HierarchyStringsFactoryBean.getObject()`에는 정확히 이 상황(`sqlHierarchicalRoles` 미설정)에 대비한 안전 기본값이 이미 있습니다.

```java
// HierarchyStringsFactoryBean.getObject()
if (StringUtils.hasText(config.getSqlHierarchicalRoles())) {
    return securedObjectService.getHierarchicalRoles();
}
return ROLE_HIERARCHY_STRING;   // "ROLE_ADMIN > ROLE_USER > ROLE_ANONYMOUS"
```

`roleHierarchy()`가 먼저 null을 반환하는 탓에 이 기본값 로직까지 가지 못합니다. 두 소비자는 null을 검사하지 않고 무조건 호출합니다.

```java
// EgovSecurityConfiguration — authenticationManager()
GrantedAuthoritiesMapper mapper = new RoleHierarchyAuthoritiesMapper(roleHierarchy(securityConfig));
```

```java
// EgovJdbcUserDetailsManager.loadUserByUsername()
Collection<? extends GrantedAuthority> authorities = roleHierarchy.getReachableGrantedAuthorities(dbAuths);
```

`RoleHierarchyAuthoritiesMapper`(Spring Security 자체 클래스)의 생성자·`mapAuthorities()`도 null 체크가 없어(바이트코드로 직접 확인), `sqlHierarchicalRoles`를 설정하지 않은 배포는 로그인마다 `NullPointerException`이 납니다. `createDefaultConfig()`도 이 필드를 설정하지 않으므로 기본 배포도 영향받습니다.

이 기본값 배선은 원래 정책이었습니다. v4.1.0의 XML 설정(`security-config.xml`)은 `sqlHierarchicalRoles` 설정 여부와 무관하게 `roleHierarchy` 빈을 항상 `hierarchyStrings`(`HierarchyStringsFactoryBean`) 참조로 배선했습니다.

```xml
<beans:bean id="roleHierarchy" class="org.springframework.security.access.hierarchicalroles.RoleHierarchyImpl">
    ...
    <beans:property name="hierarchy" ref="hierarchyStrings" />
</beans:bean>
<beans:bean id="hierarchyStrings" class="org.egovframe.rte.fdl.security.userdetails.hierarchicalroles.HierarchyStringsFactoryBean" init-method="init">
```

조기 null 반환은 v5.0.0의 Java Config 전면 재작성에서 처음 등장했습니다 — 새 정책이 아니라 재작성 과정에서 생긴 회귀입니다.

## 변경 내용

`roleHierarchy()`의 조기 null 반환 분기를 제거해 언제나 `hierarchyStrings(securityConfig)`(안전 기본값이 이미 있는)를 거치도록 고쳤습니다. 더 이상 null을 반환하지 않으므로 `@Nullable` 애노테이션도 제거했습니다.

AS-IS
```java
@Bean
@Nullable
public RoleHierarchy roleHierarchy(EgovSecurityConfig securityConfig) {
    if (ObjectUtils.isEmpty(securityConfig.getSqlHierarchicalRoles())) return null;
    RoleHierarchyImpl hierarchy = new RoleHierarchyImpl();
    hierarchy.setHierarchy(hierarchyStrings(securityConfig));
    return hierarchy;
}
```

TO-BE
```java
@Bean
public RoleHierarchy roleHierarchy(EgovSecurityConfig securityConfig) {
    RoleHierarchyImpl hierarchy = new RoleHierarchyImpl();
    hierarchy.setHierarchy(hierarchyStrings(securityConfig));
    return hierarchy;
}
```

`sqlHierarchicalRoles`가 **설정된** 경로는 `HierarchyStringsFactoryBean.getObject()`의 `StringUtils.hasText(...)` 분기가 그대로 유지되어 전혀 영향받지 않습니다.

## 영향 범위

`EgovSecurityConfiguration.java`와 신규 테스트 파일만 변경했습니다. `codegraph callers`로 확인한 `roleHierarchy()`의 실제 소비자는 `authenticationManager()`·`jdbcUserService()` 두 곳뿐이며 둘 다 이번 수정으로 함께 고쳐집니다. `sqlHierarchicalRoles`를 명시적으로 설정한 배포(기존 테스트가 쓰는 배포 포함)는 영향받지 않습니다. `sqlHierarchicalRoles`를 설정하지 않은 배포는 로그인 자체가 항상 NPE로 실패하던 상태였으므로, 이번 수정으로 새로운 권한 상승 등의 위험이 생기는 게 아니라 원래 정책(XML 시절부터 이어진 기본 계층)으로 로그인이 되살아나는 방향입니다.

## 테스트 방법

가설: `sqlHierarchicalRoles`를 지정하지 않은 `EgovSecurityConfig`로 로그인 경로(`EgovJdbcUserDetailsManager.loadUserByUsername()`)를 타면, 미수정 상태는 `NullPointerException`이 나고 수정본은 정상적으로 완료된다.

검증 방법: `EgovSecurityConfigurationRoleHierarchyTest`가 `sqlHierarchicalRoles`만 의도적으로 비운 `EgovSecurityConfig`(다른 필드는 기존 테스트 리소스와 동일하게 구성)로 `EgovSecurityConfiguration`을 실제로 띄우고 `EgovJdbcUserDetailsManager.loadUserByUsername("user")`를 호출합니다. 공유 HSQLDB("testdb")와 Spring 테스트 컨텍스트 캐시 충돌을 피하기 위해 이 테스트 전용의 독립된 in-memory DB("rolehierarchytestdb")를 구성해 `testdb.sql`을 그대로 적재했습니다. 수정 전/후 상태를 소스 라인만 토글해 같은 테스트를 각각 실행했습니다.

미수정(RED)
```
[ERROR] EgovSecurityConfigurationRoleHierarchyTest.testLoadUserByUsernameWorksWithoutSqlHierarchicalRoles:47 Unexpected exception thrown: java.lang.NullPointerException: Cannot invoke "org.springframework.security.access.hierarchicalroles.RoleHierarchy.getReachableGrantedAuthorities(java.util.Collection)" because "this.roleHierarchy" is null
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0
```

수정본(GREEN, 신규 테스트만 격리 실행)
```
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.790 s -- in org.egovframe.rte.fdl.security.config.EgovSecurityConfigurationRoleHierarchyTest
```

수정본(GREEN, 모듈 전체 회귀)
```
[INFO] Tests run: 24, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```

