### PR TITLE
fix: EgovChunkPreProcessor/PostProcessor의 확장점이 프레임워크 시그니처와 달라 호출되지 않는 문제 수정

### DIFF
--- a/Batch/org.egovframe.rte.bat.core/src/main/java/org/egovframe/rte/bat/core/listener/EgovChunkPostProcessor.java
+++ b/Batch/org.egovframe.rte.bat.core/src/main/java/org/egovframe/rte/bat/core/listener/EgovChunkPostProcessor.java
@@ -16,6 +16,7 @@
 package org.egovframe.rte.bat.core.listener;
 
 import org.springframework.batch.core.listener.ChunkListenerSupport;
+import org.springframework.batch.core.scope.context.ChunkContext;
 
 /**
  * Chunk 단계 이후에 호출되는 메소드를 갖고 있는 클래스
@@ -36,6 +37,20 @@ public class EgovChunkPostProcessor extends ChunkListenerSupport {
     /**
      * Chunk 수행 이후에 호출되는 부분
      */
+    @Override
+    public void afterChunk(ChunkContext context) {
+        afterChunk();
+    }
+
+    /**
+     * Chunk 수행 이후에 호출되는 부분
+     *
+     * @deprecated 프레임워크가 호출하는 시그니처가 ChunkContext 를 받는 형태로 바뀌어
+     * 이 메소드는 더 이상 직접 호출되지 않는다. 기존에 이 메소드를 재정의한 코드가
+     * 계속 동작하도록 {@link #afterChunk(ChunkContext)} 에서 호출해 주며,
+     * 새로 작성하는 코드는 {@link #afterChunk(ChunkContext)} 를 재정의한다.
+     */
+    @Deprecated
     public void afterChunk() {
     }
 

--- a/Batch/org.egovframe.rte.bat.core/src/main/java/org/egovframe/rte/bat/core/listener/EgovChunkPreProcessor.java
+++ b/Batch/org.egovframe.rte.bat.core/src/main/java/org/egovframe/rte/bat/core/listener/EgovChunkPreProcessor.java
@@ -16,6 +16,7 @@
 package org.egovframe.rte.bat.core.listener;
 
 import org.springframework.batch.core.listener.ChunkListenerSupport;
+import org.springframework.batch.core.scope.context.ChunkContext;
 
 /**
  * Chunk 단계 이전에 호출되는 메소드를 갖고 있는 클래스
@@ -36,6 +37,20 @@ public class EgovChunkPreProcessor extends ChunkListenerSupport {
     /**
      * Chunk 수행 이전에 호출되는 부분
      */
+    @Override
+    public void beforeChunk(ChunkContext context) {
+        beforeChunk();
+    }
+
+    /**
+     * Chunk 수행 이전에 호출되는 부분
+     *
+     * @deprecated 프레임워크가 호출하는 시그니처가 ChunkContext 를 받는 형태로 바뀌어
+     * 이 메소드는 더 이상 직접 호출되지 않는다. 기존에 이 메소드를 재정의한 코드가
+     * 계속 동작하도록 {@link #beforeChunk(ChunkContext)} 에서 호출해 주며,
+     * 새로 작성하는 코드는 {@link #beforeChunk(ChunkContext)} 를 재정의한다.
+     */
+    @Deprecated
     public void beforeChunk() {
     }
 

