### PR TITLE
fix(dataaccess): 테스트 산출물이 추적 중인 소스 파일을 덮어쓰던 문제 수정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@
 
 # Log file #
 *.log
+# 롤링 로그는 .log 뒤에 인덱스·타임스탬프가 붙어 위 패턴을 비껴간다
+*.log.*
 
 # BlueJ files #
 *.ctxt

--- a/Persistence/org.egovframe.rte.psl.dataaccess/src/test/java/org/egovframe/rte/psl/dataaccess/ibatis/RowHandlerTest.java
+++ b/Persistence/org.egovframe.rte.psl.dataaccess/src/test/java/org/egovframe/rte/psl/dataaccess/ibatis/RowHandlerTest.java
@@ -66,7 +66,7 @@ public class RowHandlerTest {
 
         // check
         ResourceLoader resourceLoader = new DefaultResourceLoader();
-        org.springframework.core.io.Resource resource = resourceLoader.getResource("file:./src/test/resources/META-INF/spring/" + schemaProperties.getProperty("outResultFile"));
+        org.springframework.core.io.Resource resource = resourceLoader.getResource("file:./target/test-output/" + schemaProperties.getProperty("outResultFile"));
         rowHandler.releaseResource();
 
         assertEquals(38416, rowHandler.getTotalCount());

--- a/Persistence/org.egovframe.rte.psl.dataaccess/src/test/java/org/egovframe/rte/psl/dataaccess/mybatis/ResultHandlerMapperTest.java
+++ b/Persistence/org.egovframe.rte.psl.dataaccess/src/test/java/org/egovframe/rte/psl/dataaccess/mybatis/ResultHandlerMapperTest.java
@@ -71,7 +71,7 @@ public class ResultHandlerMapperTest {
 
         // check
         ResourceLoader resourceLoader = new DefaultResourceLoader();
-        org.springframework.core.io.Resource resource = resourceLoader.getResource("file:./src/test/resources/META-INF/spring/" + schemaProperties.getProperty("outResultFile"));
+        org.springframework.core.io.Resource resource = resourceLoader.getResource("file:./target/test-output/" + schemaProperties.getProperty("outResultFile"));
 
         // 각 38,416개씩 두번 실행했으므로 총 76,832개 출력
         assertEquals(76832, resultHandler.getTotalCount());

--- a/Persistence/org.egovframe.rte.psl.dataaccess/src/test/java/org/egovframe/rte/psl/dataaccess/resulthandler/FileWritingResultHandler.java
+++ b/Persistence/org.egovframe.rte.psl.dataaccess/src/test/java/org/egovframe/rte/psl/dataaccess/resulthandler/FileWritingResultHandler.java
@@ -40,7 +40,9 @@ public class FileWritingResultHandler implements ResultHandler {
 
     @PostConstruct
     public void init() throws IOException {
-        this.file = new File("./src/test/resources/META-INF/spring/" + schemaProperties.getProperty("outResultFile"));
+        this.file = new File("./target/test-output/" + schemaProperties.getProperty("outResultFile"));
+        // 산출물은 빌드 디렉터리에 만든다. 소스 트리에 쓰면 추적 중인 파일이 더러워진다.
+        this.file.getParentFile().mkdirs();
         if (this.file.exists()) {
             this.file.delete();
             this.file.createNewFile();

--- a/Persistence/org.egovframe.rte.psl.dataaccess/src/test/java/org/egovframe/rte/psl/dataaccess/rowhandler/FileWritingRowHandler.java
+++ b/Persistence/org.egovframe.rte.psl.dataaccess/src/test/java/org/egovframe/rte/psl/dataaccess/rowhandler/FileWritingRowHandler.java
@@ -30,7 +30,9 @@ public class FileWritingRowHandler implements RowHandler {
 
     @PostConstruct
     public void init() throws IOException {
-        this.file = new File("./src/test/resources/META-INF/spring/" + schemaProperties.getProperty("outResultFile"));
+        this.file = new File("./target/test-output/" + schemaProperties.getProperty("outResultFile"));
+        // 산출물은 빌드 디렉터리에 만든다. 소스 트리에 쓰면 추적 중인 파일이 더러워진다.
+        this.file.getParentFile().mkdirs();
         if (this.file.exists()) {
             this.file.delete();
             this.file.createNewFile();


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

`dataaccess` 모듈 테스트가 산출물을 **소스 트리에, 그것도 추적 중인 파일에** 씁니다. 테스트를 한 번 돌리면 저장소가 더러워집니다.

```
$ git status --porcelain
(깨끗)

$ mvn test -Dtest=ResultHandlerMapperTest
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0

$ git status --porcelain
 M Persistence/org.egovframe.rte.psl.dataaccess/src/test/resources/META-INF/spring/outResultFile.txt

$ wc -c < .../outResultFile.txt
12734779
```

저장소에 담긴 크기는 0바이트인데 테스트가 **12.7MB / 76,810줄**로 채웁니다. 대용량 조회 결과를 파일로 내려받는 테스트라 의도된 출력이지만, 쓰는 자리가 `src/test/resources` 입니다.

```java
this.file = new File("./src/test/resources/META-INF/spring/" + schemaProperties.getProperty("outResultFile"));
```

같은 경로가 쓰는 쪽 둘(`FileWritingRowHandler`·`FileWritingResultHandler`)과 읽는 쪽 둘(`ResultHandlerMapperTest`·`RowHandlerTest`)에 하드코딩돼 있습니다. `target/` 으로 옮겼습니다. 쓰는 쪽이 `createNewFile()` 로 파일을 직접 만들기 때문에 저장소에 빈 파일을 두고 있을 이유가 없어 함께 지웠습니다.

AS-IS

```java
this.file = new File("./src/test/resources/META-INF/spring/" + ...);
```

TO-BE

```java
this.file = new File("./target/test-output/" + ...);
// 산출물은 빌드 디렉터리에 만든다. 소스 트리에 쓰면 추적 중인 파일이 더러워진다.
this.file.getParentFile().mkdirs();
```

### 롤링 로그 `.gitignore` 누락

`logging` 모듈 테스트 설정이 선언한 두 롤링 패턴 중 하나가 `.gitignore` 를 비껴갑니다.

```xml
<!-- src/test/resources/log4j2.xml -->
filePattern="./logs/rolling/rollingSample.%i.log"
filePattern="./logs/daily/dailyRollingSample.log.%d{yyyy-MM-dd-HH-mm-ss}"
```

```
$ git check-ignore -v logs/rolling/rollingSample.1.log
.gitignore:5:*.log	logs/rolling/rollingSample.1.log

$ git check-ignore -v logs/daily/dailyRollingSample.log.2026-08-09-22-02-55
(무시되지 않음)
```

`.log` 뒤에 타임스탬프가 붙어 `*.log` 패턴에 걸리지 않습니다. `*.log.*` 를 더했습니다.

### 영향 범위

테스트 산출물의 위치만 바뀝니다. 파일을 쓰고 읽는 두 테스트가 같은 경로를 쓰므로 검증 내용은 그대로입니다. 운영 코드는 건드리지 않았습니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

수정 전 — 테스트 한 번에 추적 파일이 더러워집니다.

```
$ mvn test -Dtest=ResultHandlerMapperTest
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0

$ git status --porcelain
 M .../src/test/resources/META-INF/spring/outResultFile.txt   (12,734,779 바이트)
```

수정 후 — 같은 테스트를 돌려도 트리가 그대로입니다.

```
$ mvn test -Dtest=ResultHandlerMapperTest,RowHandlerTest
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS

$ git status --porcelain
(이 PR 의 수정 외에는 없음)

$ ls -lh target/test-output/
-rw-r--r--  6.1M outResultFile.txt
```

모듈 전체

```
[INFO] Tests run: 119, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```

`.gitignore` 는 세 패턴으로 확인했습니다.

```
$ git check-ignore -q logs/daily/dailyRollingSample.log.2026-08-09-22-02-55 && echo 무시됨
무시됨
$ git check-ignore -q logs/rolling/rollingSample.1.log && echo 무시됨
무시됨
$ git check-ignore -q logs/file/sample.log && echo 무시됨
무시됨
```

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

테스트 산출물 위치만 바뀌어 화면 출력이 달라지지 않습니다.
