### PR TITLE
fix: EgovUUIdGnrServiceImpl이 IP octet을 16진수로 파싱해 서로 다른 IP가 같은 host id를 갖는 문제 수정

### DIFF
--- a/Foundation/org.egovframe.rte.fdl.idgnr/src/main/java/org/egovframe/rte/fdl/idgnr/impl/EgovUUIdGnrServiceImpl.java
+++ b/Foundation/org.egovframe.rte.fdl.idgnr/src/main/java/org/egovframe/rte/fdl/idgnr/impl/EgovUUIdGnrServiceImpl.java
@@ -206,7 +206,7 @@ public class EgovUUIdGnrServiceImpl implements EgovIdGnrService, ApplicationCont
                 addressBytes[1] = (byte) 255;
                 int i = 2;
                 while (stok.hasMoreTokens()) {
-                    addressBytes[i++] = Integer.valueOf(stok.nextToken(), 16).byteValue();
+                    addressBytes[i++] = Integer.valueOf(stok.nextToken(), 10).byteValue();
                 }
             } else if (address.indexOf(":") > 0) {
                 // we should have a MAC

--- a/Foundation/org.egovframe.rte.fdl.idgnr/src/test/java/org/egovframe/rte/fdl/idgnr/EgovUUIdGnrServiceTest.java
+++ b/Foundation/org.egovframe.rte.fdl.idgnr/src/test/java/org/egovframe/rte/fdl/idgnr/EgovUUIdGnrServiceTest.java
@@ -4,6 +4,7 @@ import jakarta.annotation.Resource;
 import org.egovframe.rte.fdl.cmmn.exception.FdlException;
 import org.egovframe.rte.fdl.idgnr.config.IdgnrTestConfig;
 import org.egovframe.rte.fdl.idgnr.config.UUIdGenerationConfig;
+import org.egovframe.rte.fdl.idgnr.impl.EgovUUIdGnrServiceImpl;
 import org.egovframe.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -11,7 +12,9 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.math.BigDecimal;
+import java.util.UUID;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
@@ -89,6 +92,33 @@ public class EgovUUIdGnrServiceTest {
         for (int i = 0; i < 10; i++) {
             assertNotNull(decimal = uUIdGenerationServiceWithIP.getNextBigDecimalId());
         }
+    }
+
+    /**
+     * IP 세팅시 octet 은 10진수로 해석되어야 함 테스트
+     */
+    @Test
+    public void testUUIdGenerationIPOctetRadix() throws FdlException {
+        // 100.128.120.107 의 octet 은 0x64, 0x80, 0x78, 0x6B (앞 2 byte 는 0xFF 고정)
+        assertEquals(0x0000FFFF6480786BL, hostId(uUIdGenerationServiceWithIP.getNextStringId()));
+    }
+
+    /**
+     * 서로 다른 IP 가 같은 host id 로 접히지 않는지 테스트
+     */
+    @Test
+    public void testUUIdGenerationIPHostIdCollision() throws Exception {
+        EgovUUIdGnrServiceImpl generator = new EgovUUIdGnrServiceImpl();
+        generator.setAddress("192.168.156.1");
+        EgovUUIdGnrServiceImpl other = new EgovUUIdGnrServiceImpl();
+        other.setAddress("192.168.56.1");
+
+        assertEquals(0x0000FFFFC0A89C01L, hostId(generator.getNextStringId()));
+        assertEquals(0x0000FFFFC0A83801L, hostId(other.getNextStringId()));
+    }
+
+    private long hostId(String uuid) {
+        return UUID.fromString(uuid).getLeastSignificantBits() & 0xFFFFFFFFFFFFL;
     }
 
     /**


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

`EgovUUIdGnrServiceImpl.setAddress()`는 IP와 MAC을 각각 다른 분기에서 파싱하는데 두 분기가 똑같이 radix 16을 씁니다. MAC은 본래 16진 표기라 맞지만 IP octet은 10진입니다.

10진 octet은 글자만 놓고 보면 전부 유효한 16진수여서 걸러지지 않습니다(0~255 중 거부되는 값 0건). radix 16으로 읽은 값이 한 바이트를 넘으면 `byteValue()`에서 잘리므로, 서로 다른 주소가 같은 6바이트로 접힙니다.

0~255를 전부 넣어 보면 나오는 바이트값이 100가지뿐이고 256개 octet이 모두 충돌 그룹에 들어갑니다. 그룹은 `{d, d+100, d+200}` 꼴입니다.

```
서로 다른 바이트값 개수: 100 / 256
충돌 그룹에 속한 octet: 256 / 256
  [0, 100, 200]  [1, 101, 201]  [2, 102, 202]  [3, 103, 203] …
```

`/24`를 100 단위로 끊어 쓰면 `10.0.0.5`·`10.0.100.5`·`10.0.200.5` 셋이 한 값으로 접힙니다.

| 설정한 address | 만들어지는 Address Id |
|---|---|
| `192.168.156.1` | `FF:FF:92:68:56:01` |
| `192.168.56.1` | `FF:FF:92:68:56:01` |

AS-IS (`EgovUUIdGnrServiceImpl:199~210`)

```java
if (address.indexOf(".") > 0) {
    // we should have an IP
    StringTokenizer stok = new StringTokenizer(address, ".");
    ...
    while (stok.hasMoreTokens()) {
        addressBytes[i++] = Integer.valueOf(stok.nextToken(), 16).byteValue();
    }
```

TO-BE

```java
    while (stok.hasMoreTokens()) {
        addressBytes[i++] = Integer.valueOf(stok.nextToken(), 10).byteValue();
    }
```

바로 아래 MAC 분기(`:219`)의 radix 16은 그대로 뒀습니다.

### 영향 범위

이 6바이트는 `hostId`가 되어 `TimeBasedUUIDGenerator.generateIdFromTimestamp:298`에서 UUID lsb의 하위 48비트로 들어갑니다. 따라서 `setAddress()`에 IP를 준 경우에만 `getNextStringId()`·`getNextBigDecimalId()` 값이 달라집니다. `setAddress()`를 부르지 않은 기본 경로(`UUID.randomUUID()`)와 MAC 분기는 그대로입니다.

접히던 octet 쌍으로는 `0`↔`100`, `0`↔`200`, `56`↔`156`이 있습니다. 저장소 테스트 설정 `UUIdGenerationConfig:31`의 `100.128.120.107`도 지금까지 `FF:FF:00:28:20:07`, 즉 `0.128.120.107`과 같은 값으로 해석되고 있었습니다.

클래스 javadoc(`:49~50`, `b3e4d1c` "보안점검 적용")은 여러 WAS가 "동일한 address로 설정되어" 같은 밀리초에 ID를 만들면 UUID가 겹칠 수 있다고 경고합니다. 수정 전에는 주소를 서로 **다르게** 줘도 그 조건에 걸렸습니다. `clockSequence`가 JVM별 static이라 한 JVM 안에서는 드러나지 않아, 위 두 IP를 각각 설정한 JVM 둘을 동시에 띄워 0.4초간 ID를 뽑아 대조했습니다.

```
미수정  A 6,564,099건 / B 6,572,662건 → 양쪽에 똑같이 나온 UUID 6,397,315건
        188ff9cc-01a0-1000-0000-ffff92685601
수정 후  A 8,615,328건 / B 8,615,328건 → 겹친 UUID 0건
        18905d15-01a0-1000-0000-ffffc0a89c01   (192.168.156.1)
        18905d12-01a0-1000-0000-ffffc0a83801   (192.168.56.1)
```

octet에 `a`~`f`가 섞인 값은 이제 `NumberFormatException`이 납니다. 유효한 IPv4가 아니고, 바로 아래 MAC 분기도 16진수가 아닌 토큰에 같은 예외를 냅니다. 이 분기는 원래 그 예외를 잡아 `FdlException(ERROR_STRING)`으로 바꿔 던졌는데, `ac34b96`에서 try/catch가 함께 빠졌습니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

`EgovUUIdGnrServiceTest`에 2건을 추가했습니다.

- `testUUIdGenerationIPOctetRadix` — 기존 `UUIdGenerationServiceWithIP` 빈(`100.128.120.107`)이 만든 host id가 octet의 10진 해석과 맞는지 봅니다.
- `testUUIdGenerationIPHostIdCollision` — `192.168.156.1`과 `192.168.56.1`의 host id를 각각 확인합니다.

host id 추출은 같은 모듈 `EgovUUIdGnrServiceConcurrencyTest:84`가 쓰는 `getLeastSignificantBits() & 0xFFFFFFFFFFFFL`에 맞췄습니다.

수정 전(RED, 수정 지점만 되돌려 실행)

```
[ERROR] Tests run: 6, Failures: 2, Errors: 0, Skipped: 0, Time elapsed: 0.466 s <<< FAILURE! -- in org.egovframe.rte.fdl.idgnr.EgovUUIdGnrServiceTest
[ERROR]   EgovUUIdGnrServiceTest.testUUIdGenerationIPHostIdCollision:116 expected: <281473914018817> but was: <281473138054657>
[ERROR]   EgovUUIdGnrServiceTest.testUUIdGenerationIPOctetRadix:103 expected: <281472367884395> but was: <281470684372999>
```

같은 실행의 디버그 로그입니다. 서로 다른 두 IP가 같은 Address Id로 찍힙니다.

```
DEBUG [org.egovframe.rte.fdl.idgnr.impl.EgovUUIdGnrServiceImpl] Address Id : FF:FF:92:68:56:01
DEBUG [org.egovframe.rte.fdl.idgnr.impl.EgovUUIdGnrServiceImpl] Address Id : FF:FF:92:68:56:01
```

수정 후(GREEN, idgnr 모듈 전체)

```
DEBUG [org.egovframe.rte.fdl.idgnr.impl.EgovUUIdGnrServiceImpl] Address Id : FF:FF:C0:A8:9C:01
DEBUG [org.egovframe.rte.fdl.idgnr.impl.EgovUUIdGnrServiceImpl] Address Id : FF:FF:C0:A8:38:01
[INFO] Tests run: 42, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

해당 없음 (서버 측 ID 생성 로직)

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

해당 없음 (화면 변경 없음)
