### PR TITLE
fix: EgovAccessDeniedHandler가 접근거부 URL 미설정 시 예외를 던지는 문제 수정

### DIFF
--- a/Foundation/org.egovframe.rte.fdl.security/src/main/java/org/egovframe/rte/fdl/security/bean/EgovAccessDeniedHandler.java
+++ b/Foundation/org.egovframe.rte.fdl.security/src/main/java/org/egovframe/rte/fdl/security/bean/EgovAccessDeniedHandler.java
@@ -26,10 +26,13 @@ import org.springframework.security.web.access.AccessDeniedHandler;
 import org.springframework.security.web.csrf.InvalidCsrfTokenException;
 import org.springframework.security.web.csrf.MissingCsrfTokenException;
 import org.springframework.util.ObjectUtils;
+import org.springframework.util.StringUtils;
 
 import java.io.IOException;
 
 public class EgovAccessDeniedHandler implements AccessDeniedHandler {
+
+    private static final String DEFAULT_ACCESS_DENIED_URL = "/index.html";
 
     private final EgovSecurityConfig config;
 
@@ -53,6 +56,9 @@ public class EgovAccessDeniedHandler implements AccessDeniedHandler {
         boolean isCsrfFailure = accessDeniedException instanceof InvalidCsrfTokenException
                 || accessDeniedException instanceof MissingCsrfTokenException;
         String targetUrl = isCsrfFailure ? config.getCsrfAccessDeniedUrl() : config.getAccessDeniedUrl();
+        if (!StringUtils.hasText(targetUrl)) {
+            targetUrl = DEFAULT_ACCESS_DENIED_URL;
+        }
 
         RequestDispatcher dispatcher = request.getRequestDispatcher(targetUrl);
         dispatcher.forward(request, response);

--- a/Foundation/org.egovframe.rte.fdl.security/src/test/java/org/egovframe/rte/fdl/security/bean/EgovAccessDeniedHandlerTest.java
+++ b/Foundation/org.egovframe.rte.fdl.security/src/test/java/org/egovframe/rte/fdl/security/bean/EgovAccessDeniedHandlerTest.java
@@ -1,0 +1,58 @@
+package org.egovframe.rte.fdl.security.bean;
+
+import org.egovframe.rte.fdl.security.config.EgovSecurityConfig;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.csrf.MissingCsrfTokenException;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class EgovAccessDeniedHandlerTest {
+
+    @Test
+    public void handle_fallsBackToDefaultUrl_whenCsrfAccessDeniedUrlBlank() throws Exception {
+        EgovSecurityConfig config = new EgovSecurityConfig();
+        config.setAccessDeniedUrl("/system/accessDenied.do");
+        // csrfAccessDeniedUrl은 의도적으로 미설정 상태(null)로 둔다.
+
+        EgovAccessDeniedHandler handler = new EgovAccessDeniedHandler(config);
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        assertDoesNotThrow(() -> handler.handle(request, response, new MissingCsrfTokenException("csrf-token")));
+        assertEquals("/index.html", response.getForwardedUrl());
+    }
+
+    @Test
+    public void handle_fallsBackToDefaultUrl_whenAccessDeniedUrlBlank() throws Exception {
+        EgovSecurityConfig config = new EgovSecurityConfig();
+        config.setAccessDeniedUrl(" ");
+        // 일반 접근거부 분기(CSRF 아님)도 동일 가드를 타는지 확인한다.
+
+        EgovAccessDeniedHandler handler = new EgovAccessDeniedHandler(config);
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        assertDoesNotThrow(() -> handler.handle(request, response, new AccessDeniedException("denied")));
+        assertEquals("/index.html", response.getForwardedUrl());
+    }
+
+    @Test
+    public void handle_usesConfiguredCsrfUrl_whenPresent() throws Exception {
+        EgovSecurityConfig config = new EgovSecurityConfig();
+        config.setAccessDeniedUrl("/system/accessDenied.do");
+        config.setCsrfAccessDeniedUrl("/system/csrfDenied.do");
+
+        EgovAccessDeniedHandler handler = new EgovAccessDeniedHandler(config);
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        handler.handle(request, response, new MissingCsrfTokenException("csrf-token"));
+
+        assertEquals("/system/csrfDenied.do", response.getForwardedUrl());
+    }
+
+}


### PR DESCRIPTION
## 수정 사유

- [x] 버그수정
- [ ] 기능개선
- [ ] 리팩터링

## 변경 이유

`EgovAccessDeniedHandler.handle()`은 CSRF 실패 시 `config.getCsrfAccessDeniedUrl()`을, 일반 접근거부 시 `config.getAccessDeniedUrl()`을 아무 검사 없이 바로 `RequestDispatcher`에 넘깁니다.

```java
String targetUrl = isCsrfFailure ? config.getCsrfAccessDeniedUrl() : config.getAccessDeniedUrl();

RequestDispatcher dispatcher = request.getRequestDispatcher(targetUrl);
dispatcher.forward(request, response);
```

같은 패키지의 형제 클래스 `EgovLoginFailHandler`에는 정확히 같은 위험(`config.getAccessDeniedUrl()`이 비어있을 수 있음)을 막는 방어 코드가 이미 있습니다.

```java
String failureUrl;
if (StringUtils.hasText(config.getAccessDeniedUrl())) {
    failureUrl = config.getAccessDeniedUrl();
} else {
    failureUrl = DEFAULT_LOGIN_FAILURE_URL;
}
```

`csrfAccessDeniedUrl`이 실제로 비어있을 수 있는 경로도 확인했습니다. `EgovSecurityConfigReader.createDefaultConfig()`는 `csrf`는 `false`로 명시하면서 `csrfAccessDeniedUrl`은 아예 세팅하지 않아 null로 남고 리더도 이 값을 필수로 검증하지 않습니다. 레포 자신의 테스트 리소스(`egov-security-config.properties`)도 `csrf=false`와 `csrfAccessDeniedUrl=`(빈 값)을 나란히 두고 있어 "CSRF를 켜면서 전용 URL은 빠뜨리는" 조합이 실제로 나올 수 있는 설정임을 보여줍니다.

CSRF 분기 자체는 비교적 최근(`b3e4d1c`, "보안점검 적용")에 "중복 forward로 인한 `IllegalStateException` 위험"을 고치며 지금 형태로 재작성됐는데, 그 커밋은 forward 중복 문제만 다뤘고 blank URL 문제는 손대지 않았습니다.

## 변경 내용

형제 클래스의 상수 이름·값·가드 패턴을 그대로 재사용해 CSRF·일반 접근거부 두 분기 모두를 커버하는 단일 가드를 추가했습니다.

AS-IS
```java
String targetUrl = isCsrfFailure ? config.getCsrfAccessDeniedUrl() : config.getAccessDeniedUrl();

RequestDispatcher dispatcher = request.getRequestDispatcher(targetUrl);
```

TO-BE
```java
private static final String DEFAULT_ACCESS_DENIED_URL = "/index.html";
...
String targetUrl = isCsrfFailure ? config.getCsrfAccessDeniedUrl() : config.getAccessDeniedUrl();
if (!StringUtils.hasText(targetUrl)) {
    targetUrl = DEFAULT_ACCESS_DENIED_URL;
}

RequestDispatcher dispatcher = request.getRequestDispatcher(targetUrl);
```

## 영향 범위

`csrfAccessDeniedUrl`·`accessDeniedUrl`을 정상 설정한 기존 배포는 `StringUtils.hasText`가 항상 참을 반환해 동작이 전혀 바뀌지 않습니다. 두 값 다 비어있을 때만 새 폴백이 발동합니다. CSRF 실패와 일반 접근거부 실패를 같은 URL로 보내는 게 보안상 걱정될 수 있는데, 형제 클래스 `EgovLoginFailHandler`도 이미 "실패 원인과 무관하게 동일한 안전한 목적지로"라는 같은 패턴을 계정 열거 공격(CWE-203/204) 방지 목적으로 쓰고 있어(코드 내 주석 참고) 기존 보안 설계와 일관됩니다. 변경한 파일은 `EgovAccessDeniedHandler.java`와 신규 테스트뿐입니다. `EgovAccessDeniedHandler`는 `EgovSecurityConfiguration.securityFilterChain()`에서 `.accessDeniedHandler(...)`로 실제 등록돼 있어 도달 가능한 경로입니다.

## 테스트 방법

가설: `csrfAccessDeniedUrl`(또는 `accessDeniedUrl`)이 비어있는 `EgovSecurityConfig`로 해당 분기의 실패 예외를 발생시켜 `handle()`을 호출하면, 미수정 상태는 예외가 나고 수정본은 `/index.html`로 정상 forward된다.

검증 방법: `EgovAccessDeniedHandlerTest`가 `MockHttpServletRequest`/`MockHttpServletResponse`로 실제 `handle()`을 호출해 프로덕션 코드 경로(`RequestDispatcher` 획득 → `forward`)를 그대로 태우고 `response.getForwardedUrl()`을 검증합니다. CSRF 분기 폴백, 일반 접근거부 분기 폴백, 정상 설정 시 동작 불변 3가지를 각각 확인합니다.

미수정(RED)
```
[ERROR] EgovAccessDeniedHandlerTest.handle_fallsBackToDefaultUrl_whenCsrfAccessDeniedUrlBlank:24
  Unexpected exception thrown: java.lang.IllegalArgumentException: Resource must not be null
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0
```

수정본(GREEN, 신규 테스트 3개)
```
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0
```

수정본(GREEN, 모듈 전체 회귀)
```
[INFO] Tests run: 26, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```

