### PR TITLE
fix: EgovWebServiceClassLoaderImpl이 javax 네임스페이스와 옛 패키지명을 하드코딩해 엔드포인트 생성이 실패하는 문제 수정

### DIFF
--- a/Integration/org.egovframe.rte.itl.webservice/src/main/java/org/egovframe/rte/itl/webservice/service/impl/EgovWebServiceClassLoaderImpl.java
+++ b/Integration/org.egovframe.rte.itl.webservice/src/main/java/org/egovframe/rte/itl/webservice/service/impl/EgovWebServiceClassLoaderImpl.java
@@ -68,7 +68,7 @@ public class EgovWebServiceClassLoaderImpl extends ClassLoader implements EgovWe
     public static final String CLASS_NAME_PREFIX = BASE_PACKAGE_NAME + "." + "EgovType";
     public static final String SERVICE_ENDPOINT_CLASS_NAME_POSTFIX = "ServiceImpl";
     public static final String SERVICE_ENDPOINT_INTERFACE_CLASS_NAME_POSTFIX = "Service";
-    public static final String NAME_OF_SERVICE_BRIDGE_CLASS = "egovframework/rte/itl/webservice/service/ServiceBridge";
+    public static final String NAME_OF_SERVICE_BRIDGE_CLASS = "org/egovframe/rte/itl/webservice/service/ServiceBridge";
     public static final String DESC_OF_SERVICE_BRIDGE_CLASS = "L" + NAME_OF_SERVICE_BRIDGE_CLASS + ";";
     public static final String FIELD_NAME_OF_SERVICE_BRIDGE = "serviceBridge";
     private static final Logger LOGGER = LoggerFactory.getLogger(EgovWebServiceClassLoaderImpl.class);
@@ -111,31 +111,31 @@ public class EgovWebServiceClassLoaderImpl extends ClassLoader implements EgovWe
     };
     private static final String DESC_OF_XML_ACCESSOR_TYPE =
             // org.objectweb.asm.Type.getDescriptor(XmlAccessorType.class);
-            "Ljavax/xml/bind/annotation/XmlAccessorType;";
+            "Ljakarta/xml/bind/annotation/XmlAccessorType;";
     private static final String DESC_OF_XML_ACCESS_TYPE =
             // org.objectweb.asm.Type.getDescriptor(XmlAccessType.class);
-            "Ljavax/xml/bind/annotation/XmlAccessType;";
+            "Ljakarta/xml/bind/annotation/XmlAccessType;";
     private static final String DESC_OF_WEB_SERVICE =
             // org.objectweb.asm.Type.getDescriptor(WebService.class);
-            "Ljavax/jws/WebService;";
+            "Ljakarta/jws/WebService;";
     private static final String DESC_OF_SOAP_BINDING =
             // org.objectweb.asm.Type.getDescriptor(SOAPBinding.class);
-            "Ljavax/jws/soap/SOAPBinding;";
+            "Ljakarta/jws/soap/SOAPBinding;";
     private static final String DESC_OF_SOAP_BINDING_PARAMETER_STYLE =
             // org.objectweb.asm.Type.getDescriptor(SOAPBinding.ParameterStyle.class);
-            "Ljavax/jws/soap/SOAPBinding$ParameterStyle;";
+            "Ljakarta/jws/soap/SOAPBinding$ParameterStyle;";
     private static final String DESC_OF_WEB_METHOD =
             // org.objectweb.asm.Type.getDescriptor(WebMethod.class);
-            "Ljavax/jws/WebMethod;";
+            "Ljakarta/jws/WebMethod;";
     private static final String DESC_OF_WEB_PARAM =
             // org.objectweb.asm.Type.getDescriptor(WebParam.class);
-            "Ljavax/jws/WebParam;";
+            "Ljakarta/jws/WebParam;";
     private static final String DESC_OF_WEB_PARAM_MODE =
             // org.objectweb.asm.Type.getDescriptor(WebParam.Mode.class);
-            "Ljavax/jws/WebParam$Mode;";
+            "Ljakarta/jws/WebParam$Mode;";
     private static final String DESC_OF_WEB_RESULT =
             // org.objectweb.asm.Type.getDescriptor(WebResult.class);
