### PR TITLE
fix: ServiceDefinition.toString()의 serviceProviderBeanId 라벨 오타 수정

### DIFF
--- a/Integration/org.egovframe.rte.itl.integration/src/main/java/org/egovframe/rte/itl/integration/metadata/ServiceDefinition.java
+++ b/Integration/org.egovframe.rte.itl.integration/src/main/java/org/egovframe/rte/itl/integration/metadata/ServiceDefinition.java
@@ -337,7 +337,7 @@ public class ServiceDefinition implements Validatable {
                 .append(StringUtils.quote(requestMessageTypeId))
                 .append("\n\tresponseMessageTypeId = ")
                 .append(StringUtils.quote(responseMessageTypeId))
-                .append("\n\tserivceProviderBeanId = ")
+                .append("\n\tserviceProviderBeanId = ")
                 .append(StringUtils.quote(serviceProviderBeanId))
                 .append("\n\tusing = ").append(using).append("\n\tstandard = ")
                 .append(standard).append("\n}");

--- a/Integration/org.egovframe.rte.itl.integration/src/test/java/org/egovframe/rte/itl/integration/metadata/ServiceDefinitionTest.java
+++ b/Integration/org.egovframe.rte.itl.integration/src/test/java/org/egovframe/rte/itl/integration/metadata/ServiceDefinitionTest.java
@@ -1,0 +1,25 @@
+package org.egovframe.rte.itl.integration.metadata;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * ServiceDefinition.toString() 이 필드 이름을 그대로 라벨로 쓰는지 확인한다.
+ *
+ * <p>같은 패키지의 Definition 들은 toString() 라벨을 필드 이름과 똑같이 적는다.
+ * 라벨이 어긋나면 로그를 필드 이름으로 검색할 수 없다.</p>
+ */
+public class ServiceDefinitionTest {
+
+    @Test
+    public void testToStringUsesFieldNameAsLabel() {
+        ServiceDefinition definition = new ServiceDefinition();
+        definition.setServiceProviderBeanId("sampleServiceProvider");
+
+        String printed = definition.toString();
+
+        assertTrue(printed.contains("serviceProviderBeanId = "),
+                "필드 이름과 같은 라벨이어야 한다 : " + printed);
+    }
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

`ServiceDefinition.toString()`이 찍는 라벨만 `serivceProviderBeanId`이고, 바로 다음 줄에서 꺼내는 필드는 `serviceProviderBeanId`(`:81`)입니다. 라벨과 값의 이름이 다릅니다.

AS-IS (`:339~341`)

```java
.append("\n\tserivceProviderBeanId = ")
.append(StringUtils.quote(serviceProviderBeanId))
```

TO-BE

```java
.append("\n\tserviceProviderBeanId = ")
.append(StringUtils.quote(serviceProviderBeanId))
```

### 영향 범위

`metadata` 패키지의 Definition 다섯 클래스가 `toString()`에서 쓰는 라벨 29개를 전부 대조했습니다. 나머지 28개는 모두 자기 필드 이름과 같고 이 하나만 어긋납니다.

| 클래스 | 라벨 수 | 필드명과 다른 라벨 |
|---|---|---|
| `IntegrationDefinition` | 7 | 없음 |
| `OrganizationDefinition` | 3 | 없음 |
| `RecordTypeDefinition` | 4 | 없음 |
| `SystemDefinition` | 6 | 없음 |
| `ServiceDefinition` | 9 | `serivceProviderBeanId` |

로그를 필드 이름으로 찾으면 이 항목만 걸리지 않습니다. 출력 문자열 한 곳만 바뀌고 동작은 그대로입니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

이 모듈에 `toString()` 테스트가 없어 `ServiceDefinitionTest`를 새로 만들었습니다.

수정 전(RED, 라벨만 되돌려 실행)

```
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0 <<< FAILURE! -- in org.egovframe.rte.itl.integration.metadata.ServiceDefinitionTest
[ERROR]   ServiceDefinitionTest.testToStringUsesFieldNameAsLabel:22 필드 이름과 같은 라벨이어야 한다 : org.egovframe.rte.itl.integration.metadata.ServiceDefinition {
```

수정 후(GREEN, itl-integration 모듈 전체)

```
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s -- in org.egovframe.rte.itl.integration.metadata.ServiceDefinitionTest
[INFO] Tests run: 80, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

해당 없음

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

해당 없음 (화면 변경 없음)
