### PR TITLE
fix: EgovCassandraConfiguration이 자격증명 미설정 시 무인증 클러스터에 접속하지 못하는 문제 수정

### DIFF
--- a/Persistence/org.egovframe.rte.psl.reactive.cassandra/src/main/java/org/egovframe/rte/psl/reactive/cassandra/connect/EgovCassandraConfiguration.java
+++ b/Persistence/org.egovframe.rte.psl.reactive.cassandra/src/main/java/org/egovframe/rte/psl/reactive/cassandra/connect/EgovCassandraConfiguration.java
@@ -16,6 +16,7 @@
 package org.egovframe.rte.psl.reactive.cassandra.connect;
 
 import com.datastax.oss.driver.api.core.CqlSession;
+import com.datastax.oss.driver.api.core.CqlSessionBuilder;
 import org.springframework.data.cassandra.ReactiveSession;
 import org.springframework.data.cassandra.core.cql.session.DefaultBridgedReactiveSession;
 
@@ -98,12 +99,19 @@ public class EgovCassandraConfiguration {
     }
 
     public ReactiveSession reactiveSession() {
-        return new DefaultBridgedReactiveSession(CqlSession.builder()
+        CqlSessionBuilder builder = CqlSession.builder()
                 .withLocalDatacenter(getDataCenterName())
                 .withKeyspace(getKeyspaceName())
-                .addContactPoint(InetSocketAddress.createUnresolved(getContactPoint(), getPort()))
-                .withAuthCredentials(getUsername(), getPassword())
-                .build());
+                .addContactPoint(InetSocketAddress.createUnresolved(getContactPoint(), getPort()));
+        // 자격증명을 설정하지 않으면 인증 없이 접속한다. 형제 EgovRedisConfiguration도 같은 처리다.
+        // 비어 있다는 판정은 드라이버의 Strings.requireNotEmpty와 같은 기준(null 또는 길이 0)을 쓴다.
+        // 한쪽만 설정된 경우는 설정 실수이므로 드라이버가 그대로 검증하도록 넘긴다.
+        boolean hasUsername = getUsername() != null && !getUsername().isEmpty();
+        boolean hasPassword = getPassword() != null && !getPassword().isEmpty();
+        if (hasUsername || hasPassword) {
+            builder = builder.withAuthCredentials(getUsername(), getPassword());
+        }
+        return new DefaultBridgedReactiveSession(builder.build());
     }
 
 }

