### PR TITLE
fix: CalendarMapperTypeHandler의 CallableStatement getResult가 항상 null을 반환하는 문제 수정

### DIFF
--- a/Persistence/org.egovframe.rte.psl.dataaccess/src/main/java/org/egovframe/rte/psl/dataaccess/typehandler/CalendarMapperTypeHandler.java
+++ b/Persistence/org.egovframe.rte.psl.dataaccess/src/main/java/org/egovframe/rte/psl/dataaccess/typehandler/CalendarMapperTypeHandler.java
@@ -77,7 +77,14 @@ public class CalendarMapperTypeHandler implements TypeHandler<Calendar> {
     }
 
     public Calendar getResult(CallableStatement cs, int columnIndex) throws SQLException {
-        return null;
+        java.util.Calendar cal = java.util.Calendar.getInstance();
+        if (cs.getTimestamp(columnIndex) == null) {
+            return null;
+        } else {
+            java.sql.Timestamp ts = cs.getTimestamp(columnIndex);
+            cal.setTime(ts);
+            return cal;
+        }
     }
 
 }

--- a/Persistence/org.egovframe.rte.psl.dataaccess/src/test/java/org/egovframe/rte/psl/dataaccess/typehandler/CalendarMapperTypeHandlerTest.java
+++ b/Persistence/org.egovframe.rte.psl.dataaccess/src/test/java/org/egovframe/rte/psl/dataaccess/typehandler/CalendarMapperTypeHandlerTest.java
@@ -18,6 +18,7 @@ package org.egovframe.rte.psl.dataaccess.typehandler;
 import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Proxy;
+import java.sql.CallableStatement;
 import java.sql.ResultSet;
 import java.sql.Timestamp;
 import java.util.Calendar;
@@ -60,6 +61,33 @@ public class CalendarMapperTypeHandlerTest {
         CalendarMapperTypeHandler handler = new CalendarMapperTypeHandler();
         Timestamp ts = Timestamp.valueOf("2024-01-02 03:04:05");
         Calendar cal = handler.getResult(resultSet(ts), 1);
+        assertEquals(ts.getTime(), cal.getTimeInMillis());
+    }
+
+    /** 지정한 컬럼인덱스에서 주어진 Timestamp 를 반환하는 CallableStatement 프록시 (필요 메서드만 구현). */
+    private CallableStatement callableStatement(final Timestamp ts) {
+        return (CallableStatement) Proxy.newProxyInstance(
+                getClass().getClassLoader(),
+                new Class<?>[]{CallableStatement.class},
+                (proxy, method, args) -> {
+                    if ("getTimestamp".equals(method.getName())) {
+                        return ts;
+                    }
+                    throw new UnsupportedOperationException(method.getName());
+                });
+    }
+
+    @Test
+    public void callableStatementNullColumnReturnsNull() throws Exception {
+        CalendarMapperTypeHandler handler = new CalendarMapperTypeHandler();
+        assertNull(handler.getResult(callableStatement(null), 1));
+    }
+
+    @Test
+    public void callableStatementNonNullColumnConverts() throws Exception {
+        CalendarMapperTypeHandler handler = new CalendarMapperTypeHandler();
+        Timestamp ts = Timestamp.valueOf("2024-01-02 03:04:05");
+        Calendar cal = handler.getResult(callableStatement(ts), 1);
         assertEquals(ts.getTime(), cal.getTimeInMillis());
     }
 }


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [x] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

`CalendarMapperTypeHandler`의 `getResult` 오버로드 넷 중 셋은 `getTimestamp`로 값을 읽어 `Calendar`로 변환하는데, `getResult(CallableStatement, int)`만 본문이 `return null`입니다.

```java
getResult(ResultSet, String)      rs.getTimestamp(columnName)  -> Calendar
getResult(ResultSet, int)         rs.getTimestamp(columnIndex) -> Calendar
getResult(CallableStatement, int) return null
```

`CallableStatement`에도 `getTimestamp(int)`가 있으므로 못 읽는 것이 아닙니다. 저장 프로시저의 OUT 파라미터를 `Calendar`로 매핑하면 예외도 로그도 없이 항상 `null`이 돌아옵니다.

AS-IS

```java
public Calendar getResult(CallableStatement cs, int columnIndex) throws SQLException {
    return null;
}
```

TO-BE

```java
public Calendar getResult(CallableStatement cs, int columnIndex) throws SQLException {
    java.util.Calendar cal = java.util.Calendar.getInstance();
    if (cs.getTimestamp(columnIndex) == null) {
        return null;
    } else {
        java.sql.Timestamp ts = cs.getTimestamp(columnIndex);
        cal.setTime(ts);
        return cal;
    }
}
```

형제 오버로드 `getResult(ResultSet, int)`의 본문을 그대로 옮겼습니다.

### 영향 범위

종전에 항상 `null`이던 경로만 값을 돌려주게 됩니다. 다른 세 오버로드는 건드리지 않았습니다.

## JUnit 테스트 JUnit tests

- [x] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

기존 `CalendarMapperTypeHandlerTest`에 `CallableStatement` 케이스 2건을 추가했습니다. 같은 파일이 이미 쓰고 있는 `Proxy` 방식을 그대로 따랐습니다.

수정 지점만 되돌린 상태(RED)

```
[ERROR] Tests run: 4, Failures: 0, Errors: 1, Skipped: 0
[ERROR]   CalendarMapperTypeHandlerTest.callableStatementNonNullColumnConverts NullPointer Cannot invoke "java.util.Calendar.getTimeInMillis()" because "cal" is null
```

수정 후(GREEN, 모듈 전체)

```
[INFO] Tests run: 121, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```
