### PR TITLE
fix: ShellScriptSupport.isUnix()가 AIX에서 항상 false를 반환하는 문제 수정

### DIFF
--- a/Batch/org.egovframe.rte.bat.core/src/main/java/org/egovframe/rte/bat/core/step/ShellScriptSupport.java
+++ b/Batch/org.egovframe.rte.bat.core/src/main/java/org/egovframe/rte/bat/core/step/ShellScriptSupport.java
@@ -25,6 +25,7 @@ import java.io.InputStreamReader;
 import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.Locale;
 import java.util.Set;
 import java.util.regex.Pattern;
 
@@ -40,7 +41,7 @@ public class ShellScriptSupport {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ShellScriptSupport.class);
 
-    private static String OS = System.getProperty("os.name").toLowerCase();
+    private static String OS = System.getProperty("os.name").toLowerCase(Locale.ROOT);
     private static String OSEncoding = System.getProperty("file.encoding");
 
     /** 셸 메타문자 패턴 - 명령어 삽입 방지용 (; | & ` $ ( ) \ < > newline 등) */
@@ -145,7 +146,7 @@ public class ShellScriptSupport {
     }
 
     public static boolean isUnix() {
-        return (OS.indexOf("nix") >= 0 || OS.indexOf("nux") >= 0 || OS.indexOf("aix") > 0);
+        return (OS.indexOf("nix") >= 0 || OS.indexOf("nux") >= 0 || OS.indexOf("aix") >= 0);
     }
 
     public static boolean isSolaris() {

--- a/Batch/org.egovframe.rte.bat.core/src/test/java/org/egovframe/rte/bat/core/step/ShellScriptSupportOsTest.java
+++ b/Batch/org.egovframe.rte.bat.core/src/test/java/org/egovframe/rte/bat/core/step/ShellScriptSupportOsTest.java
@@ -1,0 +1,42 @@
+package org.egovframe.rte.bat.core.step;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * OS 판별 메서드 테스트.
+ *
+ * <p>OS 필드는 클래스 로드 시 한 번만 채워지므로, 판별 로직만 보기 위해
+ * 리플렉션으로 값을 바꾼 뒤 되돌린다.</p>
+ */
+public class ShellScriptSupportOsTest {
+
+    private void withOsName(String value, Runnable body) throws Exception {
+        Field field = ShellScriptSupport.class.getDeclaredField("OS");
+        field.setAccessible(true);
+        String original = (String) field.get(null);
+        try {
+            field.set(null, value);
+            body.run();
+        } finally {
+            field.set(null, original);
+        }
+    }
+
+    @Test
+    @DisplayName("AIX에서 isUnix()가 true를 반환한다")
+    public void isUnixOnAix() throws Exception {
+        withOsName("aix", () -> assertTrue(ShellScriptSupport.isUnix(),
+                "os.name이 AIX면 isUnix()가 true여야 한다"));
+    }
+
+    @Test
+    @DisplayName("Linux 판별은 종전과 같다")
+    public void isUnixOnOthers() throws Exception {
+        withOsName("linux", () -> assertTrue(ShellScriptSupport.isUnix()));
+    }
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [x] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

`ShellScriptSupport.isUnix()` 한 줄 안에서 세 비교가 서로 다릅니다.

```java
return (OS.indexOf("nix") >= 0 || OS.indexOf("nux") >= 0 || OS.indexOf("aix") > 0);
                          ^^^^                      ^^^^                      ^^^
```

AIX의 `os.name`은 `"AIX"`이므로 소문자화하면 `"aix"`가 되고 `indexOf`는 **0**을 돌려줍니다. `> 0`이라 이 조건은 성립할 수 없습니다. 즉 `"aix"` 토큰은 자기가 매칭할 수 있는 유일한 문자열에 대해 죽어 있습니다.

같은 판정이 로케일에도 걸립니다. `OS`는 인자 없는 `toLowerCase()`로 만들어지는데, 터키어·아제르바이잔어 로케일에서 `"AIX"`는 점 없는 `ı`가 섞인 `"aıx"`가 되어 `indexOf("aix")`가 -1이 됩니다. `>= 0`으로 고쳐도 그 로케일에서는 여전히 못 찾습니다. 두 원인이 같은 판정 하나에 겹쳐 있어 함께 고쳤습니다.

AS-IS

```java
private static String OS = System.getProperty("os.name").toLowerCase();
...
return (OS.indexOf("nix") >= 0 || OS.indexOf("nux") >= 0 || OS.indexOf("aix") > 0);
```

TO-BE

```java
private static String OS = System.getProperty("os.name").toLowerCase(Locale.ROOT);
...
return (OS.indexOf("nix") >= 0 || OS.indexOf("nux") >= 0 || OS.indexOf("aix") >= 0);
```

같은 결함 클래스를 `Locale.ROOT`로 고친 선례가 이 저장소에 있습니다 — `DefaultMapUserDetailsMapping`의 컬럼명 소문자화(#321).

### 영향 범위

`isWindows()`·`isMac()`·`isSolaris()`의 판정은 그대로입니다. 바뀌는 것은 AIX에서 `isUnix()`가 이제 `true`를 돌려준다는 점뿐입니다.

## JUnit 테스트 JUnit tests

- [x] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

`ShellScriptSupportOsTest` 2건을 추가했습니다. `OS` 필드는 클래스 로드 시 한 번만 채워지므로, 리플렉션으로 값을 바꿔 판정 로직만 확인하고 `finally`에서 되돌립니다.

수정 지점만 되돌린 상태(RED)

```
[ERROR] Tests run: 2, Failures: 1, Errors: 0, Skipped: 0
[ERROR]   ShellScriptSupportOsTest.isUnixOnAix
          os.name이 AIX면 isUnix()가 true여야 한다 ==> expected: <true> but was: <false>
```

수정 후(GREEN, 모듈 전체)

```
[INFO] Tests run: 76, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```

로케일 쪽은 `OS`가 이미 채워진 뒤라 같은 방식으로 재현할 수 없어 테스트가 덮지 못합니다.
