### PR TITLE
fix: EgovStringUtil의 식별자 표기 변환이 로케일에 따라 다른 결과를 내는 문제 수정

### DIFF
--- a/Foundation/org.egovframe.rte.fdl.string/src/main/java/org/egovframe/rte/fdl/string/EgovStringUtil.java
+++ b/Foundation/org.egovframe.rte.fdl.string/src/main/java/org/egovframe/rte/fdl/string/EgovStringUtil.java
@@ -25,6 +25,7 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.StringTokenizer;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -990,7 +991,7 @@ public final class EgovStringUtil {
     public static String convertToCamelCase(String targetString, char posChar) {
         StringBuilder result = new StringBuilder();
         boolean nextUpper = false;
-        String allLower = targetString.toLowerCase();
+        String allLower = targetString.toLowerCase(Locale.ROOT);
         for (int i = 0; i < allLower.length(); i++) {
             char currentChar = allLower.charAt(i);
             if (currentChar == posChar) {
@@ -1029,7 +1030,7 @@ public final class EgovStringUtil {
             if (i > 0 && Character.isUpperCase(currentChar)) {
                 result = result.concat("_");
             }
-            result = result.concat(Character.toString(currentChar).toLowerCase());
+            result = result.concat(Character.toString(currentChar).toLowerCase(Locale.ROOT));
         }
         return result;
     }

--- a/Foundation/org.egovframe.rte.fdl.string/src/test/java/org/egovframe/rte/fdl/string/EgovStringUtilLocaleTest.java
+++ b/Foundation/org.egovframe.rte.fdl.string/src/test/java/org/egovframe/rte/fdl/string/EgovStringUtilLocaleTest.java
@@ -1,0 +1,44 @@
+package org.egovframe.rte.fdl.string;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Locale;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * 식별자 변환 메서드들이 JVM 기본 로케일과 무관하게 동작하는지 검증한다.
+ *
+ * <p>터키어·아제르바이잔어 로케일에서는 인자 없는 toUpperCase()/toLowerCase()가
+ * i ↔ İ(U+0130) / I ↔ ı(U+0131)로 변환한다. 같은 저장소의 CamelCaseUtil은
+ * Character 단위 변환을 써서 이 문제가 없다.</p>
+ */
+public class EgovStringUtilLocaleTest {
+
+    private void underTurkishLocale(Runnable body) {
+        Locale original = Locale.getDefault();
+        try {
+            Locale.setDefault(Locale.forLanguageTag("tr-TR"));
+            body.run();
+        } finally {
+            Locale.setDefault(original);
+        }
+    }
+
+    @Test
+    @DisplayName("convertToCamelCase는 로케일과 무관하게 ASCII 규칙으로 변환한다")
+    public void convertToCamelCaseIsLocaleIndependent() {
+        underTurkishLocale(() ->
+                assertEquals("printStatus", EgovStringUtil.convertToCamelCase("PRINT_STATUS", '_')));
+        assertEquals("printStatus", EgovStringUtil.convertToCamelCase("PRINT_STATUS", '_'));
+    }
+
+    @Test
+    @DisplayName("convertToUnderScore는 로케일과 무관하게 ASCII 규칙으로 변환한다")
+    public void convertToUnderScoreIsLocaleIndependent() {
+        underTurkishLocale(() ->
+                assertEquals("print_id", EgovStringUtil.convertToUnderScore("printId")));
+        assertEquals("print_id", EgovStringUtil.convertToUnderScore("printId"));
+    }
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [x] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

`convertToCamelCase`와 `convertToUnderScore`는 자기 javadoc이 식별자 표기 변환임을 명시합니다.

```
This method convert "string_util" to "stringUtil"
Convert a camel case string to underscore representation.
```

그런데 인자 없는 `toLowerCase()`를 써서 JVM 기본 로케일을 따릅니다. 터키어·아제르바이잔어 로케일에서는 `I`가 점 없는 `ı`(U+0131)로 바뀝니다.

```
convertToCamelCase("PRINT_STATUS", '_')  ->  "prıntStatus"   (기대 "printStatus")
convertToUnderScore("printId")           ->  "print_ıd"      (기대 "print_id")
```

같은 일을 하는 형제 구현이 이 저장소에 둘 있고 둘 다 로케일 독립입니다.

| 구현 | 모듈 | 방식 |
|---|---|---|
| `CamelCaseUtil.convert2CamelCase` | fdl.security | `Character.toUpperCase(char)` / `toLowerCase(char)` |
| `CamelUtil.convert2CamelCase` | psl.dataaccess | 동일 |
| `EgovStringUtil` 위 두 메서드 | fdl.string | `String.toLowerCase()` |

AS-IS

```java
String allLower = targetString.toLowerCase();
result = result.concat(Character.toString(currentChar).toLowerCase());
```

TO-BE

```java
String allLower = targetString.toLowerCase(Locale.ROOT);
result = result.concat(Character.toString(currentChar).toLowerCase(Locale.ROOT));
```

같은 결함 클래스를 `Locale.ROOT`로 고친 선례가 이 저장소에 있습니다 — `DefaultMapUserDetailsMapping`의 컬럼명 소문자화(#321).

### 범위

같은 파일의 `capitalize`와 `swapFirstLetterCase`도 인자 없는 변환을 쓰지만 뺐습니다. 두 메서드는 식별자 용도라는 근거가 없습니다.

- `swapFirstLetterCase`는 javadoc 예시가 `'Password'`/`'password'`이고, 기존 테스트(`EgovStringUtilTest.testSwapFirstLetterCase`)도 그 단어만 다룹니다.
- `capitalize`는 javadoc이 메서드명 한 줄뿐이고, 저장소 안에 호출처도 테스트도 없습니다.

로케일을 고정하면 터키어 단어를 대문자화하려는 정상 사용을 오히려 깨뜨립니다.

ASCII 식별자는 기본 로케일이 무엇이든 결과가 같습니다. 바뀌는 것은 터키어 계열 로케일에서 `i`/`I`가 든 이름뿐입니다.

## JUnit 테스트 JUnit tests

- [x] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

`EgovStringUtilLocaleTest` 2건을 추가했습니다. 기본 로케일을 `tr-TR`로 바꾼 상태와 원래 로케일 양쪽에서 같은 결과가 나오는지 봅니다. 기본 로케일은 `finally`에서 되돌립니다.

수정 지점만 되돌린 상태(RED)

```
[ERROR] Tests run: 2, Failures: 2, Errors: 0, Skipped: 0
[ERROR]   EgovStringUtilLocaleTest.convertToCamelCaseIsLocaleIndependent expected: <printStatus> but was: <prıntStatus>
[ERROR]   EgovStringUtilLocaleTest.convertToUnderScoreIsLocaleIndependent expected: <print_id> but was: <print_ıd>
```

수정 후(GREEN, 모듈 전체)

```
[INFO] Tests run: 58, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```
