### PR TITLE
fix(EgovStringUtil): encodePassword가 비밀번호를 UTF-8로 해시하도록 수정 — 기본 charset 의존 해시 불일치 (CWE-176)

### DIFF
--- a/Foundation/org.egovframe.rte.fdl.string/src/main/java/org/egovframe/rte/fdl/string/EgovStringUtil.java
+++ b/Foundation/org.egovframe.rte.fdl.string/src/main/java/org/egovframe/rte/fdl/string/EgovStringUtil.java
@@ -535,7 +535,7 @@ public final class EgovStringUtil {
      * @return encypted password based on the algorithm.
      */
     public static String encodePassword(String password, String algorithm) {
-        byte[] unencodedPassword = password.getBytes();
+        byte[] unencodedPassword = password.getBytes(StandardCharsets.UTF_8);
         MessageDigest md;
 
         try {

--- a/Foundation/org.egovframe.rte.fdl.string/src/test/java/org/egovframe/rte/fdl/string/EgovStringUtilEncodePasswordCharsetTest.java
+++ b/Foundation/org.egovframe.rte.fdl.string/src/test/java/org/egovframe/rte/fdl/string/EgovStringUtilEncodePasswordCharsetTest.java
@@ -1,0 +1,48 @@
+package org.egovframe.rte.fdl.string;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Regression test for {@link EgovStringUtil#encodePassword(String, String)}.
+ *
+ * <p>encodePassword digested {@code password.getBytes()} using the platform default charset,
+ * so a non-ASCII password (e.g. a Korean password) produced a different hash on hosts with
+ * different default charsets (UTF-8 vs. EUC-KR vs. windows-1252). That breaks authentication
+ * consistency across environments. The password must be encoded with a fixed charset (UTF-8).</p>
+ *
+ * <p>The expected value is computed here over the UTF-8 bytes explicitly, so the assertion holds
+ * regardless of the JVM default charset. Run with {@code -Dfile.encoding=ISO-8859-1} to see the
+ * pre-fix code fail (it would digest ISO-8859-1 bytes) while the fixed code passes.</p>
+ *
+ * @author EricSeokgon
+ */
+class EgovStringUtilEncodePasswordCharsetTest {
+
+    private static String sha256HexUtf8(String s) throws Exception {
+        byte[] digest = MessageDigest.getInstance("SHA-256").digest(s.getBytes(StandardCharsets.UTF_8));
+        StringBuilder sb = new StringBuilder();
+        for (byte b : digest) {
+            sb.append(String.format("%02x", b & 0xff));
+        }
+        return sb.toString();
+    }
+
+    @Test
+    @DisplayName("encodePassword hashes over UTF-8 bytes, independent of the platform default charset")
+    void encodePassword_usesUtf8ForNonAsciiPassword() throws Exception {
+        String password = "비밀번호가나다"; // "비밀번호가나다" (non-ASCII)
+
+        String expected = sha256HexUtf8(password);
+        String actual = EgovStringUtil.encodePassword(password, "SHA-256");
+
+        assertEquals(expected, actual,
+                "encodePassword must digest the UTF-8 encoding of the password, "
+                        + "not the platform default charset");
+    }
+}


### PR DESCRIPTION
## 문제

`EgovStringUtil.encodePassword(password, algorithm)`이 비밀번호를 **플랫폼 기본 charset**으로 바이트화한 뒤 해시합니다.

```java
byte[] unencodedPassword = password.getBytes(); // 기본 charset 의존
md.update(unencodedPassword);
```

비-ASCII 비밀번호(예: 한글 비밀번호)의 경우, 기본 charset이 다른 호스트(UTF-8 vs EUC-KR vs windows-1252)에서 **같은 비밀번호가 서로 다른 해시로 계산**됩니다. 그 결과 인코딩이 다른 환경 간 인증이 깨집니다(가입 서버와 로그인 서버의 기본 charset이 다르면 로그인 실패). 재현: `-Dfile.encoding=ISO-8859-1`로 실행하면 한글 비밀번호가 UTF-8 해시와 달라집니다.

## 변경

- `password.getBytes()` → `password.getBytes(StandardCharsets.UTF_8)` (해당 import는 이미 존재). 1줄.

## 검증 (TDD)

회귀 테스트 `EgovStringUtilEncodePasswordCharsetTest`를 추가했습니다. 테스트는 UTF-8 바이트에 대한 SHA-256 hex를 직접 계산해 `encodePassword` 결과와 비교하므로 JVM 기본 charset과 무관하게 성립합니다.

- `-Dfile.encoding=ISO-8859-1` 실행 시: 수정 전 **실패**(`expected: <e21a1e…> but was: <4ef566…>` — ISO-8859-1 바이트 해시), 수정 후 **통과**
- 기본(UTF-8) 실행 시: `fdl.string` 모듈 전체 **57 tests, 0 failures**(기존 테스트 회귀 없음)

## 참고(이 PR 범위 외)

- 같은 클래스의 `@Deprecated encodeString`/`decodeString`(쿠키용, 문서상 weak)도 기본 charset을 쓰지만, deprecated라 이 PR에서는 제외했습니다.