### PR TITLE
fix: iBATIS 타입핸들러 2종이 컬럼을 읽기 전에 wasNull 을 물어 값을 잃는 문제 수정

### DIFF
--- a/Persistence/org.egovframe.rte.psl.dataaccess/src/main/java/org/egovframe/rte/psl/dataaccess/typehandler/CalendarTypeHandler.java
+++ b/Persistence/org.egovframe.rte.psl.dataaccess/src/main/java/org/egovframe/rte/psl/dataaccess/typehandler/CalendarTypeHandler.java
@@ -52,11 +52,11 @@ public class CalendarTypeHandler implements TypeHandlerCallback {
      * @throws SQLException
      */
     public Object getResult(ResultGetter getter) throws SQLException {
-        if (getter.wasNull()) {
-            return null;
-        }
         java.util.Calendar cal = java.util.Calendar.getInstance();
         java.sql.Timestamp ts = getter.getTimestamp(cal);
+        if (ts == null) {
+            return null;
+        }
         cal.setTime(ts);
         return cal;
     }

--- a/Persistence/org.egovframe.rte.psl.dataaccess/src/main/java/org/egovframe/rte/psl/dataaccess/typehandler/StringTimestampTypeHandler.java
+++ b/Persistence/org.egovframe.rte.psl.dataaccess/src/main/java/org/egovframe/rte/psl/dataaccess/typehandler/StringTimestampTypeHandler.java
@@ -68,10 +68,10 @@ public class StringTimestampTypeHandler implements TypeHandlerCallback {
      * @throws SQLException
      */
     public Object getResult(ResultGetter getter) throws SQLException {
-        if (getter.wasNull()) {
+        Timestamp ts = getter.getTimestamp();
+        if (ts == null) {
             return null;
         }
-        Timestamp ts = getter.getTimestamp();
         return DTF.format(ts.toLocalDateTime());
     }
 

--- a/Persistence/org.egovframe.rte.psl.dataaccess/src/test/java/org/egovframe/rte/psl/dataaccess/typehandler/CalendarTypeHandlerTest.java
+++ b/Persistence/org.egovframe.rte.psl.dataaccess/src/test/java/org/egovframe/rte/psl/dataaccess/typehandler/CalendarTypeHandlerTest.java
@@ -94,6 +94,23 @@ public class CalendarTypeHandlerTest {
     }
 
     @Test
+    public void getResultReturnsNullWhenColumnIsNull() throws Exception {
+        CalendarTypeHandler handler = new CalendarTypeHandler();
+        // 직전 컬럼이 non-null 이면 wasNull 은 false 다. 대상 컬럼 자체가 null 인 경우다.
+        assertNull(handler.getResult(resultGetter(false, null)));
+    }
+
+    @Test
+    public void getResultReadsColumnEvenWhenPrecedingColumnWasNull() throws Exception {
+        CalendarTypeHandler handler = new CalendarTypeHandler();
+        // 직전 컬럼이 null 이면 wasNull 은 true 로 남는다. 대상 컬럼에는 값이 있다.
+        Object result = handler.getResult(resultGetter(true, EXPECTED_TS));
+
+        assertInstanceOf(Calendar.class, result);
+        assertEquals(EXPECTED_TS.getTime(), ((Calendar) result).getTimeInMillis());
+    }
+
+    @Test
     public void getResultConvertsTimestampToCalendar() throws Exception {
         CalendarTypeHandler handler = new CalendarTypeHandler();
         Object result = handler.getResult(resultGetter(false, EXPECTED_TS));

--- a/Persistence/org.egovframe.rte.psl.dataaccess/src/test/java/org/egovframe/rte/psl/dataaccess/typehandler/StringTimestampTypeHandlerTest.java
+++ b/Persistence/org.egovframe.rte.psl.dataaccess/src/test/java/org/egovframe/rte/psl/dataaccess/typehandler/StringTimestampTypeHandlerTest.java
@@ -31,6 +31,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -90,6 +91,13 @@ public class StringTimestampTypeHandlerTest {
         AtomicReference<Timestamp> captured = new AtomicReference<>();
         handler.setParameter(capturingSetter(captured), FORMATTED);
         assertEquals(EXPECTED_TS, captured.get());
+    }
+
+    @Test
+    public void getResultReturnsNullWhenColumnIsNull() throws Exception {
+        StringTimestampTypeHandler handler = new StringTimestampTypeHandler();
+        // 대상 컬럼 자체가 null 인 경우다.
+        assertNull(handler.getResult(resultGetter(null)));
     }
 
     @Test


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

`ResultGetter.wasNull()` 은 직전에 읽은 컬럼에 대한 상태입니다. `TypeHandlerCallback` 을 구현한 두 핸들러가 대상 컬럼을 읽기도 전에 이것을 묻습니다.

```java
// CalendarTypeHandler
public Object getResult(ResultGetter getter) throws SQLException {
    if (getter.wasNull()) {          // 아직 이 컬럼을 읽지 않았다
        return null;
    }
    java.util.Calendar cal = java.util.Calendar.getInstance();
    java.sql.Timestamp ts = getter.getTimestamp(cal);
    cal.setTime(ts);
    return cal;
}

// StringTimestampTypeHandler
public Object getResult(ResultGetter getter) throws SQLException {
    if (getter.wasNull()) {          // 같은 순서
        return null;
    }
    Timestamp ts = getter.getTimestamp();
    return DTF.format(ts.toLocalDateTime());
}
```

그래서 두 가지가 일어납니다. resultMap 에서 직전 컬럼이 NULL 이면 대상 컬럼에 값이 있어도 `null` 로 매핑됩니다. 반대로 직전 컬럼에 값이 있고 대상 컬럼이 NULL 이면 `wasNull()` 이 `false` 라 그대로 진행해서 `cal.setTime(null)` 과 `ts.toLocalDateTime()` 에서 `NullPointerException` 이 납니다.

같은 패키지의 `CalendarMapperTypeHandler` 는 값을 먼저 읽고 `null` 인지 봅니다.

```java
public Calendar getResult(ResultSet rs, String columnName) throws SQLException {
    java.util.Calendar cal = java.util.Calendar.getInstance();
    if (rs.getTimestamp(columnName) == null) {
        return null;
    } else {
        java.sql.Timestamp ts = rs.getTimestamp(columnName);
        cal.setTime(ts);
        return cal;
    }
}
```

기존 단위 테스트는 `wasNull` 과 조회 값을 같은 값에서 만들어 넘기기 때문에 두 값이 어긋나는 경우가 생기지 않았습니다.

### AS-IS / TO-BE

`CalendarMapperTypeHandler` 와 같은 순서로 맞췄습니다. 값을 먼저 읽고 `null` 인지 봅니다.

```diff
 // CalendarTypeHandler.getResult
-        if (getter.wasNull()) {
-            return null;
-        }
         java.util.Calendar cal = java.util.Calendar.getInstance();
         java.sql.Timestamp ts = getter.getTimestamp(cal);
+        if (ts == null) {
+            return null;
+        }
         cal.setTime(ts);
         return cal;

 // StringTimestampTypeHandler.getResult
-        if (getter.wasNull()) {
+        Timestamp ts = getter.getTimestamp();
+        if (ts == null) {
             return null;
         }
-        Timestamp ts = getter.getTimestamp();
         return DTF.format(ts.toLocalDateTime());
```

### 영향 범위

`TypeHandlerCallback` 구현은 저장소 안에 이 둘뿐이고, 둘 다 같은 순서로 되어 있었습니다.

직전 컬럼과 대상 컬럼이 모두 값을 가진 경로의 결과는 그대로입니다. 달라지는 것은 둘 중 하나가 NULL 인 경우입니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

기존 테스트 두 클래스에 케이스를 더했습니다. 두 클래스가 이미 쓰는 JDK `Proxy` 기반 `ResultGetter` 대체를 그대로 씁니다.

```java
// 직전 컬럼이 non-null 이고 대상 컬럼이 null 인 경우
assertNull(handler.getResult(resultGetter(false, null)));

// 직전 컬럼이 null 이고 대상 컬럼에 값이 있는 경우
Object result = handler.getResult(resultGetter(true, EXPECTED_TS));
assertInstanceOf(Calendar.class, result);
assertEquals(EXPECTED_TS.getTime(), ((Calendar) result).getTimeInMillis());
```

수정 전에 실행하면 셋 다 실패합니다.

```
$ mvn -pl Persistence/org.egovframe.rte.psl.dataaccess test -Dtest=CalendarTypeHandlerTest,StringTimestampTypeHandlerTest
[ERROR] CalendarTypeHandlerTest.getResultReadsColumnEvenWhenPrecedingColumnWasNull:109 Unexpected null value, expected: <java.util.Calendar> but was: <null>
[ERROR] CalendarTypeHandlerTest.getResultReturnsNullWhenColumnIsNull:100 » NullPointer date must not be null
[ERROR] StringTimestampTypeHandlerTest.getResultReturnsNullWhenColumnIsNull:100 » NullPointer Cannot invoke "java.sql.Timestamp.toLocalDateTime()" because "ts" is null
```

수정 후 모듈 전체입니다.

```
$ mvn -pl Persistence/org.egovframe.rte.psl.dataaccess test
[INFO] Tests run: 125, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```

수동 확인은 실제 `SqlMapClient` 로 했습니다. 테스트용 HSQL 에 `SQL_TIMESTAMP_TYPE` 만 NULL 인 행을 넣고 `selectTypeTest` 를 조회한 결과입니다.

```
수정 전   DB 값 = 2024-01-02 03:04:05.0   매핑 결과 calendarType = null
수정 후   DB 값 = 2024-01-02 03:04:05.0   매핑 결과 calendarType = GregorianCalendar[time=1704132245000, ...]
```

`DATE_TYPE` 만 NULL 인 행으로 `selectTypeHandlerTest` 를 조회하면 수정 전에는 예외가 나고, 수정 후에는 `strDate=null` 로 매핑됩니다.

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

화면이 없는 실행환경 모듈이라 첨부하지 않았습니다.
