### PR TITLE
fix: EgovRedisConfiguration의 useSsl이 기본 커넥션 팩토리에 반영되지 않는 문제 수정

### DIFF
--- a/Persistence/org.egovframe.rte.psl.reactive.redis/src/main/java/org/egovframe/rte/psl/reactive/redis/connect/EgovRedisConfiguration.java
+++ b/Persistence/org.egovframe.rte.psl.reactive.redis/src/main/java/org/egovframe/rte/psl/reactive/redis/connect/EgovRedisConfiguration.java
@@ -22,6 +22,7 @@ import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
 import org.springframework.data.redis.connection.ReactiveRedisConnectionFactory;
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettucePoolingClientConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettucePoolingClientConfiguration.LettucePoolingClientConfigurationBuilder;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 
 import java.time.Duration;
@@ -117,6 +118,8 @@ public class EgovRedisConfiguration {
     /**
      * ReactiveRedisConnectionFactory를 생성합니다.
      *
+     * <p>생성자로 지정한 SSL 사용 여부(useSsl)를 반영합니다.</p>
+     *
      * @return ReactiveRedisConnectionFactory 인스턴스
      */
     public ReactiveRedisConnectionFactory reactiveRedisConnectionFactory() {
@@ -127,13 +130,15 @@ public class EgovRedisConfiguration {
             redisStandaloneConfiguration.setPassword(password);
         }
         
-        // Lettuce 클라이언트 설정 (연결 타임아웃 + 커넥션 풀 적용)
-        LettucePoolingClientConfiguration clientConfig = LettucePoolingClientConfiguration.builder()
+        // Lettuce 클라이언트 설정 (연결 타임아웃 + 커넥션 풀 + SSL 사용 여부 적용)
+        LettucePoolingClientConfigurationBuilder clientConfigBuilder = LettucePoolingClientConfiguration.builder()
                 .clientOptions(clientOptions())
                 .commandTimeout(commandTimeout)
                 .shutdownTimeout(Duration.ofSeconds(2))
-                .poolConfig(poolConfig())
-                .build();
+                .poolConfig(poolConfig());
+        LettucePoolingClientConfiguration clientConfig = useSsl
+                ? clientConfigBuilder.useSsl().build()
+                : clientConfigBuilder.build();
 
         LettuceConnectionFactory connectionFactory = new LettuceConnectionFactory(redisStandaloneConfiguration, clientConfig);
         connectionFactory.setValidateConnection(true);
@@ -144,6 +149,8 @@ public class EgovRedisConfiguration {
 
     /**
      * SSL을 사용하는 ReactiveRedisConnectionFactory를 생성합니다.
+     *
+     * <p>생성자로 지정한 SSL 사용 여부(useSsl)와 무관하게 SSL을 사용합니다.</p>
      *
      * @return SSL이 활성화된 ReactiveRedisConnectionFactory 인스턴스
      */

--- a/Persistence/org.egovframe.rte.psl.reactive.redis/src/test/java/org/egovframe/rte/psl/reactive/redis/connect/EgovRedisConfigurationTest.java
+++ b/Persistence/org.egovframe.rte.psl.reactive.redis/src/test/java/org/egovframe/rte/psl/reactive/redis/connect/EgovRedisConfigurationTest.java
@@ -11,7 +11,9 @@ import org.springframework.data.redis.connection.lettuce.LettucePoolingClientCon
 import java.time.Duration;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class EgovRedisConfigurationTest {
 
@@ -45,6 +47,29 @@ public class EgovRedisConfigurationTest {
         assertEquals(20, poolConfig.getMaxTotal());
         assertEquals(15, poolConfig.getMaxIdle());
         assertEquals(5, poolConfig.getMinIdle());
+    }
+
+    @Test
+    public void reactiveRedisConnectionFactory_appliesUseSsl() {
+        EgovRedisConfiguration config = new EgovRedisConfiguration(
+                "localhost", 6379, null, true,
+                Duration.ofSeconds(10), Duration.ofSeconds(5), 8, 8, 0);
+
+        LettuceConnectionFactory factory = (LettuceConnectionFactory) config.reactiveRedisConnectionFactory();
+
+        assertTrue(config.isUseSsl());
+        assertTrue(factory.isUseSsl());
+    }
+
+    @Test
+    public void reactiveRedisConnectionFactory_doesNotApplySslWhenUseSslIsFalse() {
+        EgovRedisConfiguration config = new EgovRedisConfiguration(
+                "localhost", 6379, null, false,
+                Duration.ofSeconds(10), Duration.ofSeconds(5), 8, 8, 0);
+
+        LettuceConnectionFactory factory = (LettuceConnectionFactory) config.reactiveRedisConnectionFactory();
+
+        assertFalse(factory.isUseSsl());
     }
 
 }


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

아홉 개 인자 생성자(`:81~83`)가 받는 값 중 `useSsl`만 커넥션 생성에 쓰이지 않습니다. `reactiveRedisConnectionFactory()`(`:122~143`) 본문에 `useSsl`이 한 번도 나오지 않습니다.

| 생성자 인자 | 기본 팩토리에 반영되는 곳 |
|---|---|
| host · port · password | `:124`, `:125`, `:126~128` |
| commandTimeout | `:133` |
| connectTimeout | `:176` (`clientOptions()` 경유) |
| maxActive · maxIdle · minIdle | `:182~184` (`poolConfig()` 경유) |
| **useSsl** | **없음** |

그래서 `useSsl=true`로 만든 인스턴스가 `isUseSsl()`(`:207`)로는 `true`를 돌려주면서 평문 커넥션 팩토리를 내놓습니다. 직접 확인한 값입니다.

```
new EgovRedisConfiguration(host, port, password, true, ...)
  config.isUseSsl()                                   -> true
  reactiveRedisConnectionFactory().isUseSsl()         -> false
```

javadoc은 이 인자를 "SSL 사용 여부"라고 적고(`:74`), `getConfigurationInfo()`(`:193~196`)도 같은 필드로 `SSL: true` 문자열을 만듭니다.

같은 파일에서 [#315](https://github.com/eGovFramework/egovframe-runtime/pull/315)가 고친 것이 정확히 같은 형태였습니다. 생성자가 받는 `connectTimeout`과 커넥션 풀 설정이 실제 연결 생성에 반영되지 않던 문제였고, `useSsl`은 그때 남은 마지막 인자입니다.

AS-IS

```java
LettucePoolingClientConfiguration clientConfig = LettucePoolingClientConfiguration.builder()
        .clientOptions(clientOptions())
        .commandTimeout(commandTimeout)
        .shutdownTimeout(Duration.ofSeconds(2))
        .poolConfig(poolConfig())
        .build();
```

TO-BE

```java
LettucePoolingClientConfigurationBuilder clientConfigBuilder = LettucePoolingClientConfiguration.builder()
        .clientOptions(clientOptions())
        .commandTimeout(commandTimeout)
        .shutdownTimeout(Duration.ofSeconds(2))
        .poolConfig(poolConfig());
LettucePoolingClientConfiguration clientConfig = useSsl
        ? clientConfigBuilder.useSsl().build()
        : clientConfigBuilder.build();
```

### 영향 범위

동작이 달라지는 경우는 `useSsl=true`로 생성한 뒤 `reactiveRedisConnectionFactory()`를 부르는 하나뿐입니다. 세 개 인자 생성자(`:64~66`)는 `useSsl`에 `false`를 넘기고, 저장소 안의 사용 예(`RedisConfiguration:24`)도 그쪽을 씁니다.

`reactiveRedisConnectionFactoryWithSsl()`(`:150`)은 손대지 않았습니다. 이름 자체가 명시적 opt-in이라 기존 계약을 유지하고, `useSsl` 값과 무관하게 SSL을 쓴다는 점만 javadoc에 적었습니다.

SSL 분기에서도 #315가 넣은 설정은 그대로 남습니다. `poolConfig`의 `maxTotal`·`maxIdle`·`minIdle`과 `ClientOptions`의 `connectTimeout`이 생성자 값 그대로 들어갑니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

`EgovRedisConfigurationTest`에 2건을 추가했습니다(#315에서 만든 파일입니다). `useSsl=true`면 팩토리도 SSL이어야 하고, `false`면 아니어야 한다는 양쪽을 봅니다. 뒤쪽은 무조건 `useSsl()`을 붙이는 과잉 수정을 막습니다.

이 모듈은 pom에 `<skipTests>true</skipTests>`가 있어 기본 빌드에서 테스트가 돌지 않습니다. 아래는 그 줄을 임시로 풀고 로컬에 Redis를 띄운 상태에서 받은 출력입니다.

수정 전(RED)

```
[ERROR] Tests run: 4, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.239 s <<< FAILURE! -- in org.egovframe.rte.psl.reactive.redis.connect.EgovRedisConfigurationTest
[ERROR]   EgovRedisConfigurationTest.reactiveRedisConnectionFactory_appliesUseSsl:61 expected: <true> but was: <false>
```

수정 후(GREEN, reactive-redis 모듈 전체)

```
[INFO] Tests run: 24, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.055 s -- in org.egovframe.rte.psl.reactive.redis.repository.RedisTest
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.003 s -- in org.egovframe.rte.psl.reactive.redis.connect.EgovRedisConfigurationTest
[INFO] Tests run: 28, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

해당 없음

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

해당 없음 (화면 변경 없음)
