### PR TITLE
docs: trace.handler 와 trace.manager 의 package.html 설명이 서로 뒤바뀐 문제 수정

### DIFF
--- a/Foundation/org.egovframe.rte.fdl.cmmn/src/main/java/org/egovframe/rte/fdl/cmmn/trace/handler/package.html
+++ b/Foundation/org.egovframe.rte.fdl.cmmn/src/main/java/org/egovframe/rte/fdl/cmmn/trace/handler/package.html
@@ -3,6 +3,6 @@
     <meta content="text/html; charset=UTF-8" http-equiv="Content-Type">
 </head>
 <body>
-LeaveaTrace에서 실행하는 Handler와 실행하는 주체의 패키지,클래스와 매핑해주는 역할을 하는 Manager 클래스가 포함된 패키지이다.
+LeaveaTrace에서 실행하는 Handler를 포함하고 있는 패키지 이다.
 </body>
 </html>

--- a/Foundation/org.egovframe.rte.fdl.cmmn/src/main/java/org/egovframe/rte/fdl/cmmn/trace/manager/package.html
+++ b/Foundation/org.egovframe.rte.fdl.cmmn/src/main/java/org/egovframe/rte/fdl/cmmn/trace/manager/package.html
@@ -3,6 +3,6 @@
     <meta content="text/html; charset=UTF-8" http-equiv="Content-Type">
 </head>
 <body>
-LeaveaTrace에서 실행하는 Handler를 포함하고 있는 패키지 이다.
+LeaveaTrace에서 실행하는 Handler와 실행하는 주체의 패키지,클래스와 매핑해주는 역할을 하는 Manager 클래스가 포함된 패키지이다.
 </body>
 </html>


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

`trace.handler`와 `trace.manager`의 `package.html` 설명이 서로 뒤바뀌어 있습니다. 생성된 API 문서에서 각 패키지가 자기가 담지 않은 타입을 설명합니다.

```
trace/handler   "…Handler와 실행하는 주체의 패키지,클래스와 매핑해주는 역할을 하는 Manager 클래스가 포함된 패키지이다."
   실제 클래스   TraceHandler, DefaultTraceHandler

trace/manager   "LeaveaTrace에서 실행하는 Handler를 포함하고 있는 패키지 이다."
   실제 클래스   AbstractTraceHandleManager, DefaultTraceHandleManager, TraceHandlerService
```

같은 모듈의 형제인 `exception.handler`·`exception.manager`는 이 규칙을 지킵니다.

```
exception/handler   "Exception 발생시 처리되어야 할 인터페이스를 포함하고 있다."
   실제 클래스        ExceptionHandler

exception/manager   "…Handler 와 Exception 발생 패키지와의 연결고리를 정의하는 Manager를 포함…"
   실제 클래스        AbstractExceptionHandleManager, DefaultExceptionHandleManager, ExceptionHandlerService
```

AS-IS / TO-BE

두 설명을 맞바꿨습니다. 문장은 그대로 두고 자리만 바꿉니다.

```diff
--- a/.../trace/handler/package.html
-LeaveaTrace에서 실행하는 Handler와 실행하는 주체의 패키지,클래스와 매핑해주는 역할을 하는 Manager 클래스가 포함된 패키지이다.
+LeaveaTrace에서 실행하는 Handler를 포함하고 있는 패키지 이다.

--- a/.../trace/manager/package.html
-LeaveaTrace에서 실행하는 Handler를 포함하고 있는 패키지 이다.
+LeaveaTrace에서 실행하는 Handler와 실행하는 주체의 패키지,클래스와 매핑해주는 역할을 하는 Manager 클래스가 포함된 패키지이다.
```

### 영향 범위

`maven-javadoc-plugin`이 만드는 패키지 요약 문장 두 개입니다. 코드 변경이 없습니다.

`Batch` 모듈에도 같은 형태가 두 쌍 더 있습니다(`job.flow` ↔ `launch.support`, `item.file` ↔ `item.file.transform`). 모듈이 달라 별도로 내겠습니다.

## JUnit 테스트 JUnit tests

- [ ] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

문서 문자열이라 단위 테스트로 세울 수 있는 동작이 없습니다. 각 패키지의 실제 클래스 목록과 대조해 확인했고 모듈 테스트에 회귀가 없는 것만 봤습니다.

```
$ mvn -pl Foundation/org.egovframe.rte.fdl.cmmn test
[INFO] Tests run: 38, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

화면이 없는 실행환경 모듈이라 첨부하지 않았습니다.
