### PR TITLE
fix: DB 프로퍼티 로딩이 쓰지도 않는 컬럼을 String 으로 캐스팅해 전체가 죽는 문제 수정

### DIFF
--- a/Foundation/org.egovframe.rte.fdl.property/src/main/java/org/egovframe/rte/fdl/property/db/DbPropertySourceDelegate.java
+++ b/Foundation/org.egovframe.rte.fdl.property/src/main/java/org/egovframe/rte/fdl/property/db/DbPropertySourceDelegate.java
@@ -61,11 +61,10 @@ public class DbPropertySourceDelegate {
                     String pValue = null;
                     while (iterator.hasNext()) {
                         String key = iterator.next();
-                        String data = (String) property.get(key);
                         if (PROPERTY_SOURCE_KEY.equalsIgnoreCase(key)) {
-                            pKey = data;
+                            pKey = (String) property.get(key);
                         } else if (PROPERTY_SOURCE_VALUE.equalsIgnoreCase(key)) {
-                            pValue = data;
+                            pValue = (String) property.get(key);
                         }
                     }
                     if (pKey == null) {

--- a/Foundation/org.egovframe.rte.fdl.property/src/test/java/org/egovframe/rte/fdl/property/db/DbPropertySourceDelegateTest.java
+++ b/Foundation/org.egovframe.rte.fdl.property/src/test/java/org/egovframe/rte/fdl/property/db/DbPropertySourceDelegateTest.java
@@ -51,6 +51,20 @@ public class DbPropertySourceDelegateTest {
         }
     }
 
+    @Test
+    public void initPropertiesIgnoresTypeOfUnusedColumns() {
+        EmbeddedDatabase database = createDatabase();
+        try {
+            DbPropertySourceDelegate delegate = new DbPropertySourceDelegate(database,
+                    "SELECT PKEY, PVALUE, 1 AS SORT_ORDER FROM PROPERTY");
+
+            assertEquals("sample01", delegate.getProperty("egov.test.sample01"));
+            assertEquals("sample02", delegate.getProperty("egov.test.sample02"));
+        } finally {
+            database.shutdown();
+        }
+    }
+
     private EmbeddedDatabase createDatabase() {
         return new EmbeddedDatabaseBuilder()
                 .generateUniqueName(true)


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

`DbPropertySourceDelegate.initProperties()` 가 행의 모든 컬럼을 돌면서 값을 먼저 `String` 으로 캐스팅한 뒤에야 그 컬럼이 `PKEY` 인지 `PVALUE` 인지 판별합니다. 조회 SQL 에 숫자나 날짜 컬럼이 하나만 섞여 있어도 `ClassCastException` 이 나면서 프로퍼티 로딩 전체가 실패합니다. 정작 그 컬럼은 읽지도 않습니다.

```java
String key = iterator.next();
String data = (String) property.get(key);   // 이 컬럼을 쓸지 아직 모른다
if (PROPERTY_SOURCE_KEY.equalsIgnoreCase(key)) {
    pKey = data;
} else if (PROPERTY_SOURCE_VALUE.equalsIgnoreCase(key)) {
    pValue = data;
}
```

이 루프는 예상 밖의 컬럼을 이미 상정하고 있습니다. `71b9782` 가 컬럼 라벨을 대소문자 무시로 비교하게 하고 키 컬럼이 없는 행은 건너뛰도록 바꿨습니다. 다만 그때 다룬 것은 라벨이고, 타입은 그대로 남았습니다.

운영 테이블에 정렬 순서나 수정 일시 같은 컬럼이 함께 있는 경우, 또는 조회 SQL 이 `SELECT *` 인 경우에 바로 걸립니다.

### AS-IS / TO-BE

캐스팅을 두 분기 안으로 옮겼습니다.

```diff
                         String key = iterator.next();
-                        String data = (String) property.get(key);
                         if (PROPERTY_SOURCE_KEY.equalsIgnoreCase(key)) {
-                            pKey = data;
+                            pKey = (String) property.get(key);
                         } else if (PROPERTY_SOURCE_VALUE.equalsIgnoreCase(key)) {
-                            pValue = data;
+                            pValue = (String) property.get(key);
                         }
```

### 영향 범위

소비하는 두 컬럼의 동작은 그대로입니다. `PKEY` 나 `PVALUE` 자리에 문자열이 아닌 값이 오면 수정 전과 똑같이 `ClassCastException` 이 납니다. 달라지는 것은 읽지 않는 컬럼뿐입니다.

호출부는 `DbPropertySource:27` 입니다. 같은 모듈에서 소비 여부를 확인하기 전에 캐스팅하는 자리가 더 있는지 전수로 봤고, 나머지 `(String)` 캐스팅은 모두 실제로 쓰는 값에 대한 것이었습니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

기존 `DbPropertySourceDelegateTest` 에 케이스를 더했습니다. 같은 테스트 클래스가 쓰는 임베디드 HSQL 데이터소스를 그대로 쓰고, 조회 SQL 에만 쓰지 않는 정수 컬럼을 하나 넣었습니다.

```java
DbPropertySourceDelegate delegate = new DbPropertySourceDelegate(database,
        "SELECT PKEY, PVALUE, 1 AS SORT_ORDER FROM PROPERTY");

assertEquals("sample01", delegate.getProperty("egov.test.sample01"));
assertEquals("sample02", delegate.getProperty("egov.test.sample02"));
```

수정 전에 실행하면 실패합니다.

```
$ mvn -pl Foundation/org.egovframe.rte.fdl.property test -Dtest=DbPropertySourceDelegateTest#initPropertiesIgnoresTypeOfUnusedColumns
[ERROR] DbPropertySourceDelegateTest.initPropertiesIgnoresTypeOfUnusedColumns:58 » ClassCast class java.lang.Integer cannot be cast to class java.lang.String
[ERROR] Tests run: 1, Failures: 0, Errors: 1, Skipped: 0
```

수정 후 모듈 전체입니다.

```
$ mvn -pl Foundation/org.egovframe.rte.fdl.property test
[INFO] Tests run: 14, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

화면이 없는 실행환경 모듈이라 첨부하지 않았습니다.
