### PR TITLE
fix: EgovCryptoConfigReader가 형제 Reader와 달리 기본값을 베이스로 덮어쓰지 않는 문제 수정

### DIFF
--- a/Foundation/org.egovframe.rte.fdl.crypto/src/main/java/org/egovframe/rte/fdl/crypto/config/EgovCryptoConfigReader.java
+++ b/Foundation/org.egovframe.rte.fdl.crypto/src/main/java/org/egovframe/rte/fdl/crypto/config/EgovCryptoConfigReader.java
@@ -94,7 +94,9 @@ public class EgovCryptoConfigReader {
                 try (InputStreamReader reader = new InputStreamReader(inputStream, StandardCharsets.UTF_8)) {
                     props.load(reader);
                 }
-                return mapPropertiesToBean(props, EgovCryptoConfig.class);
+                // 파일에 명시되지 않은 키(crypto, algorithm 등)는 기본값을 유지하도록
+                // 빈 인스턴스가 아니라 createDefaultConfig()를 베이스로 덮어쓴다.
+                return mapPropertiesToBean(props, createDefaultConfig());
             }
         } catch (IOException e) {
             LOGGER.debug("Failed to read crypto configuration file, use default config. tried: {} - {}", triedPath, e.getMessage());
@@ -115,22 +117,15 @@ public class EgovCryptoConfigReader {
     }
 
     // 2026.02.28 KISA 보안취약점 조치
-    // properties 설정 파일을 읽어 EgovCryptoConfig 객체로 변환
-    private static EgovCryptoConfig mapPropertiesToBean(Properties props, Class<EgovCryptoConfig> beanClass) {
-        EgovCryptoConfig bean;
-        // 2026.02.28 KISA 보안취약점 조치
-        try {
-            bean = beanClass.getDeclaredConstructor().newInstance();
-        } catch (NoSuchMethodException | InvocationTargetException | InstantiationException | IllegalAccessException e) {
-            throw new RuntimeException("Failed to create config instance: " + e.getMessage(), e);
-        }
+    // properties 설정 파일을 읽어 기존 bean(기본값이 채워진 상태) 위에 덮어쓴다.
+    private static EgovCryptoConfig mapPropertiesToBean(Properties props, EgovCryptoConfig bean) {
         for (String key : props.stringPropertyNames()) {
             String value = props.getProperty(key);
             if (value == null) continue;
             String setterName = "set" + key.substring(0, 1).toUpperCase() + key.substring(1);
             // 2026.02.28 KISA 보안취약점 조치
             try {
-                Method setter = findSetter(beanClass, setterName);
+                Method setter = findSetter(bean.getClass(), setterName);
                 if (setter != null) {
                     Object arg = convertValue(value, setter.getParameterTypes()[0]);
                     setter.invoke(bean, arg);

--- a/Foundation/org.egovframe.rte.fdl.crypto/src/test/java/org/egovframe/rte/fdl/crypto/config/EgovCryptoConfigReaderTest.java
+++ b/Foundation/org.egovframe.rte.fdl.crypto/src/test/java/org/egovframe/rte/fdl/crypto/config/EgovCryptoConfigReaderTest.java
@@ -1,0 +1,58 @@
+package org.egovframe.rte.fdl.crypto.config;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Properties;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class EgovCryptoConfigReaderTest {
+
+    @Test
+    public void testReadConfigKeepsSafeDefaultsForOmittedKeys(@TempDir Path tempDir) throws IOException {
+        // cryptoPropertyLocation만 지정하고 crypto/algorithm/cryptoBlockSize는 생략한 부분 설정 파일.
+        Path propsFile = tempDir.resolve("egov-crypto-config.properties");
+        Properties props = new Properties();
+        props.setProperty("cryptoPropertyLocation", "classpath:/custom.properties");
+        try (BufferedWriter writer = Files.newBufferedWriter(propsFile, StandardCharsets.UTF_8)) {
+            props.store(writer, null);
+        }
+
+        EgovCryptoConfigReader reader = new EgovCryptoConfigReader("file:" + propsFile, null);
+        EgovCryptoConfig config = reader.readConfig();
+
+        assertEquals("classpath:/custom.properties", config.getCryptoPropertyLocation());
+        // 형제 구현체 EgovAccessConfigReader·EgovSecurityConfigReader와 동일하게, 파일에 명시되지 않은
+        // 키는 createDefaultConfig()의 기본값(crypto=true, algorithm=SHA-256, cryptoBlockSize=1024)을 유지해야 한다.
+        assertTrue(config.isCrypto());
+        assertEquals("SHA-256", config.getAlgorithm());
+        assertEquals(1024, config.getCryptoBlockSize());
+    }
+
+    @Test
+    public void testReadConfigHonorsExplicitOverrideOfDefaultValue(@TempDir Path tempDir) throws IOException {
+        // 사용자가 crypto를 명시적으로 false로 끈 경우, 기본값(true)에 밀려서는 안 된다.
+        Path propsFile = tempDir.resolve("egov-crypto-config.properties");
+        Properties props = new Properties();
+        props.setProperty("crypto", "false");
+        try (BufferedWriter writer = Files.newBufferedWriter(propsFile, StandardCharsets.UTF_8)) {
+            props.store(writer, null);
+        }
+
+        EgovCryptoConfigReader reader = new EgovCryptoConfigReader("file:" + propsFile, null);
+        EgovCryptoConfig config = reader.readConfig();
+
+        assertFalse(config.isCrypto());
+        // 명시 안 한 다른 키는 여전히 기본값을 유지해야 한다.
+        assertEquals("SHA-256", config.getAlgorithm());
+    }
+
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

`EgovCryptoConfigReader.readConfig()`는 properties 파일이 있으면 **빈 인스턴스** 위에 파일 내용을 덮어씁니다. 그래서 파일에 적지 않은 키는 `createDefaultConfig()`의 기본값이 아니라 `false`/`null`/`0`이 됩니다.

같은 패턴을 가진 형제 리더 둘은 이미 고쳐졌고, `EgovCryptoConfigReader`만 남았습니다.

| 리더 | 고친 시점 |
|---|---|
| `EgovAccessConfigReader:99` | b3e4d1c "보안점검 적용" (2026-07-29) |
| `EgovSecurityConfigReader:99` | #312 |
| `EgovCryptoConfigReader:97` (수정 전 기준) | 이 PR |

AS-IS
```java
return mapPropertiesToBean(props, EgovCryptoConfig.class);
```

TO-BE
```java
// 파일에 명시되지 않은 키(crypto, algorithm 등)는 기본값을 유지하도록
// 빈 인스턴스가 아니라 createDefaultConfig()를 베이스로 덮어쓴다.
return mapPropertiesToBean(props, createDefaultConfig());
```

`mapPropertiesToBean` 시그니처도 형제 둘과 동일하게 `Class<EgovCryptoConfig>` 대신 `EgovCryptoConfig bean`을 받도록 바꿔 리플렉션으로 빈 인스턴스를 만들던 코드를 지웠습니다.

### 영향 범위

파일에 적은 키는 그대로 반영되므로 바뀌는 것은 "파일은 있는데 그 키를 안 적은" 경우뿐입니다. 미수정 상태에서 `cryptoPropertyLocation`만 적은 파일로 `readConfig()`를 호출하면 이렇게 나옵니다.

```
cryptoBlockSize=0 crypto=false algorithm=null
```

- `cryptoBlockSize=0`은 `EgovCryptoConfiguration:87`의 `egovARIACryptoService.setBlockSize(...)`에서 `IllegalArgumentException: blockSize must be a positive number: 0`으로 기동이 실패합니다.
- `cryptoBlockSize`를 적고 `crypto`만 생략하면 기동은 되고 `crypto=false`가 됩니다. 이 값은 `EgovCryptoConfiguration:104`를 거쳐 `EgovEnvCryptoServiceImpl`의 복호화 분기 4곳(`:244`, `:269`, `:294`, `:319`)을 끄므로 `getDriverClassName()` 등이 암호문을 그대로 돌려줍니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

`EgovCryptoConfigReaderTest` 2건을 추가했습니다(#312에서 추가한 `EgovSecurityConfigReaderTest`와 같은 구성). 일부 키만 적었을 때 나머지가 기본값을 유지하는지, 명시적으로 적은 `crypto=false`가 기본값에 밀리지 않는지를 봅니다. 위 "영향 범위"의 값은 수정 지점만 되돌린 상태에서 직접 실행해 확인했습니다.

수정 전(RED)
```
[ERROR] Tests run: 2, Failures: 2, Errors: 0, Skipped: 0, Time elapsed: 0.266 s <<< FAILURE! -- in org.egovframe.rte.fdl.crypto.config.EgovCryptoConfigReaderTest
[ERROR]   EgovCryptoConfigReaderTest.testReadConfigHonorsExplicitOverrideOfDefaultValue:55 expected: <SHA-256> but was: <null>
[ERROR]   EgovCryptoConfigReaderTest.testReadConfigKeepsSafeDefaultsForOmittedKeys:35 expected: <true> but was: <false>
```

수정 후(GREEN, crypto 모듈 전체)
```
[INFO] Tests run: 24, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [X] 기타 Others

UI 변경이 없어 브라우저 테스트는 해당되지 않습니다.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

해당 없음.
