### PR TITLE
fix: EgovReflectionSupport의 setter/getter 이름 생성이 로케일에 따라 깨져 NPE가 나는 문제 수정

### DIFF
--- a/Batch/org.egovframe.rte.bat.core/src/main/java/org/egovframe/rte/bat/core/reflection/EgovReflectionSupport.java
+++ b/Batch/org.egovframe.rte.bat.core/src/main/java/org/egovframe/rte/bat/core/reflection/EgovReflectionSupport.java
@@ -26,6 +26,7 @@ import java.lang.reflect.Type;
 import java.math.BigDecimal;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 /**
@@ -110,7 +111,7 @@ public class EgovReflectionSupport<T> {
                 for (int i = 0; i < names.length; i++) {
                     String strMethod;
                     if (names[i].length() > 0) {
-                        strMethod = "set" + (names[i].substring(0, 1)).toUpperCase() + names[i].substring(1);
+                        strMethod = "set" + (names[i].substring(0, 1)).toUpperCase(Locale.ROOT) + names[i].substring(1);
                         methodMap.put(names[i], retrieveMethod(methods, strMethod));
                     }
                 }
@@ -169,7 +170,7 @@ public class EgovReflectionSupport<T> {
                     for (int i = 0; i < names.length; i++) {
                         String strMethod;
                         if (names[i].length() > 0) {
-                            strMethod = "get" + (names[i].substring(0, 1)).toUpperCase() + names[i].substring(1);
+                            strMethod = "get" + (names[i].substring(0, 1)).toUpperCase(Locale.ROOT) + names[i].substring(1);
                             localMap.put(names[i], retrieveMethod(localMethods, strMethod));
                         }
                     }

--- a/Batch/org.egovframe.rte.bat.core/src/test/java/org/egovframe/rte/bat/core/reflection/EgovReflectionSupportLocaleTest.java
+++ b/Batch/org.egovframe.rte.bat.core/src/test/java/org/egovframe/rte/bat/core/reflection/EgovReflectionSupportLocaleTest.java
@@ -1,0 +1,79 @@
+package org.egovframe.rte.bat.core.reflection;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Locale;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * EgovReflectionSupport 의 setter/getter 이름 생성이 JVM 기본 로케일과 무관함을 검증한다.
+ *
+ * <p>터키어 로케일에서는 "id".substring(0,1).toUpperCase() 가 점 있는 'İ'(U+0130) 이 되어
+ * "setİd"/"getİd" 를 찾게 되고, 실제 메서드명(setId/getId)과 일치하지 않아 methodMap 에
+ * null 이 담긴다. 이후 invoke 시점에 NullPointerException 으로 죽는다(CWE-176).</p>
+ */
+public class EgovReflectionSupportLocaleTest {
+
+    private static final String[] NAMES = {"id"};
+
+    /** 필드명이 i 로 시작하는 VO. 터키어 로케일에서 대문자화가 깨지는 경계 케이스다. */
+    public static class LocaleVo {
+        private String id;
+
+        public LocaleVo() {
+        }
+
+        public LocaleVo(String id) {
+            this.id = id;
+        }
+
+        public String getId() {
+            return id;
+        }
+
+        public void setId(String id) {
+            this.id = id;
+        }
+    }
+
+    @Test
+    public void getterMethodMapResolvesUnderTurkishLocale() {
+        Locale original = Locale.getDefault();
+        try {
+            Locale.setDefault(Locale.forLanguageTag("tr-TR"));
+            assertEquals("egov", readIdUnderCurrentLocale(),
+                    "터키어 로케일에서도 getId 를 찾아 값을 읽어야 한다");
+
+            Locale.setDefault(Locale.ENGLISH);
+            assertEquals("egov", readIdUnderCurrentLocale(),
+                    "영어 로케일에서도 동일해야 한다");
+        } finally {
+            Locale.setDefault(original);
+        }
+    }
+
+    @Test
+    public void setterMethodMapResolvesUnderTurkishLocale() {
+        Locale original = Locale.getDefault();
+        try {
+            Locale.setDefault(Locale.forLanguageTag("tr-TR"));
+            EgovReflectionSupport<LocaleVo> support = new EgovReflectionSupport<LocaleVo>();
+            support.generateSetterMethodMap(LocaleVo.class, NAMES);
+
+            assertNotNull(support.getMethodMap().get("id"),
+                    "터키어 로케일에서도 setId 를 찾아야 한다");
+        } finally {
+            Locale.setDefault(original);
+        }
+    }
+
+    /** getter map 을 만들고 id 값을 읽는다. 수정 전에는 map 에 null 이 담겨 invoke 에서 NPE 가 난다. */
+    private Object readIdUnderCurrentLocale() {
+        EgovReflectionSupport<LocaleVo> support = new EgovReflectionSupport<LocaleVo>();
+        LocaleVo item = new LocaleVo("egov");
+        support.generateGetterMethodMap(NAMES, item);
+        return support.invokeGettterMethod(item, "id");
+    }
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [x] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

`EgovReflectionSupport`는 VO 필드명으로 접근자 이름을 만들 때 첫 글자를 `toUpperCase()`로 올립니다. 인자 없는 `toUpperCase()`는 JVM 기본 로케일을 따르므로, 터키어·아제르바이잔어 로케일에서 `"id".substring(0, 1).toUpperCase()`는 점 있는 `İ`(U+0130)가 되어 `setİd`/`getİd`를 찾게 되고 실제 메서드명 `setId`/`getId`와 일치하지 않습니다.

`retrieveMethod`는 못 찾으면 `null`을 돌려주고 그 `null`이 그대로 `methodMap`에 담깁니다. `invokeSetterMethod`와 `invokeGettterMethod`는 맵에서 꺼낸 `Method`로 바로 `invoke`를 호출하고 catch도 `IllegalAccessException`/`InvocationTargetException`만 잡으므로, `i`로 시작하는 필드가 하나라도 있으면 `NullPointerException`으로 죽습니다.

AS-IS (`generateSetterMethodMap`, `generateGetterMethodMap` 두 곳)

```java
strMethod = "set" + (names[i].substring(0, 1)).toUpperCase() + names[i].substring(1);
strMethod = "get" + (names[i].substring(0, 1)).toUpperCase() + names[i].substring(1);
```

TO-BE

```java
strMethod = "set" + (names[i].substring(0, 1)).toUpperCase(Locale.ROOT) + names[i].substring(1);
strMethod = "get" + (names[i].substring(0, 1)).toUpperCase(Locale.ROOT) + names[i].substring(1);
```

같은 결함 클래스를 `Locale.ROOT`로 고친 선례가 이 저장소에 있습니다 — `DefaultMapUserDetailsMapping`의 컬럼명 소문자화(#321).

### 영향 범위

ASCII 필드명은 기본 로케일이 무엇이든 결과가 같습니다. 바뀌는 것은 터키어 계열 로케일에서 `i`로 시작하는 필드뿐입니다.

## JUnit 테스트 JUnit tests

- [x] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

`EgovReflectionSupportLocaleTest` 2건을 추가했습니다. 기본 로케일을 `tr-TR`로 바꾼 상태에서 setter/getter 양쪽 경로를 각각 확인하고, 영어 로케일 대조군도 함께 봅니다. 기본 로케일은 `finally`에서 되돌립니다.

수정 지점만 되돌린 상태(RED)

```
[ERROR] Tests run: 2, Failures: 1, Errors: 1, Skipped: 0
[ERROR]   EgovReflectionSupportLocaleTest.setterMethodMapResolvesUnderTurkishLocale 터키어 로케일에서도 setId 를 찾아야 한다 ==> expected: not <null>
[ERROR]   EgovReflectionSupportLocaleTest.getterMethodMapResolvesUnderTurkishLocale » NullPointer Cannot invoke "java.lang.reflect.Method.invoke(Object, Object[])" because the return value of "java.util.HashMap.get(Object)" is null
```

수정 후(GREEN, 모듈 전체)

```
[INFO] Tests run: 76, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```
