### PR TITLE
fix: EgovMongoDbRepository의 deleteDate 메서드명 오타(형제 클래스는 전부 deleteData) 수정

### DIFF
--- a/Persistence/org.egovframe.rte.psl.data.mongodb/src/main/java/org/egovframe/rte/psl/data/mongodb/repository/EgovMongoDbRepository.java
+++ b/Persistence/org.egovframe.rte.psl.data.mongodb/src/main/java/org/egovframe/rte/psl/data/mongodb/repository/EgovMongoDbRepository.java
@@ -64,8 +64,16 @@ public class EgovMongoDbRepository<T> extends MongoTemplate {
         return findAndModify(query, update, entityClass);
     }
 
-    public T deleteDate(Query query, Class<T> entityClass) {
+    public T deleteData(Query query, Class<T> entityClass) {
         return findAndRemove(query, entityClass);
+    }
+
+    /**
+     * @deprecated 메서드명 오타(Date/Data)로 도입됐습니다. {@link #deleteData(Query, Class)}를 대신 사용하세요.
+     */
+    @Deprecated
+    public T deleteDate(Query query, Class<T> entityClass) {
+        return deleteData(query, entityClass);
     }
 
 }

--- a/Persistence/org.egovframe.rte.psl.data.mongodb/src/test/java/org/egovframe/rte/psl/data/mongodb/MongoDbTest.java
+++ b/Persistence/org.egovframe.rte.psl.data.mongodb/src/test/java/org/egovframe/rte/psl/data/mongodb/MongoDbTest.java
@@ -5,11 +5,14 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration(classes = MongoDbConfiguration.class)
@@ -53,6 +56,21 @@ public class MongoDbTest {
         assertEquals("Runtime Tool", newValue.getDescription());
         assertEquals("Y", newValue.getUseYn());
         assertEquals("eGov", newValue.getRegUser());
+    }
+
+    @Test
+    @SuppressWarnings("deprecation")
+    public void deprecatedDeleteDateStillDeletes() {
+        Sample sample = makeSample();
+
+        repository.deleteSample(sample);
+        repository.insertSample(sample);
+
+        Query query = new Query();
+        query.addCriteria(Criteria.where("id").is(sample.getId()));
+        repository.deleteDate(query, Sample.class);
+
+        assertNull(repository.selectOneSample(sample.getId()));
     }
 
 }

--- a/Persistence/org.egovframe.rte.psl.data.mongodb/src/test/java/org/egovframe/rte/psl/data/mongodb/SampleRepository.java
+++ b/Persistence/org.egovframe.rte.psl.data.mongodb/src/test/java/org/egovframe/rte/psl/data/mongodb/SampleRepository.java
@@ -57,7 +57,7 @@ public class SampleRepository extends EgovMongoDbRepository<Sample> {
     public Sample deleteSample(Sample sample) {
         Query query = new Query();
         query.addCriteria(Criteria.where("id").is(sample.getId()));
-        return deleteDate(query, Sample.class);
+        return deleteData(query, Sample.class);
     }
 
 }


### PR DESCRIPTION
## 수정 사유

- [x] 버그수정
- [ ] 기능개선
- [ ] 리팩터링

## 변경 이유

`EgovMongoDbRepository`의 메서드 이름은 `selectAllData`·`selectOneData`·`countData`·`insertData`·`updateData`·`deleteDate`입니다. 마지막 하나만 `Date`이고 나머지는 전부 `Data` 접미사입니다.

```java
public List<T> selectAllData(Query query, Class<T> entityClass) { ... }
public T selectOneData(Query query, Class<T> entityClass) { ... }
public long countData(Query query, Class<T> entityClass) { ... }
public T insertData(T objectToSave) { ... }
public T updateData(Query query, UpdateDefinition update, Class<T> entityClass) { ... }
public T deleteDate(Query query, Class<T> entityClass) {
    return findAndRemove(query, entityClass);
}
```

구현(`findAndRemove(query, entityClass)`)과 파라미터(다른 `*Data` 메서드와 동일한 `Query` 기반 조건)를 보면 "날짜 기준 삭제" 같은 특수 의미는 없고 범용 삭제입니다. v5.0.0 재작성 때 같은 패턴으로 새로 만든 형제 클래스들도 전부 `deleteData`로 일관됩니다.

