### PR TITLE
fix: MessageSender가 락 대기 중 interrupt를 무시해 지연 전송이 발생하는 문제 수정

### DIFF
--- a/Integration/org.egovframe.rte.itl.integration/src/main/java/org/egovframe/rte/itl/integration/support/AbstractService.java
+++ b/Integration/org.egovframe.rte.itl.integration/src/main/java/org/egovframe/rte/itl/integration/support/AbstractService.java
@@ -24,6 +24,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.util.StringUtils;
 
+import java.util.concurrent.locks.ReentrantLock;
+
 /**
  * 전자정부 연계 서비스의 Service interface를 구현 추상 클래스
  * <p>
@@ -55,6 +57,12 @@ public abstract class AbstractService implements EgovIntegrationService {
      * default timeout
      */
     protected long defaultTimeout;
+
+    /**
+     * MessageSender가 doSend 호출 전후로 잡는 락. synchronized 대신 사용해 락 대기 중에도
+     * interrupt()가 실제로 동작하도록 한다.
+     */
+    final ReentrantLock invocationLock = new ReentrantLock();
 
     /**
      * Constructor
@@ -250,7 +258,16 @@ class MessageSender extends Thread {
     public void run() {
         LOGGER.debug("### MessageSender run() MessageSender just Start");
         //2017.02.13 장동한 시큐어코딩(ES)-검사시점과 사용시점(TOCTOU)[CWE-367]
-        synchronized (service) {
+        //synchronized(service) 대신 lockInterruptibly()를 사용해, 락을 기다리는 동안
+        //호출자가 이미 타임아웃으로 포기해 interrupt()를 건 경우 doSend를 시도하지 않고
+        //즉시 빠져나오도록 한다. (락이 지키는 검사~발송 원자성은 그대로 유지된다.)
+        try {
+            service.invocationLock.lockInterruptibly();
+        } catch (InterruptedException e) {
+            LOGGER.debug("### MessageSender run() interrupted while waiting for the lock; doSend not attempted");
+            return;
+        }
+        try {
             CallbackId callbackId = null;
             if (callback != null) {
                 callbackId = callback.createId(service, requestMessage);
@@ -264,6 +281,8 @@ class MessageSender extends Thread {
                 LOGGER.debug("### MessageSender run() Notify to callback");
                 callback.onReceive(callbackId, responseMessage);
             }
+        } finally {
+            service.invocationLock.unlock();
         }
     }
 }

--- a/Integration/org.egovframe.rte.itl.integration/src/test/java/org/egovframe/rte/itl/integration/support/MessageSenderLockContentionTest.java
+++ b/Integration/org.egovframe.rte.itl.integration/src/test/java/org/egovframe/rte/itl/integration/support/MessageSenderLockContentionTest.java
@@ -1,0 +1,97 @@
+package org.egovframe.rte.itl.integration.support;
+
+import org.egovframe.rte.itl.integration.EgovIntegrationMessage;
+import org.egovframe.rte.itl.integration.EgovIntegrationMessageHeader.ResultCode;
+import org.egovframe.rte.itl.integration.message.simple.SimpleMessage;
+import org.egovframe.rte.itl.integration.message.simple.SimpleMessageHeader;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * 같은 연계 서비스 인스턴스에 대해 동시에 두 건의 sendSync 호출이 들어왔을 때,
+ * 락을 기다리다 타임아웃한 두 번째 호출이 이후에도 doSend를 시도하지 않음을 확인한다.
+ * (수정 전에는 이 두 번째 호출의 스레드가 interrupt를 무시하고 계속 락을 기다리다,
+ * 첫 번째 호출이 끝난 뒤 아무도 기다리지 않는 상태에서 뒤늦게 doSend를 실행했다.)
+ */
+public class MessageSenderLockContentionTest {
+
+    private static final long SLOW_SERVICE_TIME = 3000L;
+    private static final long SHORT_TIMEOUT = 300L;
+
+    @Test
+    public void secondCallerNeverSendsAfterTimingOutOnTheLock() throws Exception {
+        CountDownLatch firstCallEnteredCriticalSection = new CountDownLatch(1);
+        AtomicBoolean secondActuallyRan = new AtomicBoolean(false);
+
+        RecordingService service = new RecordingService("lockContentionTest", 10_000L,
+                firstCallEnteredCriticalSection, secondActuallyRan);
+
+        EgovIntegrationMessage firstRequest = service.createRequestMessage();
+        EgovIntegrationMessage secondRequest = service.createRequestMessage();
+
+        Thread firstCaller = new Thread(() -> service.sendSync(firstRequest, 10_000L));
+        firstCaller.start();
+        assertTrue(firstCallEnteredCriticalSection.await(2, TimeUnit.SECONDS),
+                "first caller should have entered doSend within 2 seconds");
+        Thread.sleep(50); // 첫 호출이 확실히 락을 쥔 상태로 만들기 위한 여유
+
+        long before = System.currentTimeMillis();
+        EgovIntegrationMessage secondResponse = service.sendSync(secondRequest, SHORT_TIMEOUT);
+        long elapsed = System.currentTimeMillis() - before;
+
+        assertEquals(ResultCode.TIME_OUT, secondResponse.getHeader().getResultCode());
+        assertTrue(elapsed < SLOW_SERVICE_TIME,
+                "second call should time out on the lock wait (" + SHORT_TIMEOUT
+                        + "ms), not on the slow send (" + SLOW_SERVICE_TIME + "ms); took " + elapsed + "ms");
+        assertFalse(secondActuallyRan.get(),
+                "doSend must not have been attempted yet when TIME_OUT is returned");
+
+        firstCaller.join(5000);
+        // 첫 호출이 끝나 락이 풀린 뒤에도, 두 번째 호출은 이미 인터럽트되어 doSend를
+        // 다시 시도하지 않아야 한다 (뒤늦은 "유령" 전송이 없어야 한다).
+        Thread.sleep(SLOW_SERVICE_TIME);
+        assertFalse(secondActuallyRan.get(),
+                "a TIME_OUT response must not be followed by a belated (phantom) send");
+    }
+
+    private static class RecordingService extends AbstractService {
+        private final CountDownLatch firstCallEnteredCriticalSection;
+        private final AtomicBoolean secondActuallyRan;
+        private volatile boolean firstCallSeen = false;
+
+        RecordingService(String id, long defaultTimeout,
+                          CountDownLatch firstCallEnteredCriticalSection,
+                          AtomicBoolean secondActuallyRan) {
+            super(id, defaultTimeout);
+            this.firstCallEnteredCriticalSection = firstCallEnteredCriticalSection;
+            this.secondActuallyRan = secondActuallyRan;
+        }
+
+        @Override
+        protected EgovIntegrationMessage doSend(EgovIntegrationMessage requestMessage) {
+            if (!firstCallSeen) {
+                firstCallSeen = true;
+                firstCallEnteredCriticalSection.countDown();
+                try {
+                    Thread.sleep(SLOW_SERVICE_TIME);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+            } else {
+                secondActuallyRan.set(true);
+            }
+            return requestMessage;
+        }
+
+        public EgovIntegrationMessage createRequestMessage() {
+            return new SimpleMessage(new SimpleMessageHeader());
+        }
+    }
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [x] 버그수정 Bug fixes

## 수정된 소스 내용 Modified source

`Integration/org.egovframe.rte.itl.integration/.../support/AbstractService.java`

**문제**: `AbstractService.sendSync()`와 `DefaultResponse.receive()`는 `sender.join(timeout)`이
만료되면 `sender.interrupt()`를 호출하고 `TIME_OUT`을 반환합니다. 하지만 `MessageSender.run()`은
`synchronized(service)`로 락을 잡는데, 자바 언어 명세(JLS 17.1)상 `synchronized` 진입 대기
(모니터 획득 대기) 중에는 `interrupt()`가 아무 효과가 없습니다.

그 결과, 같은 연계(Integration) 서비스 인스턴스에 동시 요청 2건이 들어오면:

1. 먼저 온 요청이 락을 잡고 `doSend()`(실제 네트워크 I/O)를 실행합니다.
2. 나중 요청은 락을 기다리다 자신의 `timeout`이 지나 `TIME_OUT`을 반환받고 호출자는 그대로
   종료합니다.
3. 하지만 2번 요청의 스레드 자체는 죽지 않고 계속 락을 기다리다가, 1번 요청이 끝나 락이
   풀리는 순간 **아무도 기다리지 않는 상태에서** `doSend()`를 뒤늦게 실행합니다("유령 전송").

이 락은 2017-02-13 커밋 주석에 명시된 대로 CWE-367(TOCTOU) 대응으로 의도적으로 추가된
것이므로, 이번 수정은 **락을 제거하거나 범위를 좁히지 않고** 같은 상호배제 보장을 유지한
채로 대기 중 인터럽트만 가능하게 바꿉니다.

**변경 내용**:
- `AbstractService`에 `ReentrantLock invocationLock` 필드 추가
- `MessageSender.run()`에서 `synchronized(service)` 대신
  `service.invocationLock.lockInterruptibly()` 사용
- 락 대기 중 인터럽트되면(`InterruptedException`) `doSend()`를 시도하지 않고 즉시 반환
- 락 획득 후에는 `try/finally`로 항상 `unlock()`

`sendSync()`/`sendAsync()`/`DefaultResponse.receive()`의 반환값이나 시그니처는 바뀌지
않습니다 - `TIME_OUT`을 반환한 뒤에는 실제로도 발송 시도가 없어진다는 점만 달라집니다.

## JUnit 테스트 JUnit tests

- [x] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

`MessageSenderLockContentionTest`를 추가했습니다: 같은 서비스 인스턴스에 대해 느린 첫 호출이
락을 쥔 상태에서 두 번째 호출이 짧은 timeout으로 락 대기 중 타임아웃되면, 첫 호출이 끝나 락이
풀린 뒤에도 두 번째 호출의 `doSend`가 실행되지 않음을 확인합니다.

- 신규 테스트 1건 + 기존 `AbstractServiceTest` 6건: 통과
- `Integration/org.egovframe.rte.itl.integration`, `Integration/org.egovframe.rte.itl.webservice`
  두 모듈 전체 테스트: 통과 (회귀 없음)
- 리포 전체 24개 모듈 `mvn test`: 644건 전체 통과, errors 0 / failures 0 / skipped 0
- 이번 변경이 영향을 줄 수 있는 범위(`AbstractService`를 상속하는 클래스, 이 두 모듈에
  의존하는 다른 모듈)를 grep으로 확인한 결과 `EgovWebService`와 테스트 더미 외에는 없고,
  다른 모듈에서 이 두 모듈을 의존하는 곳도 없습니다.

## 테스트 브라우저 Test Browser

해당 없음 - 백엔드 동시성 수정으로 브라우저 테스트 대상이 아닙니다.
Not applicable - this is a backend concurrency fix with no browser-facing surface.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

해당 없음 (UI 변경 없음). 대신 JUnit 재현 테스트 로그로 수정 전/후 동작을 확인했습니다:

- 수정 전: 두 번째 호출이 300ms 만에 `TIME_OUT`을 반환하지만, 그 스레드는 계속 대기하다
  첫 호출 종료(3000ms) 직후 아무도 기다리지 않는 상태에서 `doSend`를 실행함(로그 타임스탬프로
  2,638ms 지연 확인).
- 수정 후: 동일 시나리오에서 `MessageSender run() interrupted while waiting for the lock;
  doSend not attempted` 로그가 즉시 찍히고, 첫 호출 종료 후에도 두 번째 호출의 `doSend`는
  실행되지 않음.