### PR TITLE
fix: EgovStringUtil.replace 가 토큰 길이를 무시하고 원본을 잃는 문제 수정

### DIFF
--- a/Foundation/org.egovframe.rte.fdl.string/src/main/java/org/egovframe/rte/fdl/string/EgovStringUtil.java
+++ b/Foundation/org.egovframe.rte.fdl.string/src/main/java/org/egovframe/rte/fdl/string/EgovStringUtil.java
@@ -720,13 +720,12 @@ public final class EgovStringUtil {
      * @return converting result
      */
     public static String replace(String str, String replacedStr, String replaceStr) {
-        String newStr = "";
-        if (str.contains(replacedStr)) {
-            String s1 = str.substring(0, str.indexOf(replacedStr));
-            String s2 = str.substring(str.indexOf(replacedStr) + 1);
-            newStr = s1 + replaceStr + s2;
+        int startPosit = str.indexOf(replacedStr);
+        if (startPosit != -1) {
+            int endPosit = replacedStr.length() + startPosit;
+            return str.substring(0, startPosit) + replaceStr + str.substring(endPosit);
         }
-        return newStr;
+        return str;
     }
 
     /**

--- a/Foundation/org.egovframe.rte.fdl.string/src/test/java/org/egovframe/rte/fdl/string/EgovStringUtilTest.java
+++ b/Foundation/org.egovframe.rte.fdl.string/src/test/java/org/egovframe/rte/fdl/string/EgovStringUtilTest.java
@@ -340,6 +340,11 @@ public class EgovStringUtilTest {
         String replaced = EgovStringUtil.replace("password,password", ",", "-");
 
         assertEquals("password-password", replaced);
+
+        // 1. token longer than one character
+        assertEquals("work.id", EgovStringUtil.replace("work$$id", "$$", "."));
+        // 2. original String has no token
+        assertEquals("password", EgovStringUtil.replace("password", ",", "-"));
     }
 
     @Test


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

`EgovStringUtil.replace(String, String, String)` 가 두 갈래로 잘못 동작합니다.

하나는 자른 위치입니다. 뒷부분을 `indexOf(replacedStr) + 1` 에서 잘라내서, 두 글자 이상인 토큰은 두 번째 글자부터가 결과에 그대로 남습니다. 다른 하나는 토큰이 없을 때입니다. 결과 변수를 `""` 로 초기화한 뒤 `if` 밖에서 돌려주기 때문에 원본 문자열이 빈 문자열이 됩니다.

같은 클래스를 컴파일해 수정 전후로 직접 호출한 결과입니다.

```
호출                            수정 전     수정 후
replace("work$$id", "$$", ".")  work.$id    work.id
replace("ab", "ab", "X")        Xb          X
replace("password", ",", "-")   (빈 문자열)  password
replace("abc", "", "X")         Xbc         Xabc
replace("a,b,c", ",", "-")      a-b,c       a-b,c
replace("a,b", ",", null)       anullb      anullb
replace(null, ",", "-")         NPE         NPE
```

앞 네 줄이 달라졌고, 뒤 세 줄은 그대로입니다. 첫 번째 토큰만 치환하는 기존 계약도 유지했습니다.

같은 클래스의 형제인 `trim(String, String)` 은 같은 자리에서 토큰 길이를 쓰고, 토큰이 없으면 원본을 돌려줍니다.

```java
public static String trim(String origString, String trimString) {
    int startPosit = origString.indexOf(trimString);
    if (startPosit != -1) {
        int endPosit = trimString.length() + startPosit;
        return origString.substring(0, startPosit) + origString.substring(endPosit);
    }
    return origString;
}
```

Javadoc 예시가 `replace('work$id', '$', '.')` 로 한 글자 토큰만 들고 있어서 두 결함 모두 드러나지 않았습니다.

### AS-IS / TO-BE

형제 `trim` 의 형태에 맞췄습니다.

```diff
 public static String replace(String str, String replacedStr, String replaceStr) {
-    String newStr = "";
-    if (str.contains(replacedStr)) {
-        String s1 = str.substring(0, str.indexOf(replacedStr));
-        String s2 = str.substring(str.indexOf(replacedStr) + 1);
-        newStr = s1 + replaceStr + s2;
-    }
-    return newStr;
+    int startPosit = str.indexOf(replacedStr);
+    if (startPosit != -1) {
+        int endPosit = replacedStr.length() + startPosit;
+        return str.substring(0, startPosit) + replaceStr + str.substring(endPosit);
+    }
+    return str;
 }
```

### 영향 범위

저장소 안에서 이 메서드를 부르는 곳은 기존 테스트 한 줄(`EgovStringUtilTest:340`)뿐이고, 그 호출은 한 글자 토큰이 존재하는 경우라 결과가 바뀌지 않습니다.

같은 형태로 오프셋을 상수로 잡는 자리가 더 있는지 `EgovStringUtil` 과 `EgovDateUtil` 을 전수로 확인했고, `indexOf(...) + 상수` 는 이 한 곳뿐이었습니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

기존 `testReplace` 에 두 갈래에 해당하는 케이스를 더했습니다.

```java
// 1. token longer than one character
assertEquals("work.id", EgovStringUtil.replace("work$$id", "$$", "."));
// 2. original String has no token
assertEquals("password", EgovStringUtil.replace("password", ",", "-"));
```

수정 전에 실행하면 실패합니다.

```
$ mvn -pl Foundation/org.egovframe.rte.fdl.string test -Dtest=EgovStringUtilTest#testReplace
[ERROR] EgovStringUtilTest.testReplace:345 expected: <work.id> but was: <work.$id>
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0
```

수정 후 모듈 전체입니다.

```
$ mvn -pl Foundation/org.egovframe.rte.fdl.string test
[INFO] Tests run: 59, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

화면이 없는 실행환경 모듈이라 첨부하지 않았습니다.