-            "Ljavax/jws/WebResult;";
+            "Ljakarta/jws/WebResult;";
     private static final org.objectweb.asm.Type TYPE_OF_HOLDER = org.objectweb.asm.Type.getType(Holder.class);
 
     /**
@@ -319,7 +319,7 @@ public class EgovWebServiceClassLoaderImpl extends ClassLoader implements EgovWe
                 }
                 paramClass = Holder.class;
                 paramType = TYPE_OF_HOLDER;
-                paramSign = "Ljavax/xml/ws/Holder<" + paramSign + ">;";
+                paramSign = "L" + TYPE_OF_HOLDER.getInternalName() + "<" + paramSign + ">;";
             }
             desc.append(paramType.getDescriptor());
             signature.append(paramSign);
@@ -415,7 +415,7 @@ public class EgovWebServiceClassLoaderImpl extends ClassLoader implements EgovWe
                 }
                 paramClass = Holder.class;
                 paramType = TYPE_OF_HOLDER;
-                paramSign = "Ljavax/xml/ws/Holder<" + paramSign + ">;";
+                paramSign = "L" + TYPE_OF_HOLDER.getInternalName() + "<" + paramSign + ">;";
             }
             desc.append(paramType.getDescriptor());
             signature.append(paramSign);

--- a/Integration/org.egovframe.rte.itl.webservice/src/test/java/org/egovframe/rte/itl/webservice/service/impl/EgovWebServiceClassLoaderImplTest.java
+++ b/Integration/org.egovframe.rte.itl.webservice/src/test/java/org/egovframe/rte/itl/webservice/service/impl/EgovWebServiceClassLoaderImplTest.java
@@ -1,0 +1,90 @@
+package org.egovframe.rte.itl.webservice.service.impl;
+
+import jakarta.jws.WebMethod;
+import jakarta.jws.WebParam;
+import jakarta.jws.WebParam.Mode;
+import jakarta.jws.WebService;
+import jakarta.xml.ws.Holder;
+import org.egovframe.rte.itl.integration.type.PrimitiveType;
+import org.egovframe.rte.itl.webservice.EgovWebServiceMessageHeader;
+import org.egovframe.rte.itl.webservice.service.ServiceBridge;
+import org.egovframe.rte.itl.webservice.service.ServiceEndpointInfo;
+import org.egovframe.rte.itl.webservice.service.ServiceParamInfo;
+import org.junit.jupiter.api.Test;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+import java.lang.reflect.ParameterizedType;
+import java.util.ArrayList;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class EgovWebServiceClassLoaderImplTest {
+
+    private final EgovWebServiceClassLoaderImpl classLoader = new EgovWebServiceClassLoaderImpl(getClass().getClassLoader());
+
+    /**
+     * ServiceEndpointInfoImpl(WebServiceServerDefinition, RecordType, RecordType)이 만드는 구성과 같다.
+     * header는 INOUT, request field는 IN, response field는 OUT이다.
+     */
+    private final ServiceEndpointInfo serviceEndpointInfo = new ServiceEndpointInfoImpl(
+            "http://test/", "/A/test", "ServiceA", "PortA", "service", null,
+            new ArrayList<ServiceParamInfo>() {
+                /**
+                 *  serialVersion UID
+                 */
+                private static final long serialVersionUID = -6098622390136248349L;
+
+                {
+                    add(new ServiceParamInfoImpl("header", EgovWebServiceMessageHeader.TYPE, Mode.INOUT, true));
+                    add(new ServiceParamInfoImpl("request", PrimitiveType.STRING, Mode.IN, false));
+                    add(new ServiceParamInfoImpl("response", PrimitiveType.STRING, Mode.OUT, false));
+                }
+            });
+
+    private Method getOperation(Class<?> serviceEndpointInterfaceClass) throws Exception {
+        return serviceEndpointInterfaceClass.getDeclaredMethod("service", Holder.class, String.class, Holder.class);
+    }
+
+    @Test
+    public void testServiceEndpointInterfaceHasWebServiceAnnotations() throws Exception {
+        Class<?> serviceEndpointInterfaceClass = classLoader.loadClass(serviceEndpointInfo).getInterfaces()[0];
+        Method operation = getOperation(serviceEndpointInterfaceClass);
+
+        assertNotNull(serviceEndpointInterfaceClass.getAnnotation(WebService.class));
+        assertNotNull(operation.getAnnotation(WebMethod.class));
+
+        Annotation[][] parameterAnnotations = operation.getParameterAnnotations();
+        assertEquals(3, parameterAnnotations.length);
+        for (Annotation[] annotations : parameterAnnotations) {
+            assertEquals(1, annotations.length);
+            assertInstanceOf(WebParam.class, annotations[0]);
+        }
+    }
+
+    @Test
+    public void testHolderParameterSignatureMatchesDescriptor() throws Exception {
+        Class<?> serviceEndpointInterfaceClass = classLoader.loadClass(serviceEndpointInfo).getInterfaces()[0];
+        Method operation = getOperation(serviceEndpointInterfaceClass);
+
+        // Signature 속성이 method descriptor와 다른 Holder를 가리키면 TypeNotPresentException이 발생한다.
+        java.lang.reflect.Type[] genericParameterTypes = operation.getGenericParameterTypes();
+
+        assertInstanceOf(ParameterizedType.class, genericParameterTypes[0]);
+        assertEquals(Holder.class, ((ParameterizedType) genericParameterTypes[0]).getRawType());
+        assertEquals(EgovWebServiceMessageHeader.class, ((ParameterizedType) genericParameterTypes[0]).getActualTypeArguments()[0]);
+
+        assertInstanceOf(ParameterizedType.class, genericParameterTypes[2]);
+        assertEquals(Holder.class, ((ParameterizedType) genericParameterTypes[2]).getRawType());
+        assertEquals(String.class, ((ParameterizedType) genericParameterTypes[2]).getActualTypeArguments()[0]);
+    }
+
+    @Test
+    public void testServiceEndpointHasServiceBridgeField() throws Exception {
+        Class<?> serviceEndpointClass = classLoader.loadClass(serviceEndpointInfo);
+
+        // field 타입이 존재하지 않는 class이면 getField()에서 NoClassDefFoundError가 발생한다.
+        assertEquals(ServiceBridge.class, serviceEndpointClass.getField(classLoader.getFieldNameOfServiceBridge()).getType());
+    }
+
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