--- a/Batch/org.egovframe.rte.bat.core/src/test/java/org/egovframe/rte/bat/core/listener/EgovChunkProcessorTest.java
+++ b/Batch/org.egovframe.rte.bat.core/src/test/java/org/egovframe/rte/bat/core/listener/EgovChunkProcessorTest.java
@@ -1,0 +1,70 @@
+package org.egovframe.rte.bat.core.listener;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.batch.core.ChunkListener;
+import org.springframework.batch.core.scope.context.ChunkContext;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * EgovChunkPreProcessor / EgovChunkPostProcessor 의 확장점이
+ * 프레임워크 호출 경로에서 실제로 실행되는지 확인하는 테스트.
+ *
+ * <p>두 클래스는 확장점을 인자 없는 beforeChunk() / afterChunk() 로 선언해 두었는데,
+ * ChunkListener 가 호출하는 시그니처는 ChunkContext 를 받는 형태다. 그래서 인자 없는
+ * 메소드는 상위 클래스를 재정의하지 못하는 별개 메소드가 되어 프레임워크가 영영
+ * 호출하지 않았다. 형제인 EgovJobPreProcessor(beforeJob(JobExecution)) 나
+ * EgovStepPreProcessor(beforeStep(StepExecution)) 는 프레임워크 시그니처를 그대로
+ * 쓰고 있어 같은 문제가 없다.</p>
+ *
+ * @author 기여자
+ * @version 1.0
+ * @since 2026.08.19
+ */
+@SuppressWarnings("deprecation")
+public class EgovChunkProcessorTest {
+
+    /**
+     * EgovChunkPreProcessor 를 상속해 재정의한 확장점이
+     * ChunkListener#beforeChunk(ChunkContext) 호출로 실행되는지 확인
+     */
+    @Test
+    public void testBeforeChunkIsInvokedThroughChunkListener() {
+        final AtomicBoolean called = new AtomicBoolean(false);
+
+        ChunkListener listener = new EgovChunkPreProcessor() {
+            @Override
+            public void beforeChunk() {
+                called.set(true);
+            }
+        };
+
+        // 프레임워크(TaskletStep)가 호출하는 것과 같은 경로로 호출한다.
+        listener.beforeChunk(new ChunkContext(null));
+
+        assertTrue(called.get(), "EgovChunkPreProcessor 의 beforeChunk 확장점이 호출되지 않았다.");
+    }
+
+    /**
+     * EgovChunkPostProcessor 를 상속해 재정의한 확장점이
+     * ChunkListener#afterChunk(ChunkContext) 호출로 실행되는지 확인
+     */
+    @Test
+    public void testAfterChunkIsInvokedThroughChunkListener() {
+        final AtomicBoolean called = new AtomicBoolean(false);
+
+        ChunkListener listener = new EgovChunkPostProcessor() {
+            @Override
+            public void afterChunk() {
+                called.set(true);
+            }
+        };
+
+        listener.afterChunk(new ChunkContext(null));
+
+        assertTrue(called.get(), "EgovChunkPostProcessor 의 afterChunk 확장점이 호출되지 않았다.");
+    }
+
+}

--- a/Batch/org.egovframe.rte.bat.core/src/test/java/org/egovframe/rte/bat/sample/example/listener/EgovSampleChunkPostProcessor.java
+++ b/Batch/org.egovframe.rte.bat.core/src/test/java/org/egovframe/rte/bat/sample/example/listener/EgovSampleChunkPostProcessor.java
@@ -3,6 +3,7 @@ package org.egovframe.rte.bat.sample.example.listener;
 import org.egovframe.rte.bat.core.listener.EgovChunkPostProcessor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.batch.core.scope.context.ChunkContext;
 
 /**
  * 청크단계 이후에 호출되는 프로세서 클래스
@@ -26,7 +27,8 @@ public class EgovSampleChunkPostProcessor extends EgovChunkPostProcessor {
     /**
      * chunk 단계 수행 이후에 호출되는 부분
      */
