### PR TITLE
docs: bat.core 패키지 설명 4개가 자기가 아닌 다른 패키지를 가리키는 문제 수정

### DIFF
--- a/Batch/org.egovframe.rte.bat.core/src/main/java/org/egovframe/rte/bat/core/item/file/package.html
+++ b/Batch/org.egovframe.rte.bat.core/src/main/java/org/egovframe/rte/bat/core/item/file/package.html
@@ -3,6 +3,6 @@
     <meta content="text/html; charset=UTF-8" http-equiv="Content-Type">
 </head>
 <body>
-전자정부 프레임워크의 배치실행환경 서비스의 file.transform 컨트롤러 클래스이를 포함하는 패키지이다.
+전자정부 프레임워크의 배치실행환경 서비스의 file 컨트롤러 클래스이를 포함하는 패키지이다.
 </body>
 </html>

--- a/Batch/org.egovframe.rte.bat.core/src/main/java/org/egovframe/rte/bat/core/item/file/transform/package.html
+++ b/Batch/org.egovframe.rte.bat.core/src/main/java/org/egovframe/rte/bat/core/item/file/transform/package.html
@@ -3,6 +3,6 @@
     <meta content="text/html; charset=UTF-8" http-equiv="Content-Type">
 </head>
 <body>
-전자정부 프레임워크의 배치실행환경 서비스의 item.file 컨트롤러 클래스이를 포함하는 패키지이다.
+전자정부 프레임워크의 배치실행환경 서비스의 file.transform 컨트롤러 클래스이를 포함하는 패키지이다.
 </body>
 </html>

--- a/Batch/org.egovframe.rte.bat.core/src/main/java/org/egovframe/rte/bat/core/job/flow/package.html
+++ b/Batch/org.egovframe.rte.bat.core/src/main/java/org/egovframe/rte/bat/core/job/flow/package.html
@@ -3,6 +3,6 @@
     <meta content="text/html; charset=UTF-8" http-equiv="Content-Type">
 </head>
 <body>
-전자정부 프레임워크의 배치실행환경 서비스의 launch.support 클래스를 포함하는 패키지이다.
+전자정부 프레임워크의 배치실행환경 서비스의 job.flow 클래스를 포함하는 패키지이다.
 </body>
 </html>

--- a/Batch/org.egovframe.rte.bat.core/src/main/java/org/egovframe/rte/bat/core/launch/support/package.html
+++ b/Batch/org.egovframe.rte.bat.core/src/main/java/org/egovframe/rte/bat/core/launch/support/package.html
@@ -3,6 +3,6 @@
     <meta content="text/html; charset=UTF-8" http-equiv="Content-Type">
 </head>
 <body>
-전자정부 프레임워크의 배치실행환경 서비스의 job.flow 클래스를 포함하는 패키지이다.
+전자정부 프레임워크의 배치실행환경 서비스의 launch.support 클래스를 포함하는 패키지이다.
 </body>
 </html>


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

`bat.core` 의 `package.html` 네 개가 자기가 아닌 다른 패키지를 가리킵니다. 생성된 API 문서의 패키지 요약에 그대로 실립니다.

`mvn javadoc:javadoc` 으로 만든 문서에서 요약과 그 페이지가 나열하는 클래스를 나란히 뽑았습니다.

```
org.egovframe.rte.bat.core.job.flow
  요약    …서비스의 launch.support 클래스를 포함하는 패키지이다.
  클래스  EgovDecider

org.egovframe.rte.bat.core.launch.support
  요약    …서비스의 job.flow 클래스를 포함하는 패키지이다.
  클래스  EgovBatchRunner, EgovCommandLineRunner, EgovSchedulerJCRunner, EgovSchedulerRunner

org.egovframe.rte.bat.core.item.file
  요약    …서비스의 file.transform 컨트롤러 클래스이를 포함하는 패키지이다.
  클래스  EgovByteReader, EgovByteReaderFactory, EgovFlatFileByteReader, EgovIndexFileReader, EgovIndexFileWriter, EgovLineMapper, EgovPartitionFlatFileItemWriter

org.egovframe.rte.bat.core.item.file.transform
  요약    …서비스의 item.file 컨트롤러 클래스이를 포함하는 패키지이다.
  클래스  EgovAbstractLineTokenizer, EgovDelimitedLineTokenizer, EgovFixedLengthTokenizer 등 11개
```

