### PR TITLE
fix: AuthoritiesQueryFactoryBean 기본 쿼리가 존재하지 않는 테이블명을 쓰는 문제 수정

### DIFF
--- a/Foundation/org.egovframe.rte.fdl.security/src/main/java/org/egovframe/rte/fdl/security/bean/AuthoritiesQueryFactoryBean.java
+++ b/Foundation/org.egovframe.rte.fdl.security/src/main/java/org/egovframe/rte/fdl/security/bean/AuthoritiesQueryFactoryBean.java
@@ -40,7 +40,7 @@ import org.springframework.util.StringUtils;
  */
 public class AuthoritiesQueryFactoryBean implements FactoryBean<String> {
 
-    private static final String AUTHOR_DEFAULT_QUERY = "select user_id, authority from authorites where user_id = ?";
+    private static final String AUTHOR_DEFAULT_QUERY = "select user_id, authority from authorities where user_id = ?";
     private final EgovSecurityConfig config;
 
     public AuthoritiesQueryFactoryBean(EgovSecurityConfig config) {

--- a/Foundation/org.egovframe.rte.fdl.security/src/test/java/org/egovframe/rte/fdl/security/bean/DefaultQueryFactoryBeanTest.java
+++ b/Foundation/org.egovframe.rte.fdl.security/src/test/java/org/egovframe/rte/fdl/security/bean/DefaultQueryFactoryBeanTest.java
@@ -1,0 +1,63 @@
+package org.egovframe.rte.fdl.security.bean;
+
+import org.egovframe.rte.fdl.security.config.EgovSecurityConfig;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.apache.commons.dbcp2.BasicDataSource;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * 설정을 생략했을 때 쓰이는 기본 조회 쿼리가 실제로 동작하는지 검증.
+ *
+ * UsersQueryFactoryBean과 AuthoritiesQueryFactoryBean은 같은 목적의 형제이고
+ * 둘 다 user_id 컬럼을 쓰는 Spring Security 표준 스키마를 가정한다. 그 스키마를
+ * 그대로 만들어 두 기본 쿼리를 나란히 실행한다.
+ */
+public class DefaultQueryFactoryBeanTest {
+
+    private JdbcTemplate jdbcTemplate;
+
+    @BeforeEach
+    public void setUp() {
+        BasicDataSource dataSource = new BasicDataSource();
+        dataSource.setDriverClassName("org.hsqldb.jdbcDriver");
+        dataSource.setUrl("jdbc:hsqldb:mem:defaultquerytestdb");
+        dataSource.setUsername("sa");
+        dataSource.setPassword("");
+        dataSource.setDefaultAutoCommit(true);
+        jdbcTemplate = new JdbcTemplate(dataSource);
+
+        jdbcTemplate.execute("CREATE TABLE USERS(USER_ID VARCHAR(30) NOT NULL PRIMARY KEY,"
+                + " PASSWORD VARCHAR(100) NOT NULL, ENABLED BOOLEAN DEFAULT TRUE)");
+        jdbcTemplate.execute("CREATE TABLE AUTHORITIES(USER_ID VARCHAR(30) NOT NULL,"
+                + " AUTHORITY VARCHAR(50) NOT NULL)");
+        jdbcTemplate.update("INSERT INTO USERS VALUES(?, ?, ?)", "tester", "{noop}pw", true);
+        jdbcTemplate.update("INSERT INTO AUTHORITIES VALUES(?, ?)", "tester", "ROLE_USER");
+    }
+
+    @AfterEach
+    public void tearDown() {
+        jdbcTemplate.execute("DROP TABLE AUTHORITIES");
+        jdbcTemplate.execute("DROP TABLE USERS");
+    }
+
+    @Test
+    public void usersDefaultQueryRunsOnStandardSchema() {
+        String query = new UsersQueryFactoryBean(new EgovSecurityConfig()).getObject();
+
+        assertDoesNotThrow(() -> jdbcTemplate.queryForList(query, "tester"));
+    }
+
+    @Test
+    public void authoritiesDefaultQueryRunsOnStandardSchema() {
+        String query = new AuthoritiesQueryFactoryBean(new EgovSecurityConfig()).getObject();
+
+        assertDoesNotThrow(() -> jdbcTemplate.queryForList(query, "tester"));
+        assertEquals(1, jdbcTemplate.queryForList(query, "tester").size());
+    }
+
+}


### PR DESCRIPTION
## 수정 사유

로그인할 때 사용자 권한을 조회하는 기본 SQL 에 테이블 이름 오타가 있습니다.
`authorities` 를 `authorites` 로 적어서, 권한 조회 쿼리를 직접 설정하지 않은 곳에서는
로그인이 그대로 실패합니다.

설정을 생략했을 때 쓰이는 권한 조회 기본 쿼리가 존재하지 않는 테이블 `authorites` 를 조회합니다.

- 형제인 `UsersQueryFactoryBean` 은 같은 자리에서 `from users` 를 정확히 씁니다.
- `authorites` 라는 철자는 저장소 전체에서 이 한 줄뿐입니다.

`EgovSecurityConfiguration` 이 이 값을 `EgovJdbcUserDetailsManager.setAuthoritiesByUsernameQuery()` 에
그대로 넘기므로, `jdbcAuthoritiesByUsernameQuery` 를 설정하지 않은 배포에서는 로그인이
`BadSqlGrammarException` 으로 끝납니다.

두 기본 쿼리가 기대하는 컬럼명은 `password` 와 `authority` 입니다. 모듈 테스트가 쓰는
`egov-security-config.properties` 도 `USER_PASSWORD AS PASSWORD` / `AUTHOR_CODE AS AUTHORITY` 로
그 이름에 맞춰 조회하고 있어, 두 기본값이 같은 컬럼 계약을 가정한다는 것을 확인할 수 있습니다.

## 수정된 소스 내용

`AuthoritiesQueryFactoryBean.java`

```java
// AS-IS
private static final String AUTHOR_DEFAULT_QUERY = "select user_id, authority from authorites where user_id = ?";

// TO-BE
private static final String AUTHOR_DEFAULT_QUERY = "select user_id, authority from authorities where user_id = ?";
```

## JUnit 테스트

두 기본 쿼리가 공통으로 기대하는 컬럼명을 가진 스키마를 만들고, 두 쿼리를 나란히 실행합니다.
`DefaultQueryFactoryBeanTest` 를 추가했습니다.

**수정 전** — `users` 쪽은 통과하고 `authorities` 쪽만 실패합니다.

```
[ERROR] Tests run: 2, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.474 s <<< FAILURE!
[ERROR]   DefaultQueryFactoryBeanTest.authoritiesDefaultQueryRunsOnStandardSchema:58
          Unexpected exception thrown: org.springframework.jdbc.BadSqlGrammarException:
          PreparedStatementCallback; bad SQL grammar
          [select user_id, authority from authorites where user_id = ?]
```

**수정 후**

```
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.410 s
```

**모듈 전체**

```
mvn -pl Foundation/org.egovframe.rte.fdl.security test

[INFO] Tests run: 33, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```

## 테스트 브라우저

해당 없음 (서버 측 설정값 수정)

## 테스트 스크린샷

해당 없음
