### PR TITLE
fix: 설정 리더 3종이 로케일에 따라 properties 키를 조용히 무시하는 문제 수정

### DIFF
--- a/Foundation/org.egovframe.rte.fdl.access/src/main/java/org/egovframe/rte/fdl/access/config/EgovAccessConfigReader.java
+++ b/Foundation/org.egovframe.rte.fdl.access/src/main/java/org/egovframe/rte/fdl/access/config/EgovAccessConfigReader.java
@@ -25,6 +25,7 @@ import java.io.*;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.nio.charset.StandardCharsets;
+import java.util.Locale;
 import java.util.Properties;
 
 /**
@@ -124,7 +125,7 @@ public class EgovAccessConfigReader {
         for (String key : props.stringPropertyNames()) {
             String value = props.getProperty(key);
             if (value == null) continue;
-            String setterName = "set" + key.substring(0, 1).toUpperCase() + key.substring(1);
+            String setterName = "set" + key.substring(0, 1).toUpperCase(Locale.ROOT) + key.substring(1);
             // 2026.02.28 KISA 보안취약점 조치
             try {
                 Method setter = findSetter(bean.getClass(), setterName);

--- a/Foundation/org.egovframe.rte.fdl.access/src/test/java/org/egovframe/rte/fdl/access/config/EgovAccessConfigReaderTest.java
+++ b/Foundation/org.egovframe.rte.fdl.access/src/test/java/org/egovframe/rte/fdl/access/config/EgovAccessConfigReaderTest.java
@@ -1,0 +1,43 @@
+package org.egovframe.rte.fdl.access.config;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Locale;
+import java.util.Properties;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class EgovAccessConfigReaderTest {
+
+    @Test
+    public void testReadConfigAppliesKeysUnderTurkishLocale(@TempDir Path tempDir) throws IOException {
+        // 터키어 로케일에서는 "id".substring(0, 1).toUpperCase()가 점 있는 'İ'(U+0130)가 되어
+        // setter 이름이 "setİd"로 만들어지고, findSetter가 null을 돌려주면서 이 키가 조용히 무시된다.
+        Locale original = Locale.getDefault();
+        try {
+            Locale.setDefault(Locale.forLanguageTag("tr-TR"));
+
+            Path propsFile = tempDir.resolve("egov-access-config.properties");
+            Properties props = new Properties();
+            props.setProperty("id", "customConfigId");
+            try (BufferedWriter writer = Files.newBufferedWriter(propsFile, StandardCharsets.UTF_8)) {
+                props.store(writer, null);
+            }
+
+            EgovAccessConfigReader reader = new EgovAccessConfigReader("file:" + propsFile, null);
+            EgovAccessConfig config = reader.readConfig();
+
+            assertEquals("customConfigId", config.getId(),
+                    "터키어 로케일에서도 properties의 id 키가 반영되어야 한다(기본값 egovAccessConfig로 남으면 안 된다)");
+        } finally {
+            Locale.setDefault(original);
+        }
+    }
+
+}

--- a/Foundation/org.egovframe.rte.fdl.crypto/src/main/java/org/egovframe/rte/fdl/crypto/config/EgovCryptoConfigReader.java
+++ b/Foundation/org.egovframe.rte.fdl.crypto/src/main/java/org/egovframe/rte/fdl/crypto/config/EgovCryptoConfigReader.java
@@ -25,6 +25,7 @@ import java.io.*;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.nio.charset.StandardCharsets;
+import java.util.Locale;
 import java.util.Properties;
 
 /**
@@ -122,7 +123,7 @@ public class EgovCryptoConfigReader {
         for (String key : props.stringPropertyNames()) {
             String value = props.getProperty(key);
             if (value == null) continue;
-            String setterName = "set" + key.substring(0, 1).toUpperCase() + key.substring(1);
+            String setterName = "set" + key.substring(0, 1).toUpperCase(Locale.ROOT) + key.substring(1);
             // 2026.02.28 KISA 보안취약점 조치
             try {
                 Method setter = findSetter(bean.getClass(), setterName);

--- a/Foundation/org.egovframe.rte.fdl.crypto/src/test/java/org/egovframe/rte/fdl/crypto/config/EgovCryptoConfigReaderTest.java
+++ b/Foundation/org.egovframe.rte.fdl.crypto/src/test/java/org/egovframe/rte/fdl/crypto/config/EgovCryptoConfigReaderTest.java
@@ -8,6 +8,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Locale;
 import java.util.Properties;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -53,6 +54,31 @@ public class EgovCryptoConfigReaderTest {
         assertFalse(config.isCrypto());
         // 명시 안 한 다른 키는 여전히 기본값을 유지해야 한다.
         assertEquals("SHA-256", config.getAlgorithm());
+    }
+
+    @Test
+    public void testReadConfigAppliesKeysUnderTurkishLocale(@TempDir Path tempDir) throws IOException {
+        // 터키어 로케일에서는 "id".substring(0, 1).toUpperCase()가 점 있는 'İ'(U+0130)가 되어
+        // setter 이름이 "setİd"로 만들어지고, findSetter가 null을 돌려주면서 이 키가 조용히 무시된다.
+        Locale original = Locale.getDefault();
+        try {
+            Locale.setDefault(Locale.forLanguageTag("tr-TR"));
+
+            Path propsFile = tempDir.resolve("egov-crypto-config.properties");
+            Properties props = new Properties();
+            props.setProperty("id", "customConfigId");
+            try (BufferedWriter writer = Files.newBufferedWriter(propsFile, StandardCharsets.UTF_8)) {
+                props.store(writer, null);
+            }
+
+            EgovCryptoConfigReader reader = new EgovCryptoConfigReader("file:" + propsFile, null);
+            EgovCryptoConfig config = reader.readConfig();
+
+            assertEquals("customConfigId", config.getId(),
+                    "터키어 로케일에서도 properties의 id 키가 반영되어야 한다(기본값 egovCryptoConfig로 남으면 안 된다)");
+        } finally {
+            Locale.setDefault(original);
+        }
     }
 
 }

--- a/Foundation/org.egovframe.rte.fdl.security/src/main/java/org/egovframe/rte/fdl/security/config/EgovSecurityConfigReader.java
+++ b/Foundation/org.egovframe.rte.fdl.security/src/main/java/org/egovframe/rte/fdl/security/config/EgovSecurityConfigReader.java
@@ -25,6 +25,7 @@ import java.io.*;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.nio.charset.StandardCharsets;
+import java.util.Locale;
 import java.util.Properties;
 
 /**
@@ -122,7 +123,7 @@ public class EgovSecurityConfigReader {
         for (String key : props.stringPropertyNames()) {
             String value = props.getProperty(key);
             if (value == null) continue;
-            String setterName = "set" + key.substring(0, 1).toUpperCase() + key.substring(1);
+            String setterName = "set" + key.substring(0, 1).toUpperCase(Locale.ROOT) + key.substring(1);
             // 2026.02.28 KISA 보안취약점 조치
             try {
                 Method setter = findSetter(bean.getClass(), setterName);

--- a/Foundation/org.egovframe.rte.fdl.security/src/test/java/org/egovframe/rte/fdl/security/config/EgovSecurityConfigReaderTest.java
+++ b/Foundation/org.egovframe.rte.fdl.security/src/test/java/org/egovframe/rte/fdl/security/config/EgovSecurityConfigReaderTest.java
@@ -8,6 +8,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Locale;
 import java.util.Properties;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -53,6 +54,31 @@ public class EgovSecurityConfigReaderTest {
         assertFalse(config.isSniff());
         // 명시 안 한 다른 키는 여전히 안전 기본값을 유지해야 한다.
         assertTrue(config.isXssProtection());
+    }
+
+    @Test
+    public void testReadConfigAppliesKeysUnderTurkishLocale(@TempDir Path tempDir) throws IOException {
+        // 터키어 로케일에서는 "id".substring(0, 1).toUpperCase()가 점 있는 'İ'(U+0130)가 되어
+        // setter 이름이 "setİd"로 만들어지고, findSetter가 null을 돌려주면서 이 키가 조용히 무시된다.
+        Locale original = Locale.getDefault();
+        try {
+            Locale.setDefault(Locale.forLanguageTag("tr-TR"));
+
+            Path propsFile = tempDir.resolve("egov-security-config.properties");
+            Properties props = new Properties();
+            props.setProperty("id", "customConfigId");
+            try (BufferedWriter writer = Files.newBufferedWriter(propsFile, StandardCharsets.UTF_8)) {
+                props.store(writer, null);
+            }
+
+            EgovSecurityConfigReader reader = new EgovSecurityConfigReader("file:" + propsFile, null);
+            EgovSecurityConfig config = reader.readConfig();
+
+            assertEquals("customConfigId", config.getId(),
+                    "터키어 로케일에서도 properties의 id 키가 반영되어야 한다(기본값 egovSecurityConfig로 남으면 안 된다)");
+        } finally {
+            Locale.setDefault(original);
+        }
     }
 
 }


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [x] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

`EgovAccessConfigReader` · `EgovCryptoConfigReader` · `EgovSecurityConfigReader`의 `mapPropertiesToBean`은 properties 키로 setter 이름을 만들 때 첫 글자를 `toUpperCase()`로 올립니다. 인자 없는 `toUpperCase()`는 JVM 기본 로케일을 따르므로, 터키어·아제르바이잔어 로케일에서 `"id"`는 점 있는 `İ`(U+0130)가 되어 `setİd`를 찾게 되고 실제 메서드명 `setId`와 일치하지 않습니다.

`findSetter`가 `null`을 돌려주면 바로 아래 `if (setter != null)` 가드에 걸려 **그 키가 예외도 로그도 없이 버려집니다.** 그 가드는 파일에 없는 키를 관대하게 넘기려는 것인데, 여기서는 `setId(String)`가 실제로 있는데도 이름을 못 찾아 버려집니다.

세 `Egov*Config`가 모두 `id` 필드를 갖고 있고 `EgovCryptoConfig`에는 `initial`도 있습니다. 다만 지금은 `getId()`를 읽는 곳이 없어 관측되는 오동작은 없습니다. `i`로 시작하는 키가 앞으로 하나라도 실제로 쓰이면 그때부터 조용히 어긋납니다.

세 파일의 해당 줄은 글자까지 같은 복붙이라 함께 고쳤습니다.

AS-IS

```java
String setterName = "set" + key.substring(0, 1).toUpperCase() + key.substring(1);
```

TO-BE

```java
String setterName = "set" + key.substring(0, 1).toUpperCase(Locale.ROOT) + key.substring(1);
```

같은 결함 클래스를 `Locale.ROOT`로 고친 선례가 이 저장소에 있습니다 — `DefaultMapUserDetailsMapping`의 컬럼명 소문자화(#321). main 코드에 `Locale.ENGLISH`·`Locale.US` 사용은 없고 `Locale.ROOT`만 씁니다.

### 영향 범위

ASCII 키는 기본 로케일이 무엇이든 결과가 같습니다. 바뀌는 것은 터키어 계열 로케일에서 `i`로 시작하는 키뿐입니다.

## JUnit 테스트 JUnit tests

- [x] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

세 리더에 각각 로케일 테스트를 1건씩 추가했습니다. access 모듈에는 리더 테스트가 없어 새로 만들었고, 나머지 둘은 기존 테스트 파일에 붙였습니다.

수정 지점만 되돌린 상태(RED)

```
access     [ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0
crypto     [ERROR] Tests run: 3, Failures: 1, Errors: 0, Skipped: 0
security   [ERROR] Tests run: 3, Failures: 1, Errors: 0, Skipped: 0

EgovAccessConfigReaderTest.testReadConfigAppliesKeysUnderTurkishLocale
  터키어 로케일에서도 properties의 id 키가 반영되어야 한다(기본값 egovAccessConfig로 남으면 안 된다)
  ==> expected: <customConfigId> but was: <egovAccessConfig>
```

수정 후(GREEN, 세 모듈 전체)

```
access     [INFO] Tests run: 11, Failures: 0, Errors: 0, Skipped: 0
crypto     [INFO] Tests run: 25, Failures: 0, Errors: 0, Skipped: 0
security   [INFO] Tests run: 32, Failures: 0, Errors: 0, Skipped: 0
```
