### PR TITLE
fix: EgovResourceVariable.setClear()가 뮤텍스 객체를 교체해 상호배제가 깨지는 문제 수정

### DIFF
--- a/Batch/org.egovframe.rte.bat.core/src/main/java/org/egovframe/rte/bat/support/EgovResourceVariable.java
+++ b/Batch/org.egovframe.rte.bat.core/src/main/java/org/egovframe/rte/bat/support/EgovResourceVariable.java
@@ -103,7 +103,7 @@ public class EgovResourceVariable {
 
     public void setClear() {
         synchronized (this.map) {
-            this.map = new HashMap<String, Object>();
+            this.map.clear();
         }
     }
 

--- a/Batch/org.egovframe.rte.bat.core/src/test/java/org/egovframe/rte/bat/support/EgovResourceVariableConcurrencyTest.java
+++ b/Batch/org.egovframe.rte.bat.core/src/test/java/org/egovframe/rte/bat/support/EgovResourceVariableConcurrencyTest.java
@@ -1,0 +1,72 @@
+package org.egovframe.rte.bat.support;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * EgovResourceVariable 의 뮤텍스 일관성 테스트.
+ *
+ * <p>이 클래스는 map 필드를 뮤텍스로 삼아 8개 메서드를 synchronized (this.map) 으로 잠근다.
+ * 과거 setClear 는 뮤텍스로 쓰이는 객체 자체를 새 HashMap 으로 교체해, 잠금 표현식을 이미
+ * 평가한 스레드와 그 뒤에 진입한 스레드가 서로 다른 모니터를 들고 같은 맵을 고칠 수 있었다.
+ * 형제 경로인 setPros 는 map.clear 로 제자리 비우기를 한다. 본 테스트로 회귀를 방지한다.</p>
+ *
+ * @author 기여자
+ * @version 1.0
+ * @since 2026.08.19
+ */
+public class EgovResourceVariableConcurrencyTest {
+
+    @Test
+    public void setClearKeepsMutexAndTargetMapIdentical() {
+        EgovResourceVariable variable = new EgovResourceVariable();
+        variable.setVariable("stale", "old");
+
+        // synchronized 메서드에 진입한 스레드가 들고 있는 모니터와 같은 객체다.
+        Map<String, Object> mutex = variable.getVariableMap();
+        synchronized (mutex) {
+            variable.setClear();
+            assertTrue(Thread.holdsLock(variable.getVariableMap()),
+                    "setClear 후 잠금 대상과 변경 대상이 서로 다른 객체가 됐다");
+        }
+        assertTrue(variable.getVariableMap().isEmpty(), "setClear 후 맵이 비어 있어야 한다");
+    }
+
+    @Test
+    public void writerBlockedOnMutexWritesIntoTheMapItLocked() throws InterruptedException {
+        final EgovResourceVariable variable = new EgovResourceVariable();
+        variable.setVariable("stale", "old");
+
+        final Map<String, Object> lockedMap = variable.getVariableMap();
+        Thread writer = new Thread(() -> variable.setVariable("written", "value"), "resource-variable-writer");
+
+        synchronized (lockedMap) {
+            writer.start();
+            // 잠금 표현식만 평가하고 모니터 앞에 멈춘 상태를 확인한 뒤 비운다.
+            awaitBlocked(writer);
+            variable.setClear();
+        }
+        writer.join(TimeUnit.SECONDS.toMillis(10));
+
+        assertFalse(writer.isAlive(), "쓰기 스레드가 종료되지 않았다");
+        assertFalse(lockedMap.containsKey("stale"), "setClear 가 쓰기 스레드의 잠금 대상 맵을 비우지 않았다");
+        assertTrue(lockedMap.containsKey("written"), "쓰기가 자신이 잠근 맵이 아닌 다른 맵에 들어갔다");
+    }
+
+    /**
+     * 대상 스레드가 모니터 앞에서 대기할 때까지 기다린다. 대기 상태를 확인한 뒤에만
+     * 다음 단계로 넘어가므로 검증 결과는 스케줄링에 좌우되지 않는다.
+     */
+    private static void awaitBlocked(Thread thread) throws InterruptedException {
+        long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(10);
+        while (thread.getState() != Thread.State.BLOCKED) {
+            assertTrue(System.nanoTime() < deadline, "쓰기 스레드가 모니터 앞에서 대기하지 않았다");
+            Thread.sleep(1);
+        }
+    }
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

`EgovResourceVariable`은 `map` 필드를 뮤텍스로 삼아 여덟 메서드를 잠급니다(`:55`, `:63`, `:75`, `:81`, `:87`, `:93`, `:99`, `:105`). 그중 `setClear`(`:104`)만 잠금 블록 안에서 뮤텍스 객체 자체를 갈아치웁니다.

`synchronized (this.map)`은 잠금 표현식에서 필드를 한 번 읽어 모니터를 잡고, 본문에서 필드를 다시 읽습니다. 그 사이 `setClear`가 필드를 바꾸면 스레드는 옛 맵의 모니터를 든 채 새 맵을 고칩니다. `setClear` 직전에 진입한 스레드와 직후에 진입한 스레드가 서로 다른 모니터로 같은 맵을 동시에 변경합니다.

같은 클래스의 형제 경로 `setPros`(`:60`)는 똑같은 "전체 비우기" 요구를 `map.clear()`(`:64`)로 처리합니다. 제자리 비우기 패턴이 이미 이 클래스 안에 있습니다.

AS-IS

```java
public void setClear() {
    synchronized (this.map) {
        this.map = new HashMap<String, Object>();
    }
}
```

TO-BE

```java
public void setClear() {
    synchronized (this.map) {
        this.map.clear();
    }
}
```

### 영향 범위

`setClear`는 이 저장소 안에 호출처가 없습니다. 다만 배포되는 모듈의 public 메서드이고, 클래스 javadoc(`:28`)이 "배치에서 singleton 방식으로 배치 Resource 변수 사용"이라고 적어 여러 스레드가 한 인스턴스를 공유한다고 전제합니다. `getVariableMap()`(`:74~78`)이 내부 맵 참조를 그대로 돌려주고 `EgovMyBatisBatchItemWriter:111`·`EgovMyBatisPagingItemReader:99`가 그 참조를 `putAll`로 소비합니다.

수정 전에는 `setClear`가 비우기 자체도 하지 못했습니다. 이미 내준 참조는 옛 맵을 가리키므로 기존 항목이 그대로 남습니다. 수정 후에는 그 참조도 함께 비워지므로, 옛 맵을 스냅샷처럼 쓰던 코드가 있다면 관측 결과가 달라집니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

`EgovResourceVariableConcurrencyTest` 2건을 추가했습니다. 스프링 컨텍스트 없이 돌아갑니다.

- `setClearKeepsMutexAndTargetMapIdentical` — 스레드를 쓰지 않고 `Thread.holdsLock`으로 잠근 객체와 필드가 가리키는 객체가 같은지 봅니다.
- `writerBlockedOnMutexWritesIntoTheMapItLocked` — 쓰기 스레드가 `Thread.State.BLOCKED`가 되는 것을 관측한 뒤 `setClear`를 호출합니다. 시간 대기가 아니라 조건 관측이라 스케줄링에 좌우되지 않습니다.

수정 전(RED, `setClear` 한 줄만 되돌려 실행)

```
[ERROR] Tests run: 2, Failures: 2, Errors: 0, Skipped: 0, Time elapsed: 0.174 s <<< FAILURE! -- in org.egovframe.rte.bat.support.EgovResourceVariableConcurrencyTest
[ERROR]   EgovResourceVariableConcurrencyTest.setClearKeepsMutexAndTargetMapIdentical:34 setClear 후 잠금 대상과 변경 대상이 서로 다른 객체가 됐다 ==> expected: <true> but was: <false>
[ERROR]   EgovResourceVariableConcurrencyTest.writerBlockedOnMutexWritesIntoTheMapItLocked:57 setClear 가 쓰기 스레드의 잠금 대상 맵을 비우지 않았다 ==> expected: <false> but was: <true>
```

수정 후(GREEN, bat-core 모듈 전체)

```
[INFO] Tests run: 76, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

해당 없음

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

해당 없음 (화면 변경 없음)
