### PR TITLE
fix: SqlMapClientFactoryBean의 Resource 배열 setter가 null을 받으면 NPE를 내는 문제 수정

### DIFF
--- a/Persistence/org.egovframe.rte.psl.dataaccess/src/main/java/org/egovframe/rte/psl/orm/ibatis/SqlMapClientFactoryBean.java
+++ b/Persistence/org.egovframe.rte.psl.dataaccess/src/main/java/org/egovframe/rte/psl/orm/ibatis/SqlMapClientFactoryBean.java
@@ -115,6 +115,10 @@ public class SqlMapClientFactoryBean implements FactoryBean<SqlMapClient>, Initi
      * are going to be merged into one unified configuration at runtime.
      */
     public void setConfigLocations(Resource[] configLocations) {
+        if (configLocations == null) {
+            this.configLocations = null;
+            return;
+        }
         // 2020.08.31 유지보수 시큐어코딩(ES)-Private 배열에 Public 데이터 할당[CWE-496]
         this.configLocations = new Resource[configLocations.length];
         for (int i = 0; i < configLocations.length; i++) {
@@ -133,6 +137,10 @@ public class SqlMapClientFactoryBean implements FactoryBean<SqlMapClient>, Initi
      * with any previous iBATIS version.
      */
     public void setMappingLocations(Resource[] mappingLocations) {
+        if (mappingLocations == null) {
+            this.mappingLocations = null;
+            return;
+        }
         // 2020.08.31 유지보수 시큐어코딩(ES)-Private 배열에 Public 데이터 할당[CWE-496]
         this.mappingLocations = new Resource[mappingLocations.length];
         for (int i = 0; i < mappingLocations.length; i++) {

--- a/Persistence/org.egovframe.rte.psl.dataaccess/src/test/java/org/egovframe/rte/psl/orm/ibatis/SqlMapClientFactoryBeanTest.java
+++ b/Persistence/org.egovframe.rte.psl.dataaccess/src/test/java/org/egovframe/rte/psl/orm/ibatis/SqlMapClientFactoryBeanTest.java
@@ -1,0 +1,23 @@
+package org.egovframe.rte.psl.orm.ibatis;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@SuppressWarnings("deprecation")
+public class SqlMapClientFactoryBeanTest {
+
+    /**
+     * setConfigLocation(null)과 buildSqlMapClient()가 이미 null을 '미설정'으로 다루는데
+     * 배열 setter 두 개만 null에서 NPE를 내던 것을, 같은 미설정 상태로 받도록 가드를 추가했다.
+     */
+    @Test
+    public void testSetLocationsNull() {
+        SqlMapClientFactoryBean factoryBean = new SqlMapClientFactoryBean();
+        factoryBean.setConfigLocations(null);
+        factoryBean.setMappingLocations(null);
+
+        assertThrows(IllegalArgumentException.class, factoryBean::afterPropertiesSet);
+    }
+
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

`SqlMapClientFactoryBean`은 `configLocations`에 들어온 null을 "미설정"으로 취급한다고 자기 코드로 선언합니다.

- `setConfigLocation(Resource)`(`:110`)이 `configLocation != null ? new Resource[]{configLocation} : null`로 **null을 필드에 일부러 써 넣습니다.**
- 읽는 쪽 `:328`은 `ObjectUtils.isEmpty(configLocations)`로 그 상태를 정상 처리합니다.

그런데 같은 필드의 배열 setter `setConfigLocations`(`:119`)는 null을 받으면 `configLocations.length`에서 NPE를 냅니다. `setMappingLocations`(`:137`)도 같습니다.

이건 회귀입니다. 원본인 Spring Framework 3.2.18의 `SqlMapClientFactoryBean`은 두 setter가 `this.configLocations = configLocations;` 단순 대입이라 null을 그대로 받습니다. 그 자리에 남아 있는 `// 2020.08.31 ... [CWE-496]` 주석이 밝히듯 대입이 방어복사 루프로 바뀌었고, 그때 null 검사가 같이 들어가지 않았습니다.

AS-IS

```java
public void setConfigLocations(Resource[] configLocations) {
    // 2020.08.31 유지보수 시큐어코딩(ES)-Private 배열에 Public 데이터 할당[CWE-496]
    this.configLocations = new Resource[configLocations.length];
```

TO-BE

```java
public void setConfigLocations(Resource[] configLocations) {
    if (configLocations == null) {
        this.configLocations = null;
        return;
    }
    // 2020.08.31 유지보수 시큐어코딩(ES)-Private 배열에 Public 데이터 할당[CWE-496]
    this.configLocations = new Resource[configLocations.length];
```

`setMappingLocations`도 같은 형태입니다. 방어복사 루프와 주석은 그대로 두었으므로 배열이 들어올 때의 CWE-496 방어는 변하지 않습니다.

### 영향 범위

배열이 들어오는 경로는 전혀 바뀌지 않습니다. 달라지는 것은 null을 넣었을 때 NPE 대신 "미설정"으로 남는 것뿐이고, 그 상태는 `:110`과 `:328`이 이미 전제합니다.

저장소 안에서 두 배열 setter를 부르는 곳은 없습니다. 이 클래스를 쓰는 두 설정(`DataAccessTestConfig:69`, `fdl.excel` 테스트 설정)은 단일 `setConfigLocation`을 씁니다. 즉 크래시가 지금 어딘가에서 나고 있다는 주장이 아니라, 클래스가 스스로 선언한 null 계약을 시큐어코딩 패치가 한쪽만 깼다는 이야기입니다.

같은 계약을 쓰는 현행 사례로 `mybatis-spring`의 `SqlSessionFactoryBean`도 `mapperLocations`에 null을 그대로 받고 `!= null`로 미설정을 판단합니다. `DataAccessTestConfig:79`에서 이 클래스 바로 아래 줄에 함께 등록돼 있습니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

`SqlMapClientFactoryBeanTest` 1건을 추가했습니다. 두 setter에 null을 넣은 뒤 `afterPropertiesSet()`이 NPE가 아니라 기존 `IllegalArgumentException`을 던지는지 봅니다.

수정 전(RED, 가드 두 개만 되돌려 실행)

```
[ERROR] Tests run: 1, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 0.017 s <<< FAILURE! -- in org.egovframe.rte.psl.orm.ibatis.SqlMapClientFactoryBeanTest
[ERROR]   SqlMapClientFactoryBeanTest.testSetLocationsNull:17 » NullPointer Cannot read the array length because "configLocations" is null
```

수정 후(GREEN, dataaccess 모듈 전체)

```
[INFO] Tests run: 120, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

해당 없음

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

해당 없음 (화면 변경 없음)