-    public void afterChunk() {
+    @Override
+    public void afterChunk(ChunkContext context) {
         LOGGER.debug("### EgovSampleChunkPostProcessor afterChunk()...");
     }
 

--- a/Batch/org.egovframe.rte.bat.core/src/test/java/org/egovframe/rte/bat/sample/example/listener/EgovSampleChunkPreProcessor.java
+++ b/Batch/org.egovframe.rte.bat.core/src/test/java/org/egovframe/rte/bat/sample/example/listener/EgovSampleChunkPreProcessor.java
@@ -3,6 +3,7 @@ package org.egovframe.rte.bat.sample.example.listener;
 import org.egovframe.rte.bat.core.listener.EgovChunkPreProcessor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.batch.core.scope.context.ChunkContext;
 
 /**
  * 청크단계 이전에 호출되는 리스너 클래스
@@ -25,7 +26,8 @@ public class EgovSampleChunkPreProcessor extends EgovChunkPreProcessor {
     /**
      * chunk 수행 이전에 호출되는 부분
      */
-    public void beforeChunk() {
+    @Override
+    public void beforeChunk(ChunkContext context) {
         LOGGER.debug("### EgovSampleChunkPreProcessor beforeChunk()...");
     }
 


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

`EgovChunkPreProcessor`와 `EgovChunkPostProcessor`는 `ChunkListenerSupport`를 상속하면서 확장점을 인자 없이 선언했습니다.

```java
public class EgovChunkPreProcessor extends ChunkListenerSupport {
    public void beforeChunk() {
    }
```

상위 클래스의 실제 시그니처는 `ChunkContext`를 받습니다.

```
$ javap org.springframework.batch.core.listener.ChunkListenerSupport
public class ChunkListenerSupport implements ChunkListener {
  public void afterChunk(org.springframework.batch.core.scope.context.ChunkContext);
  public void beforeChunk(org.springframework.batch.core.scope.context.ChunkContext);
  public void afterChunkError(org.springframework.batch.core.scope.context.ChunkContext);
}
```

그래서 no-arg 메서드는 오버라이드가 아니라 별개 메서드가 되고, 프레임워크는 상위 클래스의 빈 구현만 부릅니다. 저장소 자기 샘플인 `EgovSampleChunkPreProcessor`·`EgovSampleChunkPostProcessor`의 본문도 그래서 실행되지 않습니다.

같은 패키지의 Job·Step 리스너 넷은 전부 프레임워크 시그니처를 그대로 씁니다.

| 클래스 | 확장점 |
|---|---|
| `EgovJobPreProcessor:42` | `beforeJob(JobExecution)` |
| `EgovJobPostProcessor:40` | `afterJob(JobExecution)` |
| `EgovStepPreProcessor:42` | `beforeStep(StepExecution)` |
| `EgovStepPostProcessor:43` | `afterStep(StepExecution)` |
| `EgovChunkPreProcessor:39` | `beforeChunk()` |
| `EgovChunkPostProcessor:39` | `afterChunk()` |

같은 모듈의 `EgovJobVariableListener`·`EgovStepVariableListener`는 `@Override`까지 붙여 컴파일러가 검사하게 해뒀습니다. Chunk 계열만 어긋나 있습니다.

TO-BE

```java
@Override
public void beforeChunk(ChunkContext context) {
    beforeChunk();
}

/**
 * Chunk 수행 이전에 호출되는 부분
 *
 * @deprecated ...
 */
@Deprecated
public void beforeChunk() {
}
```

### 영향 범위

기존 no-arg 메서드를 지우지 않고 새 오버라이드가 호출하도록 위임했습니다. 지우는 쪽이 diff는 작고 형제 넷과 형태도 같아집니다. 다만 `beforeChunk()`를 재정의해둔 코드는 `@Override`가 없어 **컴파일 에러도 나지 않은 채** 계속 죽습니다. 저장소 샘플이 정확히 그 모양이었습니다.

위임을 두면 그런 코드가 비로소 동작합니다. 지금까지 실행되지 않던 사용자 구현이 수정 후 실행됩니다.

`git grep`으로 전수 확인한 결과 손댈 곳은 main 2개와 샘플 2개뿐입니다. 나머지 참조는 `README.md:78`의 클래스 이름 나열과 `PreProcessorJob`·`PostProcessorJob`의 빈 등록이라 시그니처와 무관합니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

`EgovChunkProcessorTest` 2건을 추가했습니다. 확장점을 재정의한 하위 클래스를 `ChunkListener` 타입으로 잡고, 프레임워크가 부르는 것과 같은 `beforeChunk(ChunkContext)`로 호출해 재정의 본문이 실행되는지 봅니다. 하위 클래스는 일부러 no-arg 쪽을 재정의합니다. 그래야 수정 전후 양쪽에서 컴파일되어 RED가 컴파일 에러가 아니라 실제 실패로 뜹니다.

수정 전(RED, 소스 4개만 되돌려 실행)

```
[ERROR] Tests run: 2, Failures: 2, Errors: 0, Skipped: 0, Time elapsed: 0.019 s <<< FAILURE! -- in org.egovframe.rte.bat.core.listener.EgovChunkProcessorTest
[ERROR]   EgovChunkProcessorTest.testAfterChunkIsInvokedThroughChunkListener:67 EgovChunkPostProcessor 의 afterChunk 확장점이 호출되지 않았다. ==> expected: <true> but was: <false>
[ERROR]   EgovChunkProcessorTest.testBeforeChunkIsInvokedThroughChunkListener:47 EgovChunkPreProcessor 의 beforeChunk 확장점이 호출되지 않았다. ==> expected: <true> but was: <false>
```

수정 후(GREEN, bat-core 모듈 전체)

```
[INFO] Tests run: 76, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

해당 없음

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

해당 없음 (화면 변경 없음)
