### PR TITLE
fix: EgovBizException 무인자 생성자의 기본 메시지가 상위 클래스명을 쓰는 문제 수정

### DIFF
--- a/Foundation/org.egovframe.rte.fdl.cmmn/src/main/java/org/egovframe/rte/fdl/cmmn/exception/EgovBizException.java
+++ b/Foundation/org.egovframe.rte.fdl.cmmn/src/main/java/org/egovframe/rte/fdl/cmmn/exception/EgovBizException.java
@@ -43,7 +43,7 @@ public class EgovBizException extends BaseException {
      * EgovBizException 생성자.
      */
     public EgovBizException() {
-        this("BaseException without message", null, null);
+        this("EgovBizException without message", null, null);
     }
 
     /**

--- a/Foundation/org.egovframe.rte.fdl.cmmn/src/test/java/org/egovframe/rte/fdl/cmmn/EgovBizExceptionTest.java
+++ b/Foundation/org.egovframe.rte.fdl.cmmn/src/test/java/org/egovframe/rte/fdl/cmmn/EgovBizExceptionTest.java
@@ -33,4 +33,11 @@ public class EgovBizExceptionTest {
         assertSame(wrapped, be.getWrappedException());
     }
 
+    @Test
+    public void testDefaultMessageWithoutArgument() {
+        EgovBizException be = new EgovBizException();
+
+        assertEquals("EgovBizException without message", be.getMessage());
+    }
+
 }


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

`exception` 패키지에서 무인자 생성자는 기본 메시지에 자기 클래스명을 씁니다. `EgovBizException`만 상위 클래스명을 씁니다.

```
$ grep -n 'without message' .../fdl/cmmn/exception/*.java
BaseException.java:55            this("BaseException without message", null, null);
BaseRuntimeException.java:53     this("BaseRuntimeException without message", null, null);
EgovBizException.java:46         this("BaseException without message", null, null);
FdlException.java:46             this("FdlException without message", null, null);
```

형제 쪽에서는 이 기본값을 이미 검증합니다.

```java
// FdlExceptionTest.java:38
assertEquals("FdlException without message", fe.getMessage());
```

메시지 없이 던져진 `EgovBizException`은 무인자 생성이라 원인 예외도 없습니다. 메시지 문자열만 남기는 로그 경로에서는 자기 타입을 알릴 수단이 없습니다. `ExceptionTransfer` 121줄의 `error(be.getMessage(), be.getCause())`가 그런 경로입니다.

AS-IS / TO-BE

```diff
 public EgovBizException() {
-    this("BaseException without message", null, null);
+    this("EgovBizException without message", null, null);
 }
```

### 영향 범위

무인자로 생성한 `EgovBizException`의 메시지 문자열 하나입니다. 인자를 준 생성자 세 개는 그대로입니다. 같은 계열에서 무인자 기본 메시지가 있는 나머지 셋은 이미 자기 클래스명을 씁니다. `BaseRuntimeException`을 상속하는 `EgovBatchException`은 무인자 생성자가 없어 해당하지 않습니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

기존 `EgovBizExceptionTest`에 형제 `FdlExceptionTest`와 같은 형태로 회귀 테스트를 더했습니다.

```
$ mvn -pl Foundation/org.egovframe.rte.fdl.cmmn test
[INFO] Tests run: 39, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```

문자열을 도로 되돌리면 실패합니다.

```
[ERROR] EgovBizExceptionTest.testDefaultMessageWithoutArgument:40
        expected: <EgovBizException without message> but was: <BaseException without message>
[ERROR] Tests run: 3, Failures: 1, Errors: 0, Skipped: 0
```

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

화면이 없는 실행환경 모듈이라 첨부하지 않았습니다.