--- a/Persistence/org.egovframe.rte.psl.reactive.cassandra/src/test/java/org/egovframe/rte/psl/reactive/cassandra/connect/EgovCassandraConfigurationTest.java
+++ b/Persistence/org.egovframe.rte.psl.reactive.cassandra/src/test/java/org/egovframe/rte/psl/reactive/cassandra/connect/EgovCassandraConfigurationTest.java
@@ -1,0 +1,83 @@
+package org.egovframe.rte.psl.reactive.cassandra.connect;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.cassandra.ReactiveSession;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * EgovCassandraConfiguration의 자격증명 처리 테스트
+ *
+ * <p>연결 성공 여부는 보지 않는다. 접속할 노드가 없으면 세션 생성은 어차피 실패하므로,
+ * "자격증명 검증 때문에 연결을 시도해보지도 못하고 막히는가"만 판정한다.
+ * 드라이버는 자격증명이 비어 있으면 연결 전에 거부한다 —
+ * ProgrammaticPlainTextAuthProvider가 Strings.requireNotEmpty로 null이면 NullPointerException,
+ * 빈 문자열이면 IllegalArgumentException을 던진다.</p>
+ */
+public class EgovCassandraConfigurationTest {
+
+    private EgovCassandraConfiguration configWithoutCredentials() {
+        EgovCassandraConfiguration config = new EgovCassandraConfiguration();
+        config.setDataCenterName("datacenter1");
+        config.setKeyspaceName("com");
+        config.setContactPoint("127.0.0.1");
+        config.setPort(9042);
+        return config;
+    }
+
+    private void assertNotRejectedByCredentials(EgovCassandraConfiguration config) {
+        ReactiveSession session = null;
+        try {
+            session = config.reactiveSession();
+        } catch (NullPointerException | IllegalArgumentException e) {
+            fail("자격증명 검증이 연결 시도를 막았다: " + e);
+        } catch (RuntimeException e) {
+            // 접속할 노드가 없어서 나는 실패는 이 테스트의 관심사가 아니다.
+        } finally {
+            if (session != null) {
+                session.close();
+            }
+        }
+    }
+
+    @Test
+    @DisplayName("username/password 미설정 시 자격증명 때문에 세션 생성이 막히지 않는다")
+    public void reactiveSessionWithoutCredentials() {
+        assertNotRejectedByCredentials(configWithoutCredentials());
+    }
+
+    @Test
+    @DisplayName("username/password가 빈 문자열이어도 자격증명 때문에 막히지 않는다")
+    public void reactiveSessionWithBlankCredentials() {
+        EgovCassandraConfiguration config = configWithoutCredentials();
+        config.setUsername("");
+        config.setPassword("");
+
+        assertNotRejectedByCredentials(config);
+    }
+
+    @Test
+    @DisplayName("username/password를 설정하면 종전대로 자격증명이 적용된다")
+    public void reactiveSessionWithCredentials() {
+        EgovCassandraConfiguration config = configWithoutCredentials();
+        config.setUsername("com");
+        config.setPassword("com01");
+
+        assertNotRejectedByCredentials(config);
+    }
+
+    @Test
+    @DisplayName("한쪽만 설정된 자격증명은 드라이버 검증에 그대로 맡긴다")
+    public void reactiveSessionWithUsernameOnly() {
+        EgovCassandraConfiguration config = configWithoutCredentials();
+        config.setUsername("com");
+
+        Throwable thrown = assertThrows(Throwable.class, config::reactiveSession);
+
+        assertInstanceOf(NullPointerException.class, thrown,
+                "password만 빠진 설정은 드라이버가 거부해야 한다. 실제 발생: " + thrown);
+    }
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [x] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

`EgovCassandraConfiguration.reactiveSession()`은 `withAuthCredentials(getUsername(), getPassword())`를 무조건 호출합니다. username/password는 no-arg 생성자와 setter로만 채워지므로 설정하지 않으면 null인데, 드라이버는 이 값을 연결하기 전에 검증합니다.

```
SessionBuilder.withAuthCredentials
  -> new ProgrammaticPlainTextAuthProvider(username, password)
     -> Strings.requireNotEmpty(username, "username")
        null -> NullPointerException: username cannot be null
        ""   -> IllegalArgumentException: username cannot be empty
```

그래서 인증을 쓰지 않는 Cassandra(기본 배포의 `AllowAllAuthenticator`)에는 접속 자체가 되지 않습니다.

형제 `EgovRedisConfiguration.reactiveRedisConnectionFactory()`는 같은 상황을 이미 다르게 처리합니다.

```java
if (password != null && !password.trim().isEmpty()) {
    redisStandaloneConfiguration.setPassword(password);
}
```

이 가드는 v5.0.0 FINAL(`4d97ab5`)에서 새로 들어왔고(v4.3.0은 무조건 `setPassword` 호출), 같은 릴리스에서 Cassandra 쪽 diff는 저작권 표기와 `@author`뿐입니다.

AS-IS

```java
return new DefaultBridgedReactiveSession(CqlSession.builder()
        .withLocalDatacenter(getDataCenterName())
        .withKeyspace(getKeyspaceName())
        .addContactPoint(InetSocketAddress.createUnresolved(getContactPoint(), getPort()))
        .withAuthCredentials(getUsername(), getPassword())
        .build());
```

TO-BE

```java
CqlSessionBuilder builder = CqlSession.builder()
        .withLocalDatacenter(getDataCenterName())
        .withKeyspace(getKeyspaceName())
        .addContactPoint(InetSocketAddress.createUnresolved(getContactPoint(), getPort()));
// 자격증명을 설정하지 않으면 인증 없이 접속한다. 형제 EgovRedisConfiguration도 같은 처리다.
// 비어 있다는 판정은 드라이버의 Strings.requireNotEmpty와 같은 기준(null 또는 길이 0)을 쓴다.
// 한쪽만 설정된 경우는 설정 실수이므로 드라이버가 그대로 검증하도록 넘긴다.
boolean hasUsername = getUsername() != null && !getUsername().isEmpty();
boolean hasPassword = getPassword() != null && !getPassword().isEmpty();
if (hasUsername || hasPassword) {
    builder = builder.withAuthCredentials(getUsername(), getPassword());
}
return new DefaultBridgedReactiveSession(builder.build());
```

### 영향 범위

username/password가 양쪽 다 null이거나 빈 문자열일 때만 동작이 달라집니다. 종전에는 예외로 막혔고 이제 인증 없이 접속합니다. 한쪽만 설정된 경우는 종전대로 드라이버 검증에 맡깁니다.

비어 있다는 판정에 `trim()`을 쓰지 않은 것은 드라이버의 `Strings.requireNotEmpty`가 길이 0만 보기 때문입니다. 기준을 맞춰야 "건너뛸지 판단한 값"과 "실제로 넘기는 값"이 어긋나지 않습니다.

## JUnit 테스트 JUnit tests

- [x] JUnit 테스트 JUnit tests
- [x] 수동 테스트 Manual testing

`EgovCassandraConfigurationTest` 4건을 추가했습니다. 기존 테스트 설정(`CassandraConfiguration`)이 username/password를 항상 채워 이 경로를 밟지 않습니다.

수정 지점만 되돌린 상태(RED)

```
[ERROR] Tests run: 4, Failures: 2, Errors: 0, Skipped: 0
[ERROR]   EgovCassandraConfigurationTest.reactiveSessionWithoutCredentials 자격증명 검증이 연결 시도를 막았다: java.lang.NullPointerException: username cannot be null
[ERROR]   EgovCassandraConfigurationTest.reactiveSessionWithBlankCredentials 자격증명 검증이 연결 시도를 막았다: java.lang.IllegalArgumentException: username cannot be empty
```

수정 후(GREEN)

```
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0
```

이 모듈은 `pom.xml`에 `<skipTests>true</skipTests>`가 있어 로컬 확인 시에만 `false`로 바꿨다가 되돌렸습니다(#315·#316과 같은 방식). 인증 없는 Cassandra 4.1 컨테이너를 띄우고 `mvn clean test`로 모듈 전체를 돌리면 기존 `CassandraTest`(CRUD)까지 포함해 통과합니다.

```
[INFO] Running org.egovframe.rte.psl.reactive.cassandra.repository.CassandraTest
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
[INFO] Running org.egovframe.rte.psl.reactive.cassandra.connect.EgovCassandraConfigurationTest
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0
[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0
```

서버가 있든 없든 같은 결과가 나옵니다. 테스트가 연결 성공이 아니라 자격증명 검증에만 반응하기 때문입니다.
