### PR TITLE
fix: EgovJdkLogger.ignore가 기록하지 않아야 할 메시지를 최고 심각도로 남기는 문제 수정

### DIFF
--- a/Foundation/org.egovframe.rte.fdl.logging/src/main/java/org/egovframe/rte/fdl/logging/util/EgovJdkLogger.java
+++ b/Foundation/org.egovframe.rte.fdl.logging/src/main/java/org/egovframe/rte/fdl/logging/util/EgovJdkLogger.java
@@ -36,7 +36,7 @@ import java.util.logging.Logger;
  */
 public final class EgovJdkLogger {
 
-    private static final Level IGNORE_INFO_LEVEL = Level.OFF;
+    private static final Level IGNORE_INFO_LEVEL = Level.ALL;
     private static final Level DEBUG_INFO_LEVEL = Level.FINEST;
     private static final Level INFO_INFO_LEVEL = Level.INFO;
 

--- a/Foundation/org.egovframe.rte.fdl.logging/src/test/java/org/egovframe/rte/fdl/logging/util/EgovJdkLoggerIgnoreTest.java
+++ b/Foundation/org.egovframe.rte.fdl.logging/src/test/java/org/egovframe/rte/fdl/logging/util/EgovJdkLoggerIgnoreTest.java
@@ -1,0 +1,77 @@
+package org.egovframe.rte.fdl.logging.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * ignore 로 넘긴 메시지가 기본 설정에서 기록되지 않는지 확인한다.
+ *
+ * <p>Level.OFF 는 임계값으로 쓸 때만 "끄기"이고, 레코드 수준으로 쓰면 intValue 가
+ * Integer.MAX_VALUE 라 어떤 로거 임계값도 걸러내지 못한다. 기록이 불필요하다고 넘긴 메시지가
+ * 오히려 가장 높은 심각도로 남는다.</p>
+ */
+class EgovJdkLoggerIgnoreTest {
+
+    private final AtomicInteger emitted = new AtomicInteger();
+    private Logger ignoreLogger;
+    private Handler counter;
+
+    @BeforeEach
+    void setUp() {
+        counter = new Handler() {
+            @Override
+            public void publish(LogRecord record) {
+                emitted.incrementAndGet();
+            }
+
+            @Override
+            public void flush() {
+                // 세는 것이 전부라 할 일이 없다
+            }
+
+            @Override
+            public void close() {
+                // 세는 것이 전부라 할 일이 없다
+            }
+        };
+        counter.setLevel(Level.ALL);
+
+        ignoreLogger = Logger.getLogger("ignore");
+        ignoreLogger.setUseParentHandlers(false);
+        ignoreLogger.addHandler(counter);
+    }
+
+    @AfterEach
+    void tearDown() {
+        ignoreLogger.removeHandler(counter);
+        ignoreLogger.setUseParentHandlers(true);
+    }
+
+    @Test
+    void testIgnoreDoesNotEmitUnderDefaultThreshold() {
+        ignoreLogger.setLevel(Level.INFO);
+
+        EgovJdkLogger.ignore("기록이 불필요한 메시지");
+        EgovJdkLogger.ignore("기록이 불필요한 메시지", new IllegalStateException("무시 대상"));
+
+        assertEquals(0, emitted.get(), "ignore 로 넘긴 메시지는 기본 임계값에서 기록되지 않아야 한다");
+    }
+
+    @Test
+    void testIgnoreIsQuieterThanDebug() {
+        ignoreLogger.setLevel(Level.FINEST);
+
+        EgovJdkLogger.ignore("기록이 불필요한 메시지");
+
+        assertEquals(0, emitted.get(), "ignore 는 debug 를 켠 수준에서도 조용해야 한다");
+    }
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

`EgovJdkLogger.ignore`는 javadoc에 "기록이나 처리가 불필요한 경우 사용"이라 적혀 있는데, 레코드 수준으로 `Level.OFF`를 씁니다.

`OFF`는 로거 임계값으로 쓸 때만 끄기로 동작합니다. 레코드 수준으로 쓰면 `intValue`가 `Integer.MAX_VALUE`(2147483647)라 어떤 임계값도 걸러내지 못합니다. 기록이 불필요하다고 넘긴 메시지가 오히려 가장 높은 심각도로 남습니다.

형제 `debug`와 비교하면 뒤집혀 있습니다.

```
ignore 로거가 OFF 레코드를 통과시키나    : true
debug  로거가 FINEST 레코드를 통과시키나 : false
```

`debug`는 `FINEST`(300)라 기본 임계값 `INFO`(800)에 정상적으로 걸립니다. `ignore`만 통과합니다.

호출처는 `EgovResourceReleaser` 일곱 곳입니다. 자원 해제 실패를 무시하겠다고 넘긴 메시지가 최고 심각도로 찍힙니다.

AS-IS

```java
private static final Level IGNORE_INFO_LEVEL = Level.OFF;
```

TO-BE

```java
private static final Level IGNORE_INFO_LEVEL = Level.ALL;
```

### 영향 범위

`ignore`로 넘긴 메시지만 조용해집니다. `debug`와 `info`는 그대로입니다.

세 후보를 놓고 로거 임계값을 바꿔가며 확인했습니다.

| 레코드 수준 | 임계값 `INFO` | 임계값 `FINEST` | 임계값 `ALL` |
|---|---|---|---|
| `OFF` (현재) | 기록됨 | 기록됨 | 기록됨 |
| `FINEST` | 조용 | 기록됨 | 기록됨 |
| `ALL` | 조용 | 조용 | 기록됨 |

`ALL`은 레코드 수준으로 가장 낮습니다(`Integer.MIN_VALUE`). 어떤 임계값에서도 조용하고, 운영자가 로거를 명시적으로 `ALL`로 열었을 때만 나옵니다.

`FINEST`로 바꾸는 방법도 있습니다. 다만 그 경우 `debug`와 수준이 같아져 둘을 나눈 뜻이 사라집니다. 그래서 이쪽을 택했습니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

`EgovJdkLoggerIgnoreTest` 2건을 추가했습니다. `ignore` 로거에 세는 핸들러를 붙여 기본 임계값과 `debug`를 켠 임계값 양쪽에서 아무것도 나오지 않는지 봅니다.

수정 전(RED, 상수 한 줄만 되돌려 실행)

```
[ERROR] Tests run: 2, Failures: 2, Errors: 0, Skipped: 0, Time elapsed: 0.023 s <<< FAILURE! -- in org.egovframe.rte.fdl.logging.util.EgovJdkLoggerIgnoreTest
[ERROR]   EgovJdkLoggerIgnoreTest.testIgnoreDoesNotEmitUnderDefaultThreshold:66 ignore 로 넘긴 메시지는 기본 임계값에서 기록되지 않아야 한다 ==> expected: <0> but was: <2>
[ERROR]   EgovJdkLoggerIgnoreTest.testIgnoreIsQuieterThanDebug:75 ignore 는 debug 를 켠 수준에서도 조용해야 한다 ==> expected: <0> but was: <1>
```

수정 후(GREEN, fdl-logging 모듈 전체)

```
[INFO] Tests run: 36, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

해당 없음 (서버 측 로깅)

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

해당 없음 (화면 변경 없음)
