### PR TITLE
fix: BlobSerializableTypeHandler 허용목록이 java.lang.Number를 빠뜨려 래퍼 타입 6종을 못 읽는 문제 수정

### DIFF
--- a/Persistence/org.egovframe.rte.psl.dataaccess/src/main/java/org/egovframe/rte/psl/orm/ibatis/support/BlobSerializableTypeHandler.java
+++ b/Persistence/org.egovframe.rte.psl.dataaccess/src/main/java/org/egovframe/rte/psl/orm/ibatis/support/BlobSerializableTypeHandler.java
@@ -68,6 +68,7 @@ public class BlobSerializableTypeHandler extends AbstractLobTypeHandler {
         ALLOWED_CLASS_NAMES.add(Boolean.class.getName());
         ALLOWED_CLASS_NAMES.add(Short.class.getName());
         ALLOWED_CLASS_NAMES.add(Byte.class.getName());
+        ALLOWED_CLASS_NAMES.add(Number.class.getName());
         ALLOWED_CLASS_NAMES.add(java.util.Date.class.getName());
         ALLOWED_CLASS_NAMES.add(java.sql.Timestamp.class.getName());
         ALLOWED_CLASS_NAMES.add(java.sql.Date.class.getName());

--- a/Persistence/org.egovframe.rte.psl.dataaccess/src/test/java/org/egovframe/rte/psl/orm/ibatis/support/BlobSerializableTypeHandlerTest.java
+++ b/Persistence/org.egovframe.rte.psl.dataaccess/src/test/java/org/egovframe/rte/psl/orm/ibatis/support/BlobSerializableTypeHandlerTest.java
@@ -1,0 +1,62 @@
+package org.egovframe.rte.psl.orm.ibatis.support;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.jdbc.support.lob.LobHandler;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.io.ObjectOutputStream;
+import java.lang.reflect.Proxy;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * 허용목록에 적힌 타입을 실제로 되읽을 수 있는지 확인한다.
+ *
+ * <p>ObjectInputFilter 는 스트림에 담긴 상위 클래스마다 다시 불리므로,
+ * 래퍼 타입을 읽으려면 java.lang.Number 도 허용목록에 있어야 한다.
+ * java.sql.Timestamp 가 java.util.Date 덕분에 통과하는 것과 같은 이유다.</p>
+ */
+public class BlobSerializableTypeHandlerTest {
+
+    @Test
+    public void testGetResultInternalReadsAllowedTypes() throws Exception {
+        Object[] allowed = {"문자열", Integer.valueOf(42), Long.valueOf(42L), Double.valueOf(4.2d),
+                Float.valueOf(4.2f), Boolean.TRUE, Short.valueOf((short) 4), Byte.valueOf((byte) 4),
+                new java.util.Date(0L), new java.sql.Timestamp(0L), new java.sql.Date(0L)};
+
+        for (Object value : allowed) {
+            assertEquals(value, readBack(value),
+                    "허용목록에 있는 " + value.getClass().getName() + " 은 되읽을 수 있어야 한다");
+        }
+    }
+
+    private Object readBack(Object value) throws Exception {
+        LobHandler lobHandler = stubLobHandler(serialize(value));
+        return new BlobSerializableTypeHandler(lobHandler).getResultInternal(null, 1, lobHandler);
+    }
+
+    private byte[] serialize(Object value) throws Exception {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        ObjectOutputStream oos = new ObjectOutputStream(baos);
+        try {
+            oos.writeObject(value);
+        } finally {
+            oos.close();
+        }
+        return baos.toByteArray();
+    }
+
+    private LobHandler stubLobHandler(byte[] stored) {
+        return (LobHandler) Proxy.newProxyInstance(
+                LobHandler.class.getClassLoader(),
+                new Class<?>[]{LobHandler.class},
+                (proxy, method, args) -> {
+                    if ("getBlobAsBinaryStream".equals(method.getName())) {
+                        return (InputStream) new ByteArrayInputStream(stored);
+                    }
+                    return null;
+                });
+    }
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

`BlobSerializableTypeHandler`의 역직렬화 허용목록(`:62~74`)은 `Integer`·`Long`·`Double`·`Float`·`Short`·`Byte`를 허용한다고 적어뒀는데, 실제로는 이 여섯이 전부 막힙니다.

`ObjectInputFilter`는 스트림에 담긴 **상위 클래스마다 다시 불립니다**(`:128~136`). 래퍼 타입은 `java.lang.Number`를 거치는데 그 이름이 목록에 없어 `REJECTED`가 됩니다.

같은 목록이 `java.sql.Timestamp`와 `java.sql.Date`는 통과시킵니다. 상위 클래스 `java.util.Date`를 같이 등록해뒀기 때문입니다(`:71~73`). 상위 클래스도 넣어야 한다는 규칙을 이 파일이 이미 지키고 있습니다. `Number`에만 빠뜨린 셈입니다.

허용목록에 적힌 11개를 그대로 넣어 필터가 어떤 클래스를 검사하는지 찍어 봤습니다.

```
타입                     판정         필터가 검사한 클래스
------------------------------------------------------------------------------
String                 읽힘         []
Integer                실패         [java.lang.Integer, java.lang.Number]
Long                   실패         [java.lang.Long, java.lang.Number]
Double                 실패         [java.lang.Double, java.lang.Number]
Float                  실패         [java.lang.Float, java.lang.Number]
Boolean                읽힘         [java.lang.Boolean]
Short                  실패         [java.lang.Short, java.lang.Number]
Byte                   실패         [java.lang.Byte, java.lang.Number]
Date                   읽힘         [java.util.Date]
Timestamp              읽힘         [java.sql.Timestamp, java.util.Date]
Date                   읽힘         [java.sql.Date, java.util.Date]
```

`String`과 `Boolean`은 상위 클래스가 `Object`뿐이라 필터를 한 번만 탑니다. 그래서 통과합니다.

AS-IS (`:62~74`)

```java
ALLOWED_CLASS_NAMES.add(Short.class.getName());
ALLOWED_CLASS_NAMES.add(Byte.class.getName());
ALLOWED_CLASS_NAMES.add(java.util.Date.class.getName());
```

TO-BE

```java
ALLOWED_CLASS_NAMES.add(Short.class.getName());
ALLOWED_CLASS_NAMES.add(Byte.class.getName());
ALLOWED_CLASS_NAMES.add(Number.class.getName());
ALLOWED_CLASS_NAMES.add(java.util.Date.class.getName());
```

### 영향 범위

허용목록에 이름 하나가 늘어납니다. `java.lang.Number`는 추상 클래스라 그 자체로는 역직렬화 대상이 되지 않습니다. 통과하게 되는 것은 이미 목록에 적혀 있던 여섯 타입입니다. 목록에 없는 다른 `Number` 하위 타입(`BigDecimal` 등)은 자기 이름에서 그대로 막히므로 필터가 넓어지지 않습니다.

`setParameterInternal`(`:107~121`)은 필터 없이 어떤 `Serializable`이든 기록합니다. 그래서 지금은 자기가 쓴 `Integer`를 자기가 되읽지 못하는 상태입니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

`BlobSerializableTypeHandlerTest` 1건을 추가했습니다. 허용목록의 11개를 직렬화한 뒤 `getResultInternal`로 되읽습니다. `LobHandler`는 `Proxy`로 세워 DB 없이 돌아갑니다.

수정 전(RED, `Number` 한 줄만 되돌려 실행)

```
[ERROR] Tests run: 1, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 0.172 s <<< FAILURE! -- in org.egovframe.rte.psl.orm.ibatis.support.BlobSerializableTypeHandlerTest
[ERROR]   BlobSerializableTypeHandlerTest.testGetResultInternalReadsAllowedTypes:30->readBack:37 » InvalidClass filter status: REJECTED
[ERROR] Tests run: 1, Failures: 0, Errors: 1, Skipped: 0
```

수정 후(GREEN, dataaccess 모듈 전체)

```
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.005 s -- in org.egovframe.rte.psl.orm.ibatis.support.BlobSerializableTypeHandlerTest
[INFO] Tests run: 120, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

해당 없음

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

해당 없음 (화면 변경 없음)
