### PR TITLE
fix: getParameterValues() 여러 번 호출 시 중복 entity encoding 수정

### DIFF
--- a/Presentation/org.egovframe.rte.ptl.mvc/src/main/java/org/egovframe/rte/ptl/mvc/filter/HTMLTagFilterRequestWrapper.java
+++ b/Presentation/org.egovframe.rte.ptl.mvc/src/main/java/org/egovframe/rte/ptl/mvc/filter/HTMLTagFilterRequestWrapper.java
@@ -46,14 +46,15 @@ public class HTMLTagFilterRequestWrapper extends HttpServletRequestWrapper {
         if (values == null) {
             return null;
         }
+        String[] safeValues = new String[values.length];
         for (int i = 0; i < values.length; i++) {
             if (values[i] != null) {
-                values[i] = getSafeParamData(values[i]);
+                safeValues[i] = getSafeParamData(values[i]);
             } else {
-                values[i] = null;
+                safeValues[i] = null;
             }
         }
-        return values;
+        return safeValues;
     }
 
     public String getParameter(String parameter) {

--- a/Presentation/org.egovframe.rte.ptl.mvc/src/test/java/org/egovframe/rte/ptl/mvc/filter/HTMLTagFilterTest.java
+++ b/Presentation/org.egovframe.rte.ptl.mvc/src/test/java/org/egovframe/rte/ptl/mvc/filter/HTMLTagFilterTest.java
@@ -68,4 +68,27 @@ public class HTMLTagFilterTest {
         assertArrayEquals(new String[]{"added"}, parameterMap.get("param02"));
     }
 
+    @Test
+    public void getParameterValuesShouldNotEscapeRepeatedCallsTwice() {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addParameter("param01", "<b>test&\"'</b>");
+        HTMLTagFilterRequestWrapper requestWrapper = new HTMLTagFilterRequestWrapper(request);
+
+        String[] expected = {"&lt;b&gt;test&amp;&quot;&apos;&lt;/b&gt;"};
+
+        assertArrayEquals(expected, requestWrapper.getParameterValues("param01"));
+        assertArrayEquals(expected, requestWrapper.getParameterValues("param01"));
+    }
+
+    @Test
+    public void getParameterValuesShouldNotMutateOriginalRequest() {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addParameter("param01", "<b>test</b>");
+        HTMLTagFilterRequestWrapper requestWrapper = new HTMLTagFilterRequestWrapper(request);
+
+        requestWrapper.getParameterValues("param01");
+
+        assertEquals("<b>test</b>", request.getParameter("param01"));
+    }
+
 }


### PR DESCRIPTION
## 수정 사유

XSS 방지 필터가 같은 파라미터를 두 번 읽으면 `<b>` 가 `&lt;b&gt;` 를 거쳐
`&amp;lt;b&amp;gt;` 까지 가서 화면에 깨진 글자가 나옵니다. 필터를 거친 값이 원래
request 에까지 남는 것도 같은 원인입니다.

`992c892` ("getParameterMap() 여러 번 호출 시 중복 entity encoding 수정") 가 `getParameterMap()` 의
같은 문제를 새 배열에 담아 반환하는 방식으로 고쳤는데, 바로 위에 있는 `getParameterValues()` 는
그대로 남아 `super` 가 돌려준 배열에 결과를 덮어씁니다. 같은 클래스 안에서 두 메서드가 반대로
동작합니다.

감싼 request 가 그 배열을 내부와 공유하는 경우 두 가지 문제가 생깁니다.

- 같은 파라미터를 두 번 읽으면 이미 이스케이프된 값이 한 번 더 이스케이프됩니다.
- 원 request 를 `getParameter` 로 읽어도 이스케이프된 값이 나옵니다.

## 수정된 소스 내용

`HTMLTagFilterRequestWrapper.java`

```java
// AS-IS
for (int i = 0; i < values.length; i++) {
    if (values[i] != null) {
        values[i] = getSafeParamData(values[i]);
    } else {
        values[i] = null;
    }
}
return values;

// TO-BE
String[] safeValues = new String[values.length];
for (int i = 0; i < values.length; i++) {
    if (values[i] != null) {
        safeValues[i] = getSafeParamData(values[i]);
    } else {
        safeValues[i] = null;
    }
}
return safeValues;
```

같은 클래스 `getParameterMap()` 이 이미 쓰고 있는 방식과 같습니다.

## JUnit 테스트

`992c892` 가 형제 메서드에 추가한 테스트와 같은 형태로 `HTMLTagFilterTest` 에 두 건을 더했습니다.

**수정 전**

```
[ERROR] Tests run: 7, Failures: 2, Errors: 0, Skipped: 0, Time elapsed: 0.179 s <<< FAILURE!
[ERROR]   HTMLTagFilterTest.getParameterValuesShouldNotEscapeRepeatedCallsTwice:81
          array contents differ at index [0],
          expected: <&lt;b&gt;test&amp;&quot;&apos;&lt;/b&gt;>
          but was:  <&amp;lt;b&amp;gt;test&amp;amp;&amp;quot;&amp;apos;&amp;lt;/b&amp;gt;>
[ERROR]   HTMLTagFilterTest.getParameterValuesShouldNotMutateOriginalRequest:92
          expected: <<b>test</b>> but was: <&lt;b&gt;test&lt;/b&gt;>
```

**수정 후 — 모듈 전체**

```
mvn -pl Presentation/org.egovframe.rte.ptl.mvc test

[INFO] Tests run: 42, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```

## 테스트 브라우저

해당 없음 (서버 측 필터 수정)

## 테스트 스크린샷

해당 없음