```java
// EgovReactiveMongoDbRepository (Persistence/org.egovframe.rte.psl.reactive.mongodb)
public Mono<T> deleteData(Query query, Class<T> entityClass) { ... }

// EgovCassandraRepository / EgovR2dbcRepository
public Mono<T> deleteData(T entity) { ... }
```

`data.mongodb`만 `Date`로 어긋나 있습니다. `git log --follow`로 확인한 결과 이 파일은 v5.0.0에서 새로 추가됐고(`new file mode`) 처음부터 이 이름이었으며 "Date"를 의도했다는 커밋 메시지나 리팩터링 이력은 없습니다.

다만 이 클래스는 v5.0.0-Final(2026-05-18)·v5.0.1-FINAL(2026-07-29)로 이미 두 차례 릴리즈된 공개 API라, 단순 rename은 기존 사용자에게 breaking change가 됩니다.

## 변경 내용

실제 구현을 새 `deleteData`로 옮기고 기존 `deleteDate`는 `@Deprecated`로 남겨 `deleteData`에 위임하는 얇은 wrapper로 바꿔 하위 호환을 유지했습니다. 이 저장소에 이미 있는 `@Deprecated` + 위임 관례(`EgovAbstractMapper.selectByPk` 등)와 같은 방식입니다.

AS-IS
```java
public T deleteDate(Query query, Class<T> entityClass) {
    return findAndRemove(query, entityClass);
}
```

TO-BE
```java
public T deleteData(Query query, Class<T> entityClass) {
    return findAndRemove(query, entityClass);
}

/**
 * @deprecated 메서드명 오타(Date/Data)로 도입됐습니다. {@link #deleteData(Query, Class)}를 대신 사용하세요.
 */
@Deprecated
public T deleteDate(Query query, Class<T> entityClass) {
    return deleteData(query, entityClass);
}
```

레포 내부의 테스트 픽스처 `SampleRepository.deleteSample()`도 새 이름(`deleteData`)을 쓰도록 갱신해 저장소 자신도 새 이름으로 갈아탔습니다.

## 영향 범위

`deleteDate`를 이미 호출하던 기존 사용자는 그대로 동작합니다(내부적으로 `deleteData`에 위임할 뿐 로직은 완전히 동일). 새로 `deleteData`를 쓰는 사용자는 형제 모듈(`reactive.mongodb`/`reactive.cassandra`/`reactive.r2dbc`/`reactive.redis`)과 일관된 이름을 쓸 수 있습니다. `deleteDate`는 레포 전체에서 이 클래스 자신과 신규 테스트 외에 다른 호출처가 없어(`grep -rn "deleteDate"` 확인) 이번 수정이 레포 내 다른 코드에 영향을 주지 않습니다.

## 테스트 방법

가설: `deleteData`가 새로 추가되기 전에는 `SampleRepository`가 새 이름을 호출하도록 고치면 컴파일이 깨진다(메서드가 존재하지 않으므로). 추가한 뒤에는 컴파일되고 기존 `deleteDate` 호출자도 여전히 정상적으로 삭제가 수행돼야 한다.

검증 방법: 신규 `deleteData` 추가 전 상태로 `SampleRepository`(내부적으로 `deleteData` 호출)만 먼저 고쳐 컴파일 실패를 확인하고 수정 후 컴파일 성공 및 기존 `MongoDbTest.crudTest`(신규 이름 경유) 통과를 확인했습니다. 또한 하위 호환을 직접 증명하기 위해 `MongoDbTest`에 `deprecatedDeleteDateStillDeletes`를 추가해 `SampleRepository`를 거치지 않고 `repository.deleteDate(...)`를 **직접** 호출한 뒤 실제로 삭제됐는지 검증합니다.

미수정(RED, 컴파일 실패)
```
[ERROR] SampleRepository.java:[60,16] cannot find symbol
[ERROR]   symbol:   method deleteData(org.springframework.data.mongodb.core.query.Query,java.lang.Class<org.egovframe.rte.psl.data.mongodb.Sample>)
[ERROR]   location: class org.egovframe.rte.psl.data.mongodb.SampleRepository
```

수정본(GREEN, 모듈 전체 — 실제 MongoDB 컨테이너 기동)
```
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```

기존 `crudTest`(새 `deleteData` 경유)와 신규 `deprecatedDeleteDateStillDeletes`(옛 `deleteDate` 직접 호출) 둘 다 통과해 신규 이름과 하위 호환 위임 경로가 모두 실제로 동작함을 확인했습니다.




