### PR TITLE
fix: EgovBizException이 원인 예외를 cause로 세우지 않아 getCause()가 항상 null인 문제 수정

### DIFF
--- a/Foundation/org.egovframe.rte.fdl.cmmn/src/main/java/org/egovframe/rte/fdl/cmmn/exception/EgovBizException.java
+++ b/Foundation/org.egovframe.rte.fdl.cmmn/src/main/java/org/egovframe/rte/fdl/cmmn/exception/EgovBizException.java
@@ -73,6 +73,7 @@ public class EgovBizException extends BaseException {
      * @param wrappedException  원인 Exception
      */
     public EgovBizException(String defaultMessage, Object[] messageParameters, Exception wrappedException) {
+        super(wrappedException);
         String userMessage = defaultMessage;
         if (messageParameters != null) {
             userMessage = MessageFormat.format(defaultMessage, messageParameters);
@@ -163,6 +164,7 @@ public class EgovBizException extends BaseException {
      * @param wrappedException  원인 Exception
      */
     public EgovBizException(MessageSource messageSource, String messageKey, Object[] messageParameters, String defaultMessage, Locale locale, Exception wrappedException) {
+        super(wrappedException);
         this.messageKey = messageKey;
         this.messageParameters = messageParameters;
         this.message = messageSource.getMessage(messageKey, messageParameters, defaultMessage, locale);

--- a/Foundation/org.egovframe.rte.fdl.cmmn/src/test/java/org/egovframe/rte/fdl/cmmn/EgovBizExceptionTest.java
+++ b/Foundation/org.egovframe.rte.fdl.cmmn/src/test/java/org/egovframe/rte/fdl/cmmn/EgovBizExceptionTest.java
@@ -1,0 +1,36 @@
+package org.egovframe.rte.fdl.cmmn;
+
+import org.egovframe.rte.fdl.cmmn.exception.EgovBizException;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.support.StaticMessageSource;
+
+import java.util.Locale;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+public class EgovBizExceptionTest {
+
+    @Test
+    public void testGetCauseWithDefaultMessage() {
+        Exception wrapped = new IllegalStateException("TEST EgovBizException");
+        EgovBizException be = new EgovBizException("message", wrapped);
+
+        assertEquals("message", be.getMessage());
+        assertEquals("TEST EgovBizException", be.getCause().getMessage());
+        assertSame(wrapped, be.getWrappedException());
+    }
+
+    @Test
+    public void testGetCauseWithMessageSource() {
+        StaticMessageSource messageSource = new StaticMessageSource();
+        messageSource.addMessage("error.biz.msg1", Locale.getDefault(), "message1");
+        Exception wrapped = new IllegalStateException("TEST EgovBizException");
+        EgovBizException be = new EgovBizException(messageSource, "error.biz.msg1", wrapped);
+
+        assertEquals("message1", be.getMessage());
+        assertEquals("TEST EgovBizException", be.getCause().getMessage());
+        assertSame(wrapped, be.getWrappedException());
+    }
+
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

`EgovBizException`은 어떤 경로로 만들어도 `getCause()`가 null입니다. 종단 생성자 둘(`:75`, `:165`)이 `this.wrappedException` 대입만 하고 `super(wrappedException)`을 부르지 않아 암묵적 no-arg super를 타기 때문입니다. 나머지 생성자 아홉 개는 전부 이 둘로 수렴합니다.

그래서 이런 일이 생깁니다.

- `printStackTrace()` 출력에 `Caused by:` 절이 붙지 않습니다.
- 로깅 프레임워크와 Spring의 예외 처리 경로가 원인 예외를 보지 못합니다.
- cause가 null로 이미 확정된 상태라 `initCause()`는 `IllegalStateException: Can't overwrite cause`를 던집니다. 호출측이 나중에 채워 넣을 수도 없습니다.

이 예외는 업무서비스 공통 상위클래스 `EgovAbstractServiceImpl:128`이 발급합니다. 저장소 전체에서 `new EgovBizException(`이 나오는 곳은 그 한 군데뿐이라 우회 경로가 없습니다.

AS-IS (`:75`)

```java
public EgovBizException(String defaultMessage, Object[] messageParameters, Exception wrappedException) {
    String userMessage = defaultMessage;
```

TO-BE

```java
public EgovBizException(String defaultMessage, Object[] messageParameters, Exception wrappedException) {
    super(wrappedException);
    String userMessage = defaultMessage;
```

`:165`도 같은 한 줄을 넣었습니다.

### 영향 범위

`this.wrappedException` 대입은 그대로 뒀습니다. 지우면 `getWrappedException()`을 쓰는 `ServiceExceptionHandlerTests:47`과 `OthersServiceExceptionHandler:15`가 깨집니다. 두 접근자는 같은 값을 가리킵니다. 추가한 테스트가 양쪽을 함께 검증합니다.

수정 후 `EgovBizException`의 스택트레이스에 `Caused by:` 절이 새로 붙습니다. `ExceptionTransfer:117~122`는 `getWrappedException()`이 null인지에 따라 갈리는데, 그 분기는 그대로 두었습니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

`EgovBizExceptionTest` 2건을 추가했습니다. 종단 생성자 둘을 각각 태워 메시지·cause·wrappedException 셋을 봅니다. 스프링 컨텍스트 없이 돌아갑니다.

수정 전(RED, `super()` 두 줄만 되돌려 실행)

```
[ERROR] Tests run: 2, Failures: 0, Errors: 2, Skipped: 0, Time elapsed: 0.172 s <<< FAILURE! -- in org.egovframe.rte.fdl.cmmn.EgovBizExceptionTest
[ERROR]   EgovBizExceptionTest.testGetCauseWithDefaultMessage:20 NullPointer Cannot invoke "java.lang.Throwable.getMessage()" because the return value of "org.egovframe.rte.fdl.cmmn.exception.EgovBizException.getCause()" is null
[ERROR]   EgovBizExceptionTest.testGetCauseWithMessageSource:32 NullPointer Cannot invoke "java.lang.Throwable.getMessage()" because the return value of "org.egovframe.rte.fdl.cmmn.exception.EgovBizException.getCause()" is null
```

수정 후(GREEN, fdl-cmmn 모듈 전체)

```
[INFO] Tests run: 31, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

해당 없음

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

해당 없음 (화면 변경 없음)
