### PR TITLE
fix: AbstractKrdsPaginationRenderer가 이름·Javadoc·형제 클래스와 다르게 abstract가 아닌 문제 수정

### DIFF
--- a/Presentation/org.egovframe.rte.ptl.mvc/src/main/java/org/egovframe/rte/ptl/mvc/tags/ui/pagination/AbstractKrdsPaginationRenderer.java
+++ b/Presentation/org.egovframe.rte.ptl.mvc/src/main/java/org/egovframe/rte/ptl/mvc/tags/ui/pagination/AbstractKrdsPaginationRenderer.java
@@ -47,7 +47,7 @@ import java.text.MessageFormat;
  * </pre>
  * @since 2025.06.01
  */
-public class AbstractKrdsPaginationRenderer implements PaginationRenderer {
+public abstract class AbstractKrdsPaginationRenderer implements PaginationRenderer {
 
     protected String firstPageLabel;
     protected String previousPageLabel;

--- a/Presentation/org.egovframe.rte.ptl.mvc/src/test/java/org/egovframe/rte/ptl/mvc/tags/ui/pagination/PaginationTest.java
+++ b/Presentation/org.egovframe.rte.ptl.mvc/src/test/java/org/egovframe/rte/ptl/mvc/tags/ui/pagination/PaginationTest.java
@@ -8,10 +8,12 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.mock.web.MockPageContext;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
+import java.lang.reflect.Modifier;
 import java.util.HashMap;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ExtendWith(SpringExtension.class)
 public class PaginationTest {
@@ -96,6 +98,46 @@ public class PaginationTest {
         assertEquals(5, pageInfo.getLastPageNoOnPageList());
         assertEquals(20, pageInfo.getFirstRecordIndex());
         assertEquals(30, pageInfo.getLastRecordIndex());
+    }
+
+    /**
+     * AbstractKrdsPaginationRenderer는 이름·Javadoc·형제 클래스(AbstractPaginationRenderer)와
+     * 동일하게 하위 클래스가 라벨 필드를 채워야 하는 계약이므로, 직접 인스턴스화를 막는
+     * abstract 클래스여야 한다.
+     */
+    @Test
+    public void abstractKrdsPaginationRendererIsAbstractTest() {
+        assertTrue(Modifier.isAbstract(AbstractKrdsPaginationRenderer.class.getModifiers()));
+    }
+
+    /**
+     * 라벨 필드를 채운 하위 클래스에서는 renderPagination()이 정상 동작해야 한다
+     * (abstract 전환이 정상적인 서브클래싱 사용까지 막지 않는지 검증).
+     */
+    @Test
+    public void abstractKrdsPaginationRendererRendersWhenSubclassedTest() {
+        AbstractKrdsPaginationRenderer renderer = new AbstractKrdsPaginationRenderer() {
+            {
+                firstPageLabel = "[first]";
+                previousPageLabel = "[prev]";
+                previousPageDisabledLabel = "[prev-disabled]";
+                currentPageLabel = "{0}";
+                otherPageLabel = "{2}";
+                nextPageLabel = "[next]";
+                nextPageDisabledLabel = "[next-disabled]";
+                lastPageLabel = "[last]";
+                dotPageLabel = "...";
+            }
+        };
+
+        PaginationInfo pageInfo = new PaginationInfo();
+        pageInfo.setCurrentPageNo(1);
+        pageInfo.setPageSize(5);
+        pageInfo.setRecordCountPerPage(10);
+        pageInfo.setTotalRecordCount(51);
+
+        String result = renderer.renderPagination(pageInfo, "");
+        assertNotNull(result);
     }
 
 }


### PR DESCRIPTION
## 수정 사유

- [x] 버그수정
- [ ] 기능개선
- [ ] 리팩터링

## 변경 이유

`AbstractKrdsPaginationRenderer`는 이름이 "Abstract"이고 자기 Javadoc이 "클래스 변수값을 AbstractKrdsPaginationRenderer를 상속받은 하위 클래스에서 주게 되면, 페이징 포맷만 프로젝트 UI에 맞춰 커스터마이징 할 수 있다"고 명시하는데, 실제 선언은 `abstract` 키워드가 없는 `public class`입니다.

```java
/**
 * ...
 * 클래스 변수값을 AbstractKrdsPaginationRenderer를 상속받은 하위 클래스에서 주게 되면,
 * 페이징 포맷만 프로젝트 UI에 맞춰 커스터마이징 할 수 있다.
 * ...
 */
public class AbstractKrdsPaginationRenderer implements PaginationRenderer {

    protected String firstPageLabel;
    protected String previousPageLabel;
    // ... 라벨 필드 9개, 전부 초기화 없이 선언만
```

형제 클래스 `AbstractPaginationRenderer`는 거의 동일한 Javadoc 문구를 쓰면서 실제로 `public abstract class`이고 그 구체 구현 `DefaultPaginationRenderer`가 생성자에서 라벨 6개를 HTML 기본값으로 채웁니다. `AbstractKrdsPaginationRenderer`는 이 짝(구체 구현체)이 저장소 어디에도 없습니다.

`abstract` 키워드가 없다는 것은 `new AbstractKrdsPaginationRenderer()`로 직접 인스턴스화할 수 있다는 뜻인데, 그렇게 하면 라벨 필드 9개가 전부 null인 채로 `renderPagination()`이 `MessageFormat.format(null, ...)`을 호출해 즉시 `NullPointerException`이 납니다. 즉 직접 인스턴스화 경로는 애초에 정상 동작한 적이 없고 NPE로만 이어지는 죽은 경로였습니다.

이 클래스는 v5.0.0(2026-05-18 v5.0.0-Final 릴리즈)에 신규 도입돼 v5.0.0-Final·v5.0.1-FINAL 두 릴리즈 모두 지금 상태(non-abstract)로 나갔지만 저장소 전체를 확인한 결과 이 클래스를 직접 인스턴스화하거나 상속하는 코드는 어디에도 없습니다.

## 변경 내용

형제 클래스와 동일하게 `abstract` 키워드를 추가했습니다.

AS-IS
```java
public class AbstractKrdsPaginationRenderer implements PaginationRenderer {
```

TO-BE
```java
public abstract class AbstractKrdsPaginationRenderer implements PaginationRenderer {
```

## 영향 범위

`AbstractKrdsPaginationRenderer.java`와 신규 테스트만 변경했습니다. 저장소 전체(`grep -rn "AbstractKrdsPaginationRenderer"`)에 이 클래스를 직접 인스턴스화(`new AbstractKrdsPaginationRenderer()`)하거나 상속(`extends AbstractKrdsPaginationRenderer`)하는 코드가 없어 이번 수정으로 깨지는 기존 코드는 없습니다. 두 차례 릴리즈된 공개 API라 형식상 소스 호환성 파괴 표면은 있지만 위에서 확인했듯 직접 인스턴스화는 라벨 미설정으로 NPE만 내던 사실상 죽은 경로였으므로 실질적인 하위 호환 위험은 없습니다. 오히려 그 위험한 경로 자체를 컴파일 타임에 막아 클래스명·Javadoc이 항상 요구해온 계약(하위 클래스가 라벨을 채워야 한다)을 강제합니다. 정상적인 서브클래싱 사용(라벨을 채운 하위 클래스)은 그대로 동작합니다.

## 테스트 방법

가설: `abstract` 키워드가 없는 미수정 상태는 클래스가 직접 인스턴스화 가능해야 하고(리플렉션으로 `Modifier.isAbstract()`가 false), 수정본은 true여야 한다. 또한 abstract 전환이 정상적인 서브클래싱 사용까지 막아서는 안 된다.

검증 방법: `PaginationTest`에 2개 테스트를 추가했습니다. (1) 리플렉션으로 `Modifier.isAbstract(AbstractKrdsPaginationRenderer.class.getModifiers())`를 확인하는 구조 테스트, (2) 라벨을 채운 익명 서브클래스로 `renderPagination()`을 호출해 정상 동작(null 없이 완주)하는지 확인하는 회귀 테스트.

미수정(RED)
```
[ERROR] PaginationTest.abstractKrdsPaginationRendererIsAbstractTest:110 expected: <true> but was: <false>
[ERROR] Tests run: 9, Failures: 1, Errors: 0, Skipped: 0
```

수정본(GREEN, 모듈 전체 회귀)
```
[INFO] Tests run: 40, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```