`EgovWebServiceClassLoaderImpl`은 ASM으로 서비스 엔드포인트 클래스를 찍어내는데, 그 안에 `javax` 네임스페이스와 4.0 이전 패키지명이 문자열로 박혀 있습니다. 모듈 자체는 `jakarta.*`로 컴파일됩니다.

한 메서드 안에서 두 값이 갈립니다. OUT/INOUT 파라미터의 method descriptor는 `:139`의 `TYPE_OF_HOLDER = Type.getType(Holder.class)`에서 도출되어 `jakarta`가 나옵니다. 반면 같은 파라미터의 Signature 속성은 `:322`·`:418`에서 `Ljavax/xml/ws/Holder<...>;`로 하드코딩돼 있었습니다. 둘은 `:334`·`:430`의 같은 `visitMethod(...)` 호출로 한 메서드에 함께 들어갑니다.

`javax` 리터럴은 애노테이션 디스크립터 9개(`:114`, `:117`, `:120`, `:123`, `:126`, `:129`, `:132`, `:135`, `:138`)와 Signature 2개(`:322`, `:418`)로 모두 11곳입니다. 여기에 `:71`의 `NAME_OF_SERVICE_BRIDGE_CLASS`가 `egovframework/rte/itl/webservice/service/ServiceBridge`로, 지금은 없는 패키지를 가리킵니다. 실제 클래스는 `org.egovframe.rte.itl.webservice.service.ServiceBridge`입니다.

생성된 클래스를 적재하면 이렇게 됩니다.

```
java.lang.TypeNotPresentException: Type javax.xml.ws.Holder not present
java.lang.NoClassDefFoundError: egovframework/rte/itl/webservice/service/ServiceBridge
```

이 경로는 살아 있습니다. `EgovWebServiceContext:361`이 `classLoader.loadClass(serviceEndpointInfo)`로 생성 클래스를 받고 `:402`에서 `getField(fieldName)`을 부릅니다. `:403`의 catch는 `NoSuchFieldException`만 잡으므로 `NoClassDefFoundError`는 그대로 `init()` 밖으로 빠져나갑니다.

상수 바로 위 주석에 이미 의도한 값이 적혀 있습니다.

```java
private static final String DESC_OF_WEB_SERVICE =
        // org.objectweb.asm.Type.getDescriptor(WebService.class);
        "Ljavax/jws/WebService;";
```

애노테이션 디스크립터 9개와 `:71`은 `jakarta`·`org/egovframe`로 고쳤고, Holder 시그니처 2곳은 문자열 대신 이미 있는 `TYPE_OF_HOLDER`에서 도출하게 바꿨습니다.

```java
paramSign = "L" + TYPE_OF_HOLDER.getInternalName() + "<" + paramSign + ">;";
```

이렇게 두면 앞으로 임포트한 타입과 어긋날 수 없습니다.

### 영향 범위

`itl.webservice` 모듈의 동적 클래스 생성 경로에만 닿습니다. 생성물이 참조하는 타입 이름이 바뀌므로 지금까지 적재 단계에서 실패하던 엔드포인트가 뜹니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

`EgovWebServiceClassLoaderImplTest` 3건을 추가했습니다. 클래스를 실제로 생성해 리플렉션으로 애노테이션·시그니처·필드를 확인합니다.

수정 전(RED, 소스만 되돌려 실행)

```
[ERROR] Tests run: 3, Failures: 1, Errors: 2, Skipped: 0, Time elapsed: 0.165 s <<< FAILURE! -- in org.egovframe.rte.itl.webservice.service.impl.EgovWebServiceClassLoaderImplTest
[ERROR]   EgovWebServiceClassLoaderImplTest.testServiceEndpointInterfaceHasWebServiceAnnotations:54 expected: not <null>
[ERROR]   EgovWebServiceClassLoaderImplTest.testHolderParameterSignatureMatchesDescriptor:71 » TypeNotPresent Type javax.xml.ws.Holder not present
[ERROR]   EgovWebServiceClassLoaderImplTest.testServiceEndpointHasServiceBridgeField:87 » NoClassDefFound egovframework/rte/itl/webservice/service/ServiceBridge
```

수정 후(GREEN, itl-webservice 모듈 전체)

```
[INFO] Tests run: 22, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

해당 없음

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

해당 없음 (화면 변경 없음)
