### PR TITLE
fix: EgovRedisConfiguration이 검증하는 connectTimeout/커넥션 풀 설정이 실제 연결 생성에 반영되지 않는 문제 수정

### DIFF
--- a/Persistence/org.egovframe.rte.psl.reactive.redis/pom.xml
+++ b/Persistence/org.egovframe.rte.psl.reactive.redis/pom.xml
@@ -33,6 +33,7 @@
         <slf4j.version>2.0.17</slf4j.version>
         <easymock.version>5.3.0</easymock.version>
         <lombok.version>1.18.42</lombok.version>
+        <commons-pool2.version>2.12.1</commons-pool2.version>
     </properties>
 
     <repositories>
@@ -110,6 +111,11 @@
             <groupId>io.lettuce</groupId>
             <artifactId>lettuce-core</artifactId>
             <version>${lettuce.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-pool2</artifactId>
+            <version>${commons-pool2.version}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/Persistence/org.egovframe.rte.psl.reactive.redis/src/main/java/org/egovframe/rte/psl/reactive/redis/connect/EgovRedisConfiguration.java
+++ b/Persistence/org.egovframe.rte.psl.reactive.redis/src/main/java/org/egovframe/rte/psl/reactive/redis/connect/EgovRedisConfiguration.java
@@ -15,9 +15,13 @@
  */
 package org.egovframe.rte.psl.reactive.redis.connect;
 
+import io.lettuce.core.ClientOptions;
+import io.lettuce.core.SocketOptions;
+import io.lettuce.core.api.StatefulConnection;
+import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
 import org.springframework.data.redis.connection.ReactiveRedisConnectionFactory;
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
-import org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettucePoolingClientConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 
 import java.time.Duration;
@@ -123,16 +127,18 @@ public class EgovRedisConfiguration {
             redisStandaloneConfiguration.setPassword(password);
         }
         
-        // Lettuce 클라이언트 설정
-        LettuceClientConfiguration clientConfig = LettuceClientConfiguration.builder()
+        // Lettuce 클라이언트 설정 (연결 타임아웃 + 커넥션 풀 적용)
+        LettucePoolingClientConfiguration clientConfig = LettucePoolingClientConfiguration.builder()
+                .clientOptions(clientOptions())
                 .commandTimeout(commandTimeout)
                 .shutdownTimeout(Duration.ofSeconds(2))
+                .poolConfig(poolConfig())
                 .build();
-        
+
         LettuceConnectionFactory connectionFactory = new LettuceConnectionFactory(redisStandaloneConfiguration, clientConfig);
         connectionFactory.setValidateConnection(true);
         connectionFactory.setShareNativeConnection(false);
-        
+
         return connectionFactory;
     }
 
@@ -149,18 +155,34 @@ public class EgovRedisConfiguration {
             redisStandaloneConfiguration.setPassword(password);
         }
         
-        // Lettuce 클라이언트 설정 (SSL 포함)
-        LettuceClientConfiguration clientConfig = LettuceClientConfiguration.builder()
+        // Lettuce 클라이언트 설정 (연결 타임아웃 + 커넥션 풀 + SSL 적용)
+        LettucePoolingClientConfiguration clientConfig = LettucePoolingClientConfiguration.builder()
+                .clientOptions(clientOptions())
                 .commandTimeout(commandTimeout)
                 .shutdownTimeout(Duration.ofSeconds(2))
+                .poolConfig(poolConfig())
                 .useSsl()
                 .build();
-        
+
         LettuceConnectionFactory connectionFactory = new LettuceConnectionFactory(redisStandaloneConfiguration, clientConfig);
         connectionFactory.setValidateConnection(true);
         connectionFactory.setShareNativeConnection(false);
-        
+
         return connectionFactory;
