### PR TITLE
fix: TypedMessage가 attachment value null을 허용해 인터페이스 문서와 모순되는 문제 수정

### DIFF
--- a/Integration/org.egovframe.rte.itl.integration/src/main/java/org/egovframe/rte/itl/integration/message/typed/TypedMessage.java
+++ b/Integration/org.egovframe.rte.itl.integration/src/main/java/org/egovframe/rte/itl/integration/message/typed/TypedMessage.java
@@ -134,12 +134,18 @@ public final class TypedMessage extends TypedMap implements EgovIntegrationMessa
             if (StringUtils.hasText(entry.getKey()) == false) {
                 throw new IllegalArgumentException();
             }
+            if (entry.getValue() == null) {
+                throw new IllegalArgumentException();
+            }
         }
         this.attachments = attachments;
     }
 
     public Object putAttachment(String name, Object attachment) {
         if (StringUtils.hasText(name) == false) {
+            throw new IllegalArgumentException();
+        }
+        if (attachment == null) {
             throw new IllegalArgumentException();
         }
         return attachments.put(name, attachment);

--- a/Integration/org.egovframe.rte.itl.integration/src/test/java/org/egovframe/rte/itl/integration/message/typed/TypedMessageTest.java
+++ b/Integration/org.egovframe.rte.itl.integration/src/test/java/org/egovframe/rte/itl/integration/message/typed/TypedMessageTest.java
@@ -1,0 +1,55 @@
+package org.egovframe.rte.itl.integration.message.typed;
+
+import org.egovframe.rte.itl.integration.type.PrimitiveType;
+import org.egovframe.rte.itl.integration.type.RecordType;
+import org.egovframe.rte.itl.integration.type.Type;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class TypedMessageTest {
+
+    private static final RecordType bodyType = new RecordType("recordA", "RecordA", new HashMap<String, Type>() {
+        /**
+         *  serialVersion UID
+         */
+        private static final long serialVersionUID = 1L;
+
+        {
+            put("stringValue", PrimitiveType.STRING);
+        }
+    });
+
+    @Test
+    public void testSetAttachmentsRejectsNullValue() {
+        // EgovIntegrationMessage#setAttachments의 javadoc: attachments의 value 값 중 null이 있으면 IllegalArgumentException.
+        TypedMessage message = new TypedMessage(bodyType);
+        Map<String, Object> attachments = new HashMap<String, Object>();
+        attachments.put("key", null);
+
+        assertThrows(IllegalArgumentException.class, () -> message.setAttachments(attachments));
+    }
+
+    @Test
+    public void testSetAttachmentsRejectsNullValueAmongMultipleEntries() {
+        // 여러 entry 중 뒤쪽 하나만 value가 null이어도 검증을 통과해선 안 된다.
+        TypedMessage message = new TypedMessage(bodyType);
+        Map<String, Object> attachments = new HashMap<String, Object>();
+        attachments.put("first", "ok");
+        attachments.put("second", null);
+
+        assertThrows(IllegalArgumentException.class, () -> message.setAttachments(attachments));
+    }
+
+    @Test
+    public void testPutAttachmentRejectsNullValue() {
+        // EgovIntegrationMessage#putAttachment의 javadoc: attachment 값이 null이면 IllegalArgumentException.
+        TypedMessage message = new TypedMessage(bodyType);
+
+        assertThrows(IllegalArgumentException.class, () -> message.putAttachment("key", null));
+    }
+
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [x] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

`EgovIntegrationMessage` 인터페이스는 두 메서드에 대해 value가 `null`이면 `IllegalArgumentException`을 던진다고 번호를 매겨 선언합니다.

```
setAttachments  3. Argument attachments의 value 값들 중 null 값이 있는 경우
putAttachment   2. Argument attachment 값이 null인 경우
```

`TypedMessage`는 두 메서드 모두 key만 `StringUtils.hasText`로 검사하고 value는 보지 않아 `null`이 그대로 attachments 맵에 들어갑니다.

형제 구현체 `SimpleMessage`는 #311에서 같은 계약을 지키도록 고쳐졌고 이 클래스만 남았습니다.

AS-IS

```java
public void setAttachments(Map<String, Object> attachments) {
    ...
    for (Entry<String, Object> entry : attachments.entrySet()) {
        if (StringUtils.hasText(entry.getKey()) == false) {
            throw new IllegalArgumentException();
        }
    }
    this.attachments = attachments;
}

public Object putAttachment(String name, Object attachment) {
    if (StringUtils.hasText(name) == false) {
        throw new IllegalArgumentException();
    }
    return attachments.put(name, attachment);
}
```

TO-BE

```java
        if (StringUtils.hasText(entry.getKey()) == false) {
            throw new IllegalArgumentException();
        }
        if (entry.getValue() == null) {
            throw new IllegalArgumentException();
        }
```

```java
    if (StringUtils.hasText(name) == false) {
        throw new IllegalArgumentException();
    }
    if (attachment == null) {
        throw new IllegalArgumentException();
    }
```

### 범위

`setBody`는 뺐습니다. `SimpleMessage`는 자기 생성자 javadoc이 body의 value null 계약을 따로 선언하고 있어 #311이 함께 고쳤지만, `TypedMessage`에는 그 문서가 없고 인터페이스의 `setBody` javadoc도 body 자체가 null인 경우만 규정합니다.

`TypedMessage`의 attachments는 `TypedMap`을 거치지 않는 평범한 `HashMap`이라 바디부의 타입 변환과는 무관한 경로입니다.

## JUnit 테스트 JUnit tests

- [x] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

`TypedMessageTest` 3건을 추가했습니다(#311에서 추가한 `SimpleMessageTest`와 같은 구성).

수정 전(RED)

```
[ERROR] Tests run: 3, Failures: 3, Errors: 0, Skipped: 0
[ERROR]   TypedMessageTest.testSetAttachmentsRejectsNullValue Expected java.lang.IllegalArgumentException to be thrown, but nothing was thrown.
[ERROR]   TypedMessageTest.testSetAttachmentsRejectsNullValueAmongMultipleEntries Expected java.lang.IllegalArgumentException to be thrown, but nothing was thrown.
[ERROR]   TypedMessageTest.testPutAttachmentRejectsNullValue Expected java.lang.IllegalArgumentException to be thrown, but nothing was thrown.
```

수정 후(GREEN, 모듈 전체)

```
[INFO] Tests run: 82, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```
