### PR TITLE
fix(fdl-security): DefaultMapUserDetailsMapping 컬럼명 소문자화 로케일 고정(Locale.ROOT)

### DIFF
--- a/Foundation/org.egovframe.rte.fdl.security/src/main/java/org/egovframe/rte/fdl/security/userdetails/DefaultMapUserDetailsMapping.java
+++ b/Foundation/org.egovframe.rte.fdl.security/src/main/java/org/egovframe/rte/fdl/security/userdetails/DefaultMapUserDetailsMapping.java
@@ -23,6 +23,7 @@ import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 
 /**
@@ -57,7 +58,7 @@ public class DefaultMapUserDetailsMapping extends EgovUsersByUsernameMapping {
         ResultSetMetaData md = rs.getMetaData();
         int cnt = md.getColumnCount();
         for (int i = 1; i <= cnt; i++) {
-            String column = md.getColumnName(i).toLowerCase();
+            String column = md.getColumnName(i).toLowerCase(Locale.ROOT);
             String value = rs.getString(column);
             map.put(CamelCaseUtil.convert2CamelCase(column), value);
         }

--- a/Foundation/org.egovframe.rte.fdl.security/src/test/java/org/egovframe/rte/fdl/security/userdetails/DefaultMapUserDetailsMappingLocaleTest.java
+++ b/Foundation/org.egovframe.rte.fdl.security/src/test/java/org/egovframe/rte/fdl/security/userdetails/DefaultMapUserDetailsMappingLocaleTest.java
@@ -1,0 +1,71 @@
+package org.egovframe.rte.fdl.security.userdetails;
+
+import org.easymock.EasyMock;
+import org.junit.jupiter.api.Test;
+
+import javax.sql.DataSource;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.util.Locale;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * DefaultMapUserDetailsMapping 의 컬럼명 소문자화가 JVM 기본 로케일과 무관함을 검증한다.
+ *
+ * <p>터키어 로케일에서는 "USER_ID".toLowerCase() 가 점 없는 'ı'(U+0131) 때문에 "user_ıd" 가 되어,
+ * 그 이름으로 ResultSet 을 조회하면 실제 컬럼(user_id)을 찾지 못하고 사용자 속성이 유실된다(CWE-176).
+ * Locale.ROOT 고정으로 어떤 기본 로케일에서도 동일하게 매핑되어야 한다.</p>
+ */
+class DefaultMapUserDetailsMappingLocaleTest {
+
+    private static final String QUERY =
+            "select user_id, password, enabled from users where user_id = ?";
+
+    @Test
+    void mapRow_lowercasesColumnNamesLocaleIndependently() throws Exception {
+        Locale original = Locale.getDefault();
+        try {
+            // 터키어 로케일에서 재현: 'I' -> 'ı'(dotless i) 로 매핑되어 컬럼명 소문자화가 깨진다.
+            Locale.setDefault(Locale.forLanguageTag("tr-TR"));
+            assertEquals("honggildong", mapUserIdUnderCurrentLocale(),
+                    "터키어 로케일에서도 컬럼값(user_id)이 유실 없이 매핑되어야 한다");
+
+            // 대조군: 영어 로케일에서도 동일 결과여야 한다(로케일 독립성).
+            Locale.setDefault(Locale.ENGLISH);
+            assertEquals("honggildong", mapUserIdUnderCurrentLocale(),
+                    "영어 로케일에서도 동일하게 매핑되어야 한다");
+        } finally {
+            Locale.setDefault(original);
+        }
+    }
+
+    /**
+     * USER_ID 컬럼 하나를 보고하는 ResultSet 을 mapRow 로 매핑한 뒤,
+     * 카멜케이스 키(userId)에 담긴 값을 반환한다.
+     */
+    private String mapUserIdUnderCurrentLocale() throws Exception {
+        DataSource ds = EasyMock.createNiceMock(DataSource.class);
+        ResultSet rs = EasyMock.createNiceMock(ResultSet.class);
+        ResultSetMetaData md = EasyMock.createNiceMock(ResultSetMetaData.class);
+
+        // 실제 DB(예: Oracle/HSQLDB)는 메타데이터 컬럼명을 대문자로 돌려준다.
+        EasyMock.expect(md.getColumnCount()).andReturn(1).anyTimes();
+        EasyMock.expect(md.getColumnName(1)).andReturn("USER_ID").anyTimes();
+        // ASCII 소문자 컬럼명으로만 값이 조회되도록 한다.
+        // (버그가 있으면 코드는 "user_ıd" 로 조회하고, nice mock 은 null 을 돌려준다.)
+        EasyMock.expect(rs.getString("user_id")).andReturn("honggildong").anyTimes();
+        EasyMock.expect(rs.getString("password")).andReturn("secret").anyTimes();
+        EasyMock.expect(rs.getBoolean("enabled")).andReturn(true).anyTimes();
+        EasyMock.expect(rs.getMetaData()).andReturn(md).anyTimes();
+        EasyMock.replay(ds, rs, md);
+
+        DefaultMapUserDetailsMapping mapping = new DefaultMapUserDetailsMapping(ds, QUERY);
+        EgovUserDetails details = mapping.mapRow(rs, 1);
+
+        @SuppressWarnings("unchecked")
+        Map<String, String> attributes = (Map<String, String>) details.getEgovUserVO();
+        return attributes.get("userId");
+    }
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [x] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

DefaultMapUserDetailsMapping.mapRow() 는 ResultSetMetaData.getColumnName(i).toLowerCase() 로 컬럼명을 소문자화합니다. toLowerCase() 는 JVM 기본 로케일에 의존하므로, 터키어/아제르바이잔어 로케일에서는 대문자 I 가 점 없는 소문자 ı(U+0131)로 변환됩니다.

서버 로케일이 tr-TR 인 경우 "USER_ID".toLowerCase() 는 "user_ıd" 가 되어 실제 컬럼 user_id 와 불일치하고, 이후 rs.getString("user_ıd") 가 해당 컬럼을 찾지 못해 사용자 속성이 유실되거나 SQLException 이 발생합니다. 로케일 의존 대소문자 변환 버그(CWE-176, Improper Handling of Unicode Encoding)입니다.

수정: 컬럼명 소문자화에 Locale.ROOT 를 명시하여 기본 로케일과 무관하게 ASCII 규칙으로 변환합니다.

    String column = md.getColumnName(i).toLowerCase(Locale.ROOT);

## JUnit 테스트 JUnit tests

- [x] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

DefaultMapUserDetailsMappingLocaleTest 회귀 테스트를 추가했습니다. 기본 로케일을 tr-TR 로 설정한 상태에서 USER_ID 컬럼이 유실 없이 userId 로 매핑되는지 검증합니다(영어 로케일 대조군 포함). 수정 전에는 실패하고 수정 후 통과함(TDD 토글)을 확인했습니다. mvn -pl Foundation/org.egovframe.rte.fdl.security test -Dtest=DefaultMapUserDetailsMappingLocaleTest → tests=1, failures=0, errors=0.