### PR TITLE
fix: ExceptionTransfer.processHandling()이 후처리 서비스 미설정 시 NPE로 원본 예외를 대체하는 문제 수정

### DIFF
--- a/Foundation/org.egovframe.rte.fdl.cmmn/src/main/java/org/egovframe/rte/fdl/cmmn/aspect/ExceptionTransfer.java
+++ b/Foundation/org.egovframe.rte.fdl.cmmn/src/main/java/org/egovframe/rte/fdl/cmmn/aspect/ExceptionTransfer.java
@@ -216,6 +216,10 @@ public class ExceptionTransfer {
      * @param exceptionHandlerServices 등록되어 있는 ExceptionHandlerService 리스트
      */
     protected void processHandling(Class<?> clazz, String methodName, Exception exception, PathMatcher pm, ExceptionHandlerService[] exceptionHandlerServices) {
+        if (exceptionHandlerServices == null) {
+            return;
+        }
+
         for (ExceptionHandlerService ehm : exceptionHandlerServices) {
             // 2026.02.28 KISA 보안취약점 조치
             try {

--- a/Foundation/org.egovframe.rte.fdl.cmmn/src/test/java/org/egovframe/rte/fdl/cmmn/aspect/ExceptionTransferHandlerNullTest.java
+++ b/Foundation/org.egovframe.rte.fdl.cmmn/src/test/java/org/egovframe/rte/fdl/cmmn/aspect/ExceptionTransferHandlerNullTest.java
@@ -1,0 +1,61 @@
+package org.egovframe.rte.fdl.cmmn.aspect;
+
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.Signature;
+import org.egovframe.rte.fdl.cmmn.exception.EgovBizException;
+import org.egovframe.rte.fdl.cmmn.exception.manager.ExceptionHandlerService;
+import org.junit.jupiter.api.Test;
+
+import static org.easymock.EasyMock.createNiceMock;
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.replay;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class ExceptionTransferHandlerNullTest {
+
+    // exceptionHandlerService 를 주입하지 않은 구성에서도 발생한 업무 예외를 그대로 전달해야 한다.
+    @Test
+    public void testTransferBizExceptionWithoutHandlerService() {
+        ExceptionTransfer transfer = new ExceptionTransfer();
+        EgovBizException be = new EgovBizException("해당 데이터가 없습니다.");
+
+        Exception thrown = assertThrows(EgovBizException.class, () -> transfer.transfer(joinPoint(), be));
+
+        assertSame(be, thrown);
+    }
+
+    // 빈 배열을 주입한 동일 구성과 결과가 같아야 한다.
+    @Test
+    public void testTransferBizExceptionWithEmptyHandlerService() {
+        ExceptionTransfer transfer = new ExceptionTransfer();
+        transfer.setExceptionHandlerService(new ExceptionHandlerService[]{});
+        EgovBizException be = new EgovBizException("해당 데이터가 없습니다.");
+
+        Exception thrown = assertThrows(EgovBizException.class, () -> transfer.transfer(joinPoint(), be));
+
+        assertSame(be, thrown);
+    }
+
+    // RuntimeException 도 같은 후처리 경로를 거치므로 동일하게 원본을 전달해야 한다.
+    @Test
+    public void testTransferRuntimeExceptionWithoutHandlerService() {
+        ExceptionTransfer transfer = new ExceptionTransfer();
+        RuntimeException re = new IllegalStateException("runtime exception");
+
+        Exception thrown = assertThrows(IllegalStateException.class, () -> transfer.transfer(joinPoint(), re));
+
+        assertSame(re, thrown);
+    }
+
+    private JoinPoint joinPoint() {
+        Signature signature = createNiceMock(Signature.class);
+        expect(signature.getName()).andStubReturn("updateMethod");
+        JoinPoint joinPoint = createNiceMock(JoinPoint.class);
+        expect(joinPoint.getTarget()).andStubReturn(new Object());
+        expect(joinPoint.getSignature()).andStubReturn(signature);
+        replay(signature, joinPoint);
+        return joinPoint;
+    }
+
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

`exceptionHandlerService`를 주입하지 않은 `exceptionTransfer`를 after-throwing advice로 걸면, 호출자가 업무 예외 대신 `NullPointerException`을 받습니다.

이 프로퍼티는 선택 항목입니다. 같은 클래스의 접근자는 미설정 상태에도 값을 돌려줍니다. setter에는 `@Required`도 `afterPropertiesSet`도 없습니다.

```java
// ExceptionTransfer.java:91-93
public int countOfTheExceptionHandlerService() {
    return exceptionHandlerServices != null ? exceptionHandlerServices.length : 0;
}
```

그런데 `processHandling`은 그 배열을 null 검사 없이 순회합니다. 순회 헤더는 곧이어 열리는 try 바깥에 있습니다.

```java
// ExceptionTransfer.java:218-227
protected void processHandling(..., ExceptionHandlerService[] exceptionHandlerServices) {
    for (ExceptionHandlerService ehm : exceptionHandlerServices) {   // ← 219, try 바깥
        // 2026.02.28 KISA 보안취약점 조치
        try {                                                        // ← 221
            ...
        } catch (NullPointerException e) {                           // ← 227
```

그 try는 `NullPointerException`을 포함한 다섯 종류를 전부 debug 로그로 삼킵니다. 핸들러 쪽 사정이 예외 전달을 깨지 않게 하려는 것인데, 정작 루프 헤더의 NPE만 그 보호 밖에 있습니다.

`transfer()`의 두 호출부가 모두 같습니다.

```
ExceptionTransfer.java:219   ← processHandling 의 for
ExceptionTransfer.java:124   ← EgovBizException 분기
ExceptionTransfer.java:132   ← RuntimeException 분기
```

원본 예외는 `throw` 앞에서 사라집니다(124→125, 132→143). cause로도 남지 않습니다.

```
[ERROR] ExceptionTransferHandlerNullTest.testTransferBizExceptionWithoutHandlerService:23
        Unexpected exception type thrown, expected: <org.egovframe.rte.fdl.cmmn.exception.EgovBizException> but was: <java.lang.NullPointerException>
[ERROR] ExceptionTransferHandlerNullTest.testTransferRuntimeExceptionWithoutHandlerService:46
        Unexpected exception type thrown, expected: <java.lang.IllegalStateException> but was: <java.lang.NullPointerException>
[ERROR] Tests run: 3, Failures: 2, Errors: 0, Skipped: 0
```

빈 배열을 준 동일 구성은 원본 예외를 그대로 전달합니다. 위 3건 중 그 대조군만 통과하므로, 차이는 null과 빈 배열뿐입니다.

형제 후처리 경로인 `LeaveaTrace.trace()`는 같은 자리에 가드를 둡니다.

```java
// LeaveaTrace.java:137-139
if (traceHandlerServices == null) {
    return;
}
```

AS-IS / TO-BE

```diff
 protected void processHandling(Class<?> clazz, String methodName, Exception exception, PathMatcher pm, ExceptionHandlerService[] exceptionHandlerServices) {
+    if (exceptionHandlerServices == null) {
+        return;
+    }
+
     for (ExceptionHandlerService ehm : exceptionHandlerServices) {
```

try를 루프 바깥으로 빼도 NPE는 막힙니다. 그러나 지금은 핸들러 하나가 던져도 다음 반복이 계속되는데, 밖으로 빼면 첫 실패에서 나머지 핸들러를 건너뜁니다. 위 KISA 주석이 만든 핸들러별 격리가 깨지므로 택하지 않았습니다.

### 영향 범위

배열이 null이 아니면 실행되지 않는 가드입니다. 시그니처도 바뀌지 않습니다. 달라지는 경로는 지금 NPE를 내는 구성 하나이고, 그 결과는 빈 배열을 준 구성과 같아집니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

`ExceptionTransferHandlerNullTest`를 추가했습니다. 미설정·빈 배열 두 구성을 `EgovBizException`과 `RuntimeException` 경로에 각각 태워, 던져진 예외가 원본 인스턴스 그대로인지 봅니다.

```
$ mvn -pl Foundation/org.egovframe.rte.fdl.cmmn test
[INFO] Tests run: 41, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```

가드 세 줄을 도로 빼면 위 RED가 다시 나옵니다.

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

화면이 없는 실행환경 모듈이라 첨부하지 않았습니다.