`job.flow` 와 `launch.support` 는 설명이 서로 맞바뀌었습니다. `item.file` 은 하위 패키지를, `item.file.transform` 은 상위 패키지를 가리킵니다.

같은 모듈의 나머지 아홉 개는 모두 자기 패키지를 가리키고, 형제가 쓰는 표기도 일정합니다.

```
event                    "event …"
item/composite           "composite …"           item/composite/provider  "composite.provider …"
item/database            "database …"            item/composite/reader    "composite.reader …"
listener                 "listener …"            item/database/support    "database.support …"
reflection               "reflection …"          item/file/mapping        "file.mapping …"
```

`src/test` 쪽 `launch/support/package.html` 은 자기를 `launch.support` 라고 정확히 적고 있습니다.

### AS-IS / TO-BE

가리키는 패키지 이름만 고쳤습니다. 나머지 문장은 형제들이 쓰는 표현 그대로 두었습니다.

```diff
--- a/.../bat/core/job/flow/package.html
-…배치실행환경 서비스의 launch.support 클래스를 포함하는 패키지이다.
+…배치실행환경 서비스의 job.flow 클래스를 포함하는 패키지이다.

--- a/.../bat/core/launch/support/package.html
-…배치실행환경 서비스의 job.flow 클래스를 포함하는 패키지이다.
+…배치실행환경 서비스의 launch.support 클래스를 포함하는 패키지이다.

--- a/.../bat/core/item/file/package.html
-…배치실행환경 서비스의 file.transform 컨트롤러 클래스이를 포함하는 패키지이다.
+…배치실행환경 서비스의 file 컨트롤러 클래스이를 포함하는 패키지이다.

--- a/.../bat/core/item/file/transform/package.html
-…배치실행환경 서비스의 item.file 컨트롤러 클래스이를 포함하는 패키지이다.
+…배치실행환경 서비스의 file.transform 컨트롤러 클래스이를 포함하는 패키지이다.
```

`item/file` 은 `file.transform` 을 `file` 로 적었습니다. 형제인 `item/database` 와 `item/composite` 가 자기를 `database`·`composite` 로 적고 있어 그 깊이에 맞췄습니다.

### 영향 범위

`maven-javadoc-plugin` 이 만드는 패키지 요약 문장 네 개입니다. 코드 변경이 없습니다.

`Foundation` 모듈의 `trace.handler`·`trace.manager` 에 같은 형태가 있어 #353 로 따로 냈습니다. 모듈이 달라 나눴습니다.

## JUnit 테스트 JUnit tests

- [ ] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

문서 문자열이라 단위 테스트로 세울 수 있는 동작이 없습니다. 문서를 실제로 생성해 요약이 바뀌는지 보고, 모듈 테스트에 회귀가 없는 것을 확인했습니다.

수정 후 다시 생성한 문서입니다.

```
$ mvn -pl Batch/org.egovframe.rte.bat.core javadoc:javadoc
[INFO] BUILD SUCCESS

org.egovframe.rte.bat.core.job.flow             …서비스의 job.flow 클래스를 포함하는 패키지이다.
org.egovframe.rte.bat.core.launch.support       …서비스의 launch.support 클래스를 포함하는 패키지이다.
org.egovframe.rte.bat.core.item.file            …서비스의 file 컨트롤러 클래스이를 포함하는 패키지이다.
org.egovframe.rte.bat.core.item.file.transform  …서비스의 file.transform 컨트롤러 클래스이를 포함하는 패키지이다.
```

```
$ mvn -pl Batch/org.egovframe.rte.bat.core test
[INFO] Tests run: 86, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```

모듈의 `package.html` 열세 개를 전수로 대조했고, 위 네 개 외에는 어긋나는 것이 없습니다.

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

화면이 없는 실행환경 모듈이라 첨부하지 않았습니다.
