### PR TITLE
fix: crypto 설정의 algorithm 이 GeneralCryptoService 에 주입돼 암호화가 항상 실패하는 문제 수정

### DIFF
--- a/Foundation/org.egovframe.rte.fdl.crypto/src/main/java/org/egovframe/rte/fdl/crypto/config/EgovCryptoConfiguration.java
+++ b/Foundation/org.egovframe.rte.fdl.crypto/src/main/java/org/egovframe/rte/fdl/crypto/config/EgovCryptoConfiguration.java
@@ -114,7 +114,6 @@ public class EgovCryptoConfiguration {
     public EgovGeneralCryptoServiceImpl egovGeneralCryptoService(EgovCryptoConfig cryptoConfig) {
         EgovGeneralCryptoServiceImpl egovGeneralCryptoService = new EgovGeneralCryptoServiceImpl();
         egovGeneralCryptoService.setPasswordEncoder(egovPasswordEncoder(cryptoConfig));
-        egovGeneralCryptoService.setAlgorithm(cryptoConfig.getAlgorithm());
         egovGeneralCryptoService.setBlockSize(cryptoConfig.getCryptoBlockSize());
         return egovGeneralCryptoService;
     }

--- a/Foundation/org.egovframe.rte.fdl.crypto/src/test/java/org/egovframe/rte/fdl/crypto/config/EgovCryptoTestConfig.java
+++ b/Foundation/org.egovframe.rte.fdl.crypto/src/test/java/org/egovframe/rte/fdl/crypto/config/EgovCryptoTestConfig.java
@@ -112,16 +112,10 @@ public class EgovCryptoTestConfig {
         return egovDigestService;
     }
 
-    /**
-     * Jasypt PBE는 SecretKeyFactory 알고리즘명(PBEWithSHA1AndDESede 등)이 필요하나,
-     * 설정 파일의 algorithm=SHA-256은 MessageDigest용이라 GeneralCryptoService에서 오류가 난다.
-     * 테스트에서만 PBE 알고리즘으로 오버라이드한다.
-     */
     @Bean(name = "generalCryptoService")
     @Primary
-    public org.egovframe.rte.fdl.crypto.impl.EgovGeneralCryptoServiceImpl generalCryptoServiceForTest(
+    public org.egovframe.rte.fdl.crypto.impl.EgovGeneralCryptoServiceImpl generalCryptoServiceAlias(
             org.egovframe.rte.fdl.crypto.impl.EgovGeneralCryptoServiceImpl egovGeneralCryptoService) {
-        egovGeneralCryptoService.setAlgorithm("PBEWithSHA1AndDESede");
         return egovGeneralCryptoService;
     }
 


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

`EgovCryptoConfiguration` 이 설정의 `algorithm` 값을 네 개의 빈에 그대로 넣습니다.

```java
egovPasswordEncoder.setAlgorithm(cryptoConfig.getAlgorithm());          // :78
egovEnvCryptoService.setCryptoAlgorithm(cryptoConfig.getAlgorithm());   // :105
egovGeneralCryptoService.setAlgorithm(cryptoConfig.getAlgorithm());     // :117
egovDigestService.setAlgorithm(cryptoConfig.getAlgorithm());            // :125
```

이 중 `egovGeneralCryptoService` 만 다른 이름 공간을 씁니다. jasypt `StandardPBEByteEncryptor` 는 `SecretKeyFactory` 알고리즘명이 필요합니다. 나머지 셋은 `MessageDigest` 알고리즘명을 씁니다. `EgovPasswordEncoder` 는 `ConfigurablePasswordEncryptor` 에 넘기고, `EgovDigestServiceImpl` 은 jasypt digester 에 넘기며, `EgovEnvCryptoServiceImpl:368` 의 Javadoc 은 이 값을 `MD5, SHA-1, SHA-256` 으로 적고 있습니다.

```
$ MessageDigest.getInstance / SecretKeyFactory.getInstance (JDK 17)
SHA-256                MessageDigest=OK                     SecretKeyFactory(PBE)=NoSuchAlgorithmException
PBEWithSHA1AndDESede   MessageDigest=NoSuchAlgorithmException SecretKeyFactory(PBE)=OK

$ 설치된 전 프로바이더의 두 이름 공간을 대조
MessageDigest 알고리즘 13개, SecretKeyFactory 알고리즘 24개
두 이름공간의 교집합: 없음 (0개)
```

두 이름 공간에 동시에 속하는 알고리즘명이 없으므로, 어떤 값을 넣어도 `encrypt()` 가 실패합니다. 두 클래스의 기본값이 각각 다른 이름 공간에서 온 것도 같은 이야기입니다. `EgovDigestServiceImpl:26` 은 `SHA-256`, `EgovGeneralCryptoServiceImpl:37` 은 `PBEWithSHA1AndDESede` 입니다.

`EgovCryptoConfiguration` 을 `@Import` 하고 `egovGeneralCryptoService` 를 주입받아 호출한 결과입니다.

```
algorithm=SHA-256  (README 와 배포 설정 파일의 값)
  encrypt -> EncryptionInitializationException: NoSuchAlgorithmException: SHA-256 SecretKeyFactory not available
  digest  -> ok

algorithm=PBEWithSHA1AndDESede
  encrypt -> EncryptionInitializationException: NoSuchAlgorithmException: PBEWithSHA1AndDESede MessageDigest not available
  digest  -> EncryptionInitializationException: NoSuchAlgorithmException: PBEWithSHA1AndDESede MessageDigest not available
```

PBE 이름을 넣으면 `encrypt()` 가 먼저 부르는 `passwordEncoder.checkPassword()` 에서 걸립니다.

같은 사정이 테스트 설정에 주석으로 적혀 있습니다.

```java
/**
 * Jasypt PBE는 SecretKeyFactory 알고리즘명(PBEWithSHA1AndDESede 등)이 필요하나,
 * 설정 파일의 algorithm=SHA-256은 MessageDigest용이라 GeneralCryptoService에서 오류가 난다.
 * 테스트에서만 PBE 알고리즘으로 오버라이드한다.
 */
```

### AS-IS / TO-BE

주입을 걷어내 이 서비스가 자기 기본값을 쓰게 했습니다.

```diff
         egovGeneralCryptoService.setPasswordEncoder(egovPasswordEncoder(cryptoConfig));
-        egovGeneralCryptoService.setAlgorithm(cryptoConfig.getAlgorithm());
         egovGeneralCryptoService.setBlockSize(cryptoConfig.getCryptoBlockSize());
```

테스트 설정의 오버라이드도 함께 걷었습니다. 빈 이름은 그대로 두어 기존 테스트가 그대로 주입받습니다.

```diff
-    /**
-     * Jasypt PBE는 SecretKeyFactory 알고리즘명(PBEWithSHA1AndDESede 등)이 필요하나,
-     * 설정 파일의 algorithm=SHA-256은 MessageDigest용이라 GeneralCryptoService에서 오류가 난다.
-     * 테스트에서만 PBE 알고리즘으로 오버라이드한다.
-     */
     @Bean(name = "generalCryptoService")
     @Primary
-    public ... generalCryptoServiceForTest(... egovGeneralCryptoService) {
-        egovGeneralCryptoService.setAlgorithm("PBEWithSHA1AndDESede");
+    public ... generalCryptoServiceAlias(... egovGeneralCryptoService) {
         return egovGeneralCryptoService;
     }
```

### 영향 범위

알고리즘을 바꾸려면 `EgovGeneralCryptoServiceImpl.setAlgorithm(...)` 을 호출하면 됩니다. 이 클래스의 Javadoc 이 이미 그렇게 안내하고 있습니다.

설정으로 이 서비스의 알고리즘을 지정하더라도 `encrypt()` 는 지금까지 어떤 값에서도 동작하지 않았습니다. 주입을 걷어내면서 잃는 동작이 없는 이유입니다.

`egovPasswordEncoder`·`egovDigestService`·`egovEnvCryptoService` 는 그대로입니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

테스트를 새로 만들지 않았습니다. 위 오버라이드를 걷어내면 기존 `EgovGeneralCryptoServiceTest` 가 이 결함을 그대로 잡습니다.

오버라이드만 걷고 본체 수정은 하지 않은 상태입니다.

```
$ mvn -pl Foundation/org.egovframe.rte.fdl.crypto test
[ERROR] EgovGeneralCryptoServiceTest.testString:76 » EncryptionInitialization java.security.NoSuchAlgorithmException: SHA-256 SecretKeyFactory not available
[ERROR] EgovGeneralCryptoServiceTest.testBigDecimal:85 » EncryptionInitialization java.security.NoSuchAlgorithmException: SHA-256 SecretKeyFactory not available
[ERROR] EgovGeneralCryptoServiceTest.testFile:106 java.security.NoSuchAlgorithmException: SHA-256 SecretKeyFactory not available
[ERROR] Tests run: 25, Failures: 1, Errors: 2, Skipped: 0
```

본체까지 수정한 상태입니다.

```
$ mvn -pl Foundation/org.egovframe.rte.fdl.crypto test
[INFO] Tests run: 25, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

화면이 없는 실행환경 모듈이라 첨부하지 않았습니다.
