### PR TITLE
fix: EgovUserDetailsHelper.getHashedPassword가 프레임워크 설정으로 검증할 수 없는 해시를 반환하는 문제 수정

### DIFF
--- a/Foundation/org.egovframe.rte.fdl.security/src/main/java/org/egovframe/rte/fdl/security/userdetails/util/EgovUserDetailsHelper.java
+++ b/Foundation/org.egovframe.rte.fdl.security/src/main/java/org/egovframe/rte/fdl/security/userdetails/util/EgovUserDetailsHelper.java
@@ -24,8 +24,6 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.crypto.factory.PasswordEncoderFactories;
-import org.springframework.security.crypto.password.DelegatingPasswordEncoder;
 import org.springframework.security.crypto.password.MessageDigestPasswordEncoder;
 import org.springframework.util.ObjectUtils;
 
@@ -128,16 +126,17 @@ public final class EgovUserDetailsHelper {
     }
 
     /**
-     * 기본 algorithmd(SHA-256)에 대한 패스워드 얻기.
+     * 기본 algorithm(SHA-256)에 대한 패스워드 얻기.
+     *
+     * <p>eGovFrame {@code hash}를 지정하지 않았을 때 적용되는 기본 설정과 동일한 방식이다.
+     * {@code hash=eccp} / {@code hash=egov-sha256}을 쓴다면
+     * {@link #getIdSaltHashedPassword(String, String)}를 사용한다.</p>
      *
      * @param password 평문 비밀번호
-     * @return SHA-256 해시
+     * @return salt를 앞에 붙인 SHA-256 해시
      */
     public static String getHashedPassword(String password) {
-        DelegatingPasswordEncoder delegatingPasswordEncoder =
-                (DelegatingPasswordEncoder) PasswordEncoderFactories.createDelegatingPasswordEncoder();
-        delegatingPasswordEncoder.setDefaultPasswordEncoderForMatches(new MessageDigestPasswordEncoder("SHA-256"));
-        return delegatingPasswordEncoder.encode(password);
+        return new MessageDigestPasswordEncoder("SHA-256").encode(password);
     }
 
     /**

--- a/Foundation/org.egovframe.rte.fdl.security/src/test/java/org/egovframe/rte/fdl/security/userdetails/util/EgovUserDetailsHelperTest.java
+++ b/Foundation/org.egovframe.rte.fdl.security/src/test/java/org/egovframe/rte/fdl/security/userdetails/util/EgovUserDetailsHelperTest.java
@@ -1,0 +1,30 @@
+package org.egovframe.rte.fdl.security.userdetails.util;
+
+import org.egovframe.rte.fdl.security.config.EgovSecurityConfig;
+import org.egovframe.rte.fdl.security.config.EgovSecurityConfiguration;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * getHashedPassword 가 만든 해시를 프레임워크가 주입하는 인코더로 검증할 수 있는지 확인한다.
+ *
+ * <p>hash 를 지정하지 않으면 EgovSecurityConfiguration.passwordEncoder() 는 SHA-256 인코더를 돌려준다.
+ * 가입 시 이 메서드로 저장한 값은 그 인코더로 로그인할 수 있어야 한다.</p>
+ */
+public class EgovUserDetailsHelperTest {
+
+    private static final String RAW_PASSWORD = "egov1234";
+
+    @Test
+    public void testGetHashedPasswordMatchesDefaultConfiguredEncoder() {
+        String stored = EgovUserDetailsHelper.getHashedPassword(RAW_PASSWORD);
+
+        PasswordEncoder configured =
+                new EgovSecurityConfiguration().passwordEncoder(new EgovSecurityConfig());
+
+        assertTrue(configured.matches(RAW_PASSWORD, stored),
+                "기본 설정 인코더로 검증되어야 한다 : " + stored);
+    }
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

`EgovUserDetailsHelper.getHashedPassword()`가 돌려준 해시는 이 프레임워크가 주입하는 어떤 인코더로도 검증되지 않습니다. 가입 때 이 메서드로 저장하면 로그인이 되지 않습니다.

반환값에 붙는 `{bcrypt}` 접두어는 `DelegatingPasswordEncoder`만 해석합니다. 그런데 `EgovSecurityConfiguration.passwordEncoder()`가 돌려주는 것은 전부 구체 인코더라 접두어가 붙은 문자열을 풀지 못합니다. `hash` 설정을 바꿔가며 저장값을 그대로 넣어 봤습니다.

| `hash` 설정 | `passwordEncoder()`가 고르는 인코더 | 로그인 |
|---|---|---|
| 미지정 (기본값 `sha-256`) | `MessageDigestPasswordEncoder("SHA-256")` | 실패 |
| `sha-256` + `hashBase64` | 같음, Base64 출력 | 실패 |
| `md5` | `MessageDigestPasswordEncoder("MD5")` | 실패 |
| `ldap` | `LdapShaPasswordEncoder` | `IllegalArgumentException` |
| 그 밖의 값 | `BCryptPasswordEncoder` | 실패 |
| `eccp` · `egov-sha256` | `EgovIdSaltSha256PasswordEncoder` | 실패 |

javadoc은 "기본 algorithmd(SHA-256)에 대한 패스워드 얻기"라고 적고, `EgovSecurityConfiguration:211`도 `hash`를 지정하지 않으면 `sha-256`을 기본값으로 삼습니다. 문서와 설정이 같은 곳을 가리키는데 코드만 다른 값을 냅니다.

| 시점 | 코드 | javadoc |
|---|---|---|
| 초기 커밋 | `ShaPasswordEncoder(256)` | 요약 "기본 algorithmd(SHA-256)", `@return` 비어 있음 |
| `ac34b96` v4.0.0 alpha | `DelegatingPasswordEncoder`(기본 bcrypt) | 요약 그대로, `@return` 비어 있음 |
| `73f7d40` "NCSC&NIA 보안점검 적용" | 그대로 | `@return SHA-256 해시` 채움 |

`73f7d40`은 비어 있던 `@param`과 `@return`을 채우면서 형제 `getIdSaltHashedPassword`도 같이 넣었고, 그쪽 javadoc에는 자기 알고리즘과 짝이 되는 `hash` 설정(`egov-sha256`·`eccp`)까지 적혀 있습니다. 그 정리를 `getHashedPassword`까지 마저 맞추는 변경입니다. `hash` 기본값에 맞추고, `eccp`·`egov-sha256`을 쓸 때는 형제를 쓰도록 안내를 넣었습니다.

`ac34b96`에서 같이 들어간 `setDefaultPasswordEncoderForMatches(...)`는 `matches()`가 접두어 없는 값을 만났을 때 쓸 인코더를 정하는 것이라 `encode()` 결과에 관여하지 않습니다. 이 인스턴스는 `encode()`를 한 번 부르고 버려집니다.

AS-IS

```java
/**
 * 기본 algorithmd(SHA-256)에 대한 패스워드 얻기.
 *
 * @param password 평문 비밀번호
 * @return SHA-256 해시
 */
public static String getHashedPassword(String password) {
    DelegatingPasswordEncoder delegatingPasswordEncoder =
            (DelegatingPasswordEncoder) PasswordEncoderFactories.createDelegatingPasswordEncoder();
    delegatingPasswordEncoder.setDefaultPasswordEncoderForMatches(new MessageDigestPasswordEncoder("SHA-256"));
    return delegatingPasswordEncoder.encode(password);
}
```

TO-BE

```java
/**
 * 기본 algorithm(SHA-256)에 대한 패스워드 얻기.
 *
 * <p>eGovFrame {@code hash}를 지정하지 않았을 때 적용되는 기본 설정과 동일한 방식이다.
 * {@code hash=eccp} / {@code hash=egov-sha256}을 쓴다면
 * {@link #getIdSaltHashedPassword(String, String)}를 사용한다.</p>
 *
 * @param password 평문 비밀번호
 * @return salt를 앞에 붙인 SHA-256 해시
 */
public static String getHashedPassword(String password) {
    return new MessageDigestPasswordEncoder("SHA-256").encode(password);
}
```

### 영향 범위

반환값이 `{bcrypt}...`에서 `{salt}sha256hex` 형태로 바뀝니다. 다만 기존 형식은 위 표대로 어떤 설정으로도 검증되지 않아 인증에 쓰이고 있을 수가 없습니다. 호출처는 이 저장소와 공통컴포넌트(`269caa04`) 모두 없습니다.

bcrypt 쪽으로 맞추는 방향은 택하지 않았습니다. `passwordEncoder()`가 `BCryptPasswordEncoder`를 고르는 경우는 `hash`가 알려진 값 중 어느 것도 아닐 때뿐이고 javadoc과 `hash` 기본값이 모두 SHA-256을 가리키기 때문입니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

`EgovUserDetailsHelperTest` 1건을 추가했습니다. `EgovSecurityConfiguration.passwordEncoder()`를 직접 불러 프레임워크가 실제로 주입하는 인코더를 얻고 그 인코더로 저장값이 검증되는지 봅니다.

수정 전(RED, 소스 파일만 되돌려 실행)

```
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.285 s <<< FAILURE! -- in org.egovframe.rte.fdl.security.userdetails.util.EgovUserDetailsHelperTest
[ERROR]   EgovUserDetailsHelperTest.testGetHashedPasswordMatchesDefaultConfiguredEncoder:27 기본 설정 인코더로 검증되어야 한다 : {bcrypt}$2a$10$Sg0.AGzko7ZrsZFuT3kyL.RlrovGguu8KkuYnNU4l5.DPdVZuPbQm ==> expected: <true> but was: <false>
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0
```

수정 후(GREEN, fdl-security 모듈 전체)

```
[INFO] Tests run: 32, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

해당 없음

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

해당 없음 (화면 변경 없음)
