### PR TITLE
fix: 비밀번호 인코더 선택이 로케일에 따라 달라지는 문제 수정

### DIFF
--- a/Foundation/org.egovframe.rte.fdl.security/src/main/java/org/egovframe/rte/fdl/security/config/EgovSecurityConfiguration.java
+++ b/Foundation/org.egovframe.rte.fdl.security/src/main/java/org/egovframe/rte/fdl/security/config/EgovSecurityConfiguration.java
@@ -208,9 +208,9 @@ public class EgovSecurityConfiguration {
     @Bean
     public PasswordEncoder passwordEncoder(EgovSecurityConfig securityConfig) {
         String rawHash = securityConfig != null ? securityConfig.getHash() : null;
-        String securityHash = (rawHash == null || rawHash.trim().isEmpty()) ? "sha-256" : rawHash.trim().toLowerCase();
+        String securityHash = (rawHash == null || rawHash.trim().isEmpty()) ? "sha-256" : rawHash.trim().toLowerCase(Locale.ROOT);
         boolean securityHashBase64 = securityConfig != null && securityConfig.isHashBase64();
-        switch (securityHash.toLowerCase()) {
+        switch (securityHash) {
             case "plaintext":
             case "noop":
                 return NoOpPasswordEncoder.getInstance();
@@ -225,7 +225,7 @@ public class EgovSecurityConfiguration {
                 return md5Encoder;
             default:
                 if (securityHash.startsWith("sha")) {
-                    String algorithm = securityHash.replace("-", "").toUpperCase();
+                    String algorithm = securityHash.replace("-", "").toUpperCase(Locale.ROOT);
                     if ("SHA".equals(algorithm)) algorithm = "SHA-256"; // "sha" 입력 시 기본값 설정
                     MessageDigestPasswordEncoder shaEncoder = new MessageDigestPasswordEncoder(algorithm);
                     shaEncoder.setEncodeHashAsBase64(securityHashBase64);
@@ -244,7 +244,7 @@ public class EgovSecurityConfiguration {
     @Bean
     public AuthenticationManager authenticationManager(EgovSecurityConfig securityConfig, PasswordEncoder passwordEncoder) {
         String rawHash = securityConfig != null ? securityConfig.getHash() : null;
-        String securityHash = (rawHash == null || rawHash.trim().isEmpty()) ? "sha-256" : rawHash.trim().toLowerCase();
+        String securityHash = (rawHash == null || rawHash.trim().isEmpty()) ? "sha-256" : rawHash.trim().toLowerCase(Locale.ROOT);
 
         DaoAuthenticationProvider provider;
         if (isIdSaltHash(securityHash)) {

--- a/Foundation/org.egovframe.rte.fdl.security/src/test/java/org/egovframe/rte/fdl/security/config/EgovSecurityConfigurationHashLocaleTest.java
+++ b/Foundation/org.egovframe.rte.fdl.security/src/test/java/org/egovframe/rte/fdl/security/config/EgovSecurityConfigurationHashLocaleTest.java
@@ -1,0 +1,43 @@
+package org.egovframe.rte.fdl.security.config;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.crypto.password.NoOpPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.Locale;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+/**
+ * hash 설정값을 switch 키로 정규화할 때 기본 로케일에 휘둘리지 않는지 검증한다.
+ *
+ * <p>터키어·아제르바이잔어 로케일에서 "PLAINTEXT".toLowerCase()는 점 없는 ı가 섞인
+ * "plaıntext"가 되어 case "plaintext"에 걸리지 않는다. 같은 파일의 xframeOptions
+ * 분기(:488)는 이미 Locale.ROOT로 정규화한다.</p>
+ */
+public class EgovSecurityConfigurationHashLocaleTest {
+
+    private PasswordEncoder encoderFor(String hash) {
+        EgovSecurityConfig config = new EgovSecurityConfig();
+        config.setHash(hash);
+        return new EgovSecurityConfiguration().passwordEncoder(config);
+    }
+
+    @Test
+    @DisplayName("hash=PLAINTEXT는 로케일과 무관하게 NoOpPasswordEncoder로 해석된다")
+    public void plaintextHashResolvesUnderTurkishLocale() {
+        Locale original = Locale.getDefault();
+        try {
+            Locale.setDefault(Locale.forLanguageTag("tr-TR"));
+            assertInstanceOf(NoOpPasswordEncoder.class, encoderFor("PLAINTEXT"),
+                    "터키어 로케일에서도 PLAINTEXT는 NoOp으로 해석되어야 한다");
+
+            Locale.setDefault(Locale.ENGLISH);
+            assertInstanceOf(NoOpPasswordEncoder.class, encoderFor("PLAINTEXT"),
+                    "영어 로케일에서도 동일해야 한다");
+        } finally {
+            Locale.setDefault(original);
+        }
+    }
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [x] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

`EgovSecurityConfiguration.passwordEncoder`는 설정값 `hash`를 소문자로 정규화해 `switch` 키로 씁니다. 인자 없는 `toLowerCase()`는 JVM 기본 로케일을 따르므로, 터키어·아제르바이잔어 로케일에서 `"PLAINTEXT"`는 점 없는 `ı`가 섞인 `"plaıntext"`가 되어 `case "plaintext"`에 걸리지 않습니다.

그러면 `default` 분기로 빠지고 `securityHash.startsWith("sha")`도 아니므로 `NoOpPasswordEncoder` 대신 `BCryptPasswordEncoder`가 선택됩니다. 평문으로 저장된 비밀번호를 BCrypt로 검증하게 되어 로그인이 실패합니다.

**같은 파일이 이미 정답을 갖고 있습니다.** `xframeOptions` 분기는 같은 종류의 정규화를 `Locale.ROOT`로 합니다.

```java
:488  switch (xfo.trim().toUpperCase(Locale.ROOT))   // 있음
:213  switch (securityHash.toLowerCase())            // 없음
```

AS-IS

```java
String securityHash = (rawHash == null || rawHash.trim().isEmpty()) ? "sha-256" : rawHash.trim().toLowerCase();
...
switch (securityHash.toLowerCase()) {
...
    String algorithm = securityHash.replace("-", "").toUpperCase();
```

TO-BE

```java
String securityHash = (rawHash == null || rawHash.trim().isEmpty()) ? "sha-256" : rawHash.trim().toLowerCase(Locale.ROOT);
...
switch (securityHash) {
...
    String algorithm = securityHash.replace("-", "").toUpperCase(Locale.ROOT);
```

`switch` 문의 `securityHash.toLowerCase()`는 바로 위에서 이미 정규화한 값을 다시 소문자화하던 것이라 함께 지웠습니다. `authenticationManager`의 같은 정규화에도 `Locale.ROOT`를 넣었습니다.

같은 결함 클래스를 `Locale.ROOT`로 고친 선례가 이 저장소에 있습니다 — `DefaultMapUserDetailsMapping`의 컬럼명 소문자화(#321).

### 영향 범위

ASCII 설정값은 기본 로케일이 무엇이든 결과가 같습니다. 바뀌는 것은 터키어 계열 로케일에서 `i`/`I`가 든 값뿐이고, 현재 switch 케이스 중에는 `plaintext`가 해당합니다.

## JUnit 테스트 JUnit tests

- [x] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

`EgovSecurityConfigurationHashLocaleTest` 1건을 추가했습니다. 기본 로케일을 `tr-TR`로 바꾼 상태와 영어 로케일에서 각각 `hash=PLAINTEXT`가 `NoOpPasswordEncoder`로 해석되는지 봅니다.

수정 지점만 되돌린 상태(RED)

```
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0
[ERROR]   EgovSecurityConfigurationHashLocaleTest.plaintextHashResolvesUnderTurkishLocale
          터키어 로케일에서도 PLAINTEXT는 NoOp으로 해석되어야 한다
          ==> Unexpected type, expected: <NoOpPasswordEncoder> but was: <BCryptPasswordEncoder>
```

수정 후(GREEN, 모듈 전체)

```
[INFO] Tests run: 32, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```
