### PR TITLE
fix: EgovMongoDbRepository.insertData()가 save()에 위임해 기존 문서를 덮어쓰는 문제 수정

### DIFF
--- a/Persistence/org.egovframe.rte.psl.data.mongodb/src/main/java/org/egovframe/rte/psl/data/mongodb/repository/EgovMongoDbRepository.java
+++ b/Persistence/org.egovframe.rte.psl.data.mongodb/src/main/java/org/egovframe/rte/psl/data/mongodb/repository/EgovMongoDbRepository.java
@@ -57,7 +57,7 @@ public class EgovMongoDbRepository<T> extends MongoTemplate {
     }
 
     public T insertData(T objectToSave) {
-        return save(objectToSave);
+        return insert(objectToSave);
     }
 
     public T updateData(Query query, UpdateDefinition update, Class<T> entityClass) {

--- a/Persistence/org.egovframe.rte.psl.data.mongodb/src/test/java/org/egovframe/rte/psl/data/mongodb/MongoDbTest.java
+++ b/Persistence/org.egovframe.rte.psl.data.mongodb/src/test/java/org/egovframe/rte/psl/data/mongodb/MongoDbTest.java
@@ -10,9 +10,12 @@ import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
+import org.springframework.dao.DuplicateKeyException;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration(classes = MongoDbConfiguration.class)
@@ -32,6 +35,20 @@ public class MongoDbTest {
         sample.setUseYn("Y");
         sample.setRegUser("eGov");
         return sample;
+    }
+
+    @Test
+    public void insertDataRejectsDuplicateId() {
+        Sample sample = makeSample();
+
+        repository.deleteSample(sample);
+        repository.insertSample(sample);
+
+        Sample duplicate = makeSample();
+        duplicate.setName("Overwritten");
+
+        assertThrows(DuplicateKeyException.class, () -> repository.insertSample(duplicate));
+        assertEquals("Runtime", repository.selectOneSample(1).getName());
     }
 
     @Test


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

`EgovMongoDbRepository.insertData()`가 `MongoTemplate.save()`를 부릅니다. `save()`는 `_id` 기준 upsert라 같은 id로 다시 넣으면 예외 없이 기존 문서를 덮어씁니다. 같은 클래스가 `updateData()`를 따로 두는데도 insert가 update 역할을 겸하는 셈입니다.

형제 셋은 같은 이름, 같은 파라미터명으로 전부 `insert()`를 씁니다.

| 클래스 | `insertData` 위임 대상 |
|---|---|
| `EgovReactiveMongoDbRepository:59` | `insert(objectToSave)` |
| `EgovCassandraRepository:58` | `insert(entity)` |
| `EgovR2dbcRepository:58` | `insert(entity)` |
| `EgovMongoDbRepository:59` (수정 전) | `save(objectToSave)` |

동기 mongodb 하나만 다릅니다.

AS-IS

```java
public T insertData(T objectToSave) {
    return save(objectToSave);
}
```

TO-BE

```java
public T insertData(T objectToSave) {
    return insert(objectToSave);
}
```

### 영향 범위

동작이 바뀝니다. 지금까지 `insertData()`로 같은 `_id`를 다시 넣으면 조용히 덮어썼지만 수정 후에는 `DuplicateKeyException`이 납니다.

`insertData()`를 upsert로 쓰던 코드가 있다면 영향을 받습니다. 다만 같은 클래스에 `updateData()`가 따로 있습니다. 리액티브 짝을 비롯한 형제 셋도 모두 `insert()`라 이 메서드가 upsert를 겸할 자리는 아니라고 봤습니다. upsert가 필요하면 `MongoTemplate.save()`를 그대로 쓸 수 있습니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

기존 `MongoDbTest`에 1건을 더했습니다. 같은 `_id`로 두 번 넣어 두 번째가 거부되는지, 첫 문서가 그대로 남는지를 봅니다. 로컬에 MongoDB를 띄우고 실행했습니다.

수정 전(RED, `insertData` 한 줄만 되돌려 실행)

```
[ERROR] Tests run: 3, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.699 s <<< FAILURE! -- in org.egovframe.rte.psl.data.mongodb.MongoDbTest
[ERROR]   MongoDbTest.insertDataRejectsDuplicateId:50 Expected org.springframework.dao.DuplicateKeyException to be thrown, but nothing was thrown.
```

수정 후(GREEN, data-mongodb 모듈 전체)

```
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.652 s -- in org.egovframe.rte.psl.data.mongodb.MongoDbTest
[INFO] BUILD SUCCESS
```

이 모듈은 pom에 `<skipTests>true</skipTests>`가 있어 기본 빌드에서 테스트가 돌지 않습니다. 위 출력은 그 줄을 임시로 풀고 받은 것입니다. pom 변경은 커밋에 넣지 않았습니다.

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

해당 없음

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

해당 없음 (화면 변경 없음)