+    }
+
+    private ClientOptions clientOptions() {
+        return ClientOptions.builder()
+                .socketOptions(SocketOptions.builder().connectTimeout(connectTimeout).build())
+                .build();
+    }
+
+    private GenericObjectPoolConfig<StatefulConnection<?, ?>> poolConfig() {
+        GenericObjectPoolConfig<StatefulConnection<?, ?>> poolConfig = new GenericObjectPoolConfig<>();
+        poolConfig.setMaxTotal(maxActive);
+        poolConfig.setMaxIdle(maxIdle);
+        poolConfig.setMinIdle(minIdle);
+        return poolConfig;
     }
 
     /**

--- a/Persistence/org.egovframe.rte.psl.reactive.redis/src/test/java/org/egovframe/rte/psl/reactive/redis/connect/EgovRedisConfigurationTest.java
+++ b/Persistence/org.egovframe.rte.psl.reactive.redis/src/test/java/org/egovframe/rte/psl/reactive/redis/connect/EgovRedisConfigurationTest.java
@@ -1,0 +1,50 @@
+package org.egovframe.rte.psl.reactive.redis.connect;
+
+import io.lettuce.core.SocketOptions;
+import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.redis.connection.ReactiveRedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettucePoolingClientConfiguration;
+
+import java.time.Duration;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+public class EgovRedisConfigurationTest {
+
+    @Test
+    public void reactiveRedisConnectionFactory_appliesConnectTimeout() {
+        Duration customConnectTimeout = Duration.ofMillis(1234);
+        EgovRedisConfiguration config = new EgovRedisConfiguration(
+                "localhost", 6379, null, false,
+                customConnectTimeout, Duration.ofSeconds(5), 8, 8, 0);
+
+        LettuceConnectionFactory factory = (LettuceConnectionFactory) config.reactiveRedisConnectionFactory();
+        LettuceClientConfiguration clientConfiguration = factory.getClientConfiguration();
+        SocketOptions socketOptions = clientConfiguration.getClientOptions()
+                .orElseThrow(() -> new AssertionError("ClientOptions must be set"))
+                .getSocketOptions();
+
+        assertEquals(customConnectTimeout, socketOptions.getConnectTimeout());
+    }
+
+    @Test
+    public void reactiveRedisConnectionFactory_appliesPoolSettings() {
+        EgovRedisConfiguration config = new EgovRedisConfiguration(
+                "localhost", 6379, null, false,
+                Duration.ofSeconds(10), Duration.ofSeconds(5), 20, 15, 5);
+
+        LettuceConnectionFactory factory = (LettuceConnectionFactory) config.reactiveRedisConnectionFactory();
+        LettuceClientConfiguration clientConfiguration = factory.getClientConfiguration();
+
+        assertInstanceOf(LettucePoolingClientConfiguration.class, clientConfiguration);
+        GenericObjectPoolConfig<?> poolConfig = ((LettucePoolingClientConfiguration) clientConfiguration).getPoolConfig();
+        assertEquals(20, poolConfig.getMaxTotal());
+        assertEquals(15, poolConfig.getMaxIdle());
+        assertEquals(5, poolConfig.getMinIdle());
+    }
+
+}


### PR DESCRIPTION
## 수정 사유

- [x] 버그수정
- [ ] 기능개선
- [ ] 리팩터링

## 변경 이유

`EgovRedisConfiguration`의 전체 설정 생성자는 `connectTimeout`·`maxActive`·`maxIdle`·`minIdle` 4개 값을 받아 엄격히 검증합니다.

```java
public EgovRedisConfiguration(String host, int port, String password, boolean useSsl,
                             Duration connectTimeout, Duration commandTimeout,
                             int maxActive, int maxIdle, int minIdle) {
    ...
    if (connectTimeout == null || connectTimeout.isNegative()) {
        throw new IllegalArgumentException("Connect timeout cannot be null or negative");
    }
    ...
    if (maxActive <= 0) {
        throw new IllegalArgumentException("Max active connections must be positive");
    }
    if (maxIdle < 0) {
        throw new IllegalArgumentException("Max idle connections cannot be negative");
    }
    if (minIdle < 0) {
        throw new IllegalArgumentException("Min idle connections cannot be negative");
    }
    ...
}
```

`getConfigurationInfo()`도 이 값들을 "현재 설정"으로 노출합니다.

```java
public String getConfigurationInfo() {
    return String.format("Redis Configuration - Host: %s, Port: %d, SSL: %s, MaxActive: %d, MaxIdle: %d, MinIdle: %d",
            host, port, useSsl, maxActive, maxIdle, minIdle);
}
```

그런데 실제 연결을 만드는 `reactiveRedisConnectionFactory()`는 이 4개 값 중 `commandTimeout`만 씁니다.

```java
LettuceClientConfiguration clientConfig = LettuceClientConfiguration.builder()
        .commandTimeout(commandTimeout)
        .shutdownTimeout(Duration.ofSeconds(2))
        .build();
```

`connectTimeout`은 `ClientOptions`에 전달된 적이 없어 io.lettuce 기본값(10초)이 항상 적용됩니다. `maxActive`/`maxIdle`/`minIdle`은 애초에 커넥션 풀(`LettucePoolingClientConfiguration`)을 쓰지 않으니 반영될 자리 자체가 없습니다. `reactiveRedisConnectionFactoryWithSsl()`도 동일합니다.

이 4개 필드와 그 검증 로직은 v5.0.0 Java Config 전면 재작성 커밋에서 처음 생겼습니다(`git diff 08cb972 4d97ab5`로 확인 — v4.3.0에는 `host`/`port`/`password`만 있었습니다). **검증 로직과, 그 값을 무시하는 팩토리 로직이 같은 커밋의 같은 파일에서 동시에 작성됐습니다.** 별도 TODO나 "추후 확장" 커밋 메시지도 없습니다. 같은 저자·같은 라이선스 헤더를 쓰는 형제 모듈 `EgovCassandraConfiguration`(`Persistence/org.egovframe.rte.psl.reactive.cassandra`)은 선언한 필드(`dataCenterName`·`keyspaceName`·`contactPoint`·`port`·`username`·`password`) 전부를 실제 `reactiveSession()`에서 소비합니다 — "검증만 하고 안 쓰는" 패턴은 이 프로젝트의 관례가 아니라 Redis 클래스에서만 나타나는 예외입니다.

## 변경 내용

`LettuceClientConfiguration` 대신 `LettucePoolingClientConfiguration`을 써서 `connectTimeout`(`ClientOptions`의 `SocketOptions`)과 커넥션 풀(`GenericObjectPoolConfig`)을 실제로 배선했습니다. 두 팩토리 메서드(SSL 포함/미포함) 모두 동일하게 고쳤습니다.

AS-IS
```java
LettuceClientConfiguration clientConfig = LettuceClientConfiguration.builder()
        .commandTimeout(commandTimeout)
        .shutdownTimeout(Duration.ofSeconds(2))
        .build();
```

TO-BE
```java
LettucePoolingClientConfiguration clientConfig = LettucePoolingClientConfiguration.builder()
        .clientOptions(clientOptions())
        .commandTimeout(commandTimeout)
        .shutdownTimeout(Duration.ofSeconds(2))
        .poolConfig(poolConfig())
        .build();
```

```java
private ClientOptions clientOptions() {
    return ClientOptions.builder()
            .socketOptions(SocketOptions.builder().connectTimeout(connectTimeout).build())
            .build();
}

private GenericObjectPoolConfig<StatefulConnection<?, ?>> poolConfig() {
    GenericObjectPoolConfig<StatefulConnection<?, ?>> poolConfig = new GenericObjectPoolConfig<>();
    poolConfig.setMaxTotal(maxActive);
    poolConfig.setMaxIdle(maxIdle);
    poolConfig.setMinIdle(minIdle);
    return poolConfig;
}
```

`LettucePoolingClientConfiguration.poolConfig()`가 컴파일 타임에 `org.apache.commons.pool2.impl.GenericObjectPoolConfig`를 요구해 `commons-pool2`를 신규 의존성으로 추가했습니다(Spring Data Redis가 Lettuce 풀링을 쓰려면 공식 문서가 요구하는 표준 라이브러리입니다).

## 영향 범위

`commandTimeout`은 그대로 동작하므로 기존 사용에는 영향이 없습니다. 이번 수정으로 동작이 실제로 바뀌는 건 두 가지입니다.

1. **`connectTimeout`이 이제 진짜로 적용됩니다.** 기본 생성자(`connectTimeout=10초`)를 쓰는 경우는 io.lettuce 기본값과 같아 체감 변화가 없습니다. 전체 생성자로 다른 값(특히 더 짧은 값)을 직접 넘긴 경우에만 이제 그 값이 실제로 적용됩니다 — 검증만 하고 무시하던 값이 원래 계약대로 동작하게 됩니다.
2. **연결이 매번 새로 열리던 방식에서 커넥션 풀링 방식으로 바뀝니다.** 기본값(`maxActive=8, maxIdle=8, minIdle=0`)은 Apache Commons Pool2의 기본값과 사실상 같습니다. 다만 `GenericObjectPoolConfig`의 기본 `maxWaitMillis`는 -1(무한 대기)이므로 `maxActive`를 작게 설정한 배포에서 풀이 소진되면 연결 획득이 즉시 실패하는 대신 무기한 대기할 수 있습니다. 이는 커넥션 풀링을 쓰는 애플리케이션 일반의 표준 동작입니다. 새로 생기는 리스크라기보다는 애초에 `maxActive`를 설정한 목적(동시 연결 수 제한) 자체가 이제야 실제로 작동하는 것입니다.

`codegraph callers`로 확인한 이 클래스의 레포 내 실사용처는 테스트 설정(`RedisConfiguration.java`) 1곳뿐입니다. 라이브러리 모듈 특성상 실제 소비자는 이 프레임워크를 쓰는 다운스트림 애플리케이션입니다.

## 테스트 방법

가설: 전체 생성자로 `connectTimeout`/`maxActive`/`maxIdle`/`minIdle`에 기본값과 다른 값을 넘기고 `reactiveRedisConnectionFactory()`가 만든 `LettuceConnectionFactory`의 실제 클라이언트 설정을 들여다보면, 미수정 상태는 그 값들이 반영되지 않고(connectTimeout은 io.lettuce 기본값 10초, 풀링은 아예 미적용), 수정본은 반영된다.

검증 방법: `EgovRedisConfigurationTest`가 실제 `LettuceConnectionFactory.getClientConfiguration()`을 통해 (1) `SocketOptions.getConnectTimeout()` 값과 (2) 반환된 설정이 `LettucePoolingClientConfiguration`인지, 그 `GenericObjectPoolConfig`의 `maxTotal`/`maxIdle`/`minIdle`이 생성자 값과 일치하는지를 검증합니다. 별도 Redis 서버 연결 없이 순수하게 객체 그래프만 검증합니다.

미수정(RED)
```
[ERROR] Tests run: 2, Failures: 2, Errors: 0, Skipped: 0
[ERROR]   EgovRedisConfigurationTest.reactiveRedisConnectionFactory_appliesConnectTimeout:31 expected: <PT1.234S> but was: <PT10S>
[ERROR]   EgovRedisConfigurationTest.reactiveRedisConnectionFactory_appliesPoolSettings:43 Unexpected type, expected: <org.springframework.data.redis.connection.lettuce.LettucePoolingClientConfiguration> but was: <org.springframework.data.redis.connection.lettuce.DefaultLettuceClientConfiguration>
```

수정본(GREEN, 신규 테스트)
```
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0
```

수정본(GREEN, 모듈 전체 회귀 — 실제 Redis 컨테이너 기동 후 기존 CRUD 통합 테스트 24건 포함)
```
[INFO] Tests run: 26, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```

기존 `RedisTest`(값 설정·조회·증분·만료 등 24개 시나리오)가 새 풀링 연결 팩토리를 그대로 통해 실제 Redis에 대해 전부 통과해 이번 수정이 기존 CRUD 동작을 깨지 않음을 확인했습니다.

