### PR TITLE
fix: 예외 응답 본문의 status 가 enum 으로 직렬화돼 JSON 파싱이 불가능한 문제 수정

### DIFF
--- a/Presentation/org.egovframe.rte.ptl.reactive/src/main/java/org/egovframe/rte/ptl/reactive/exception/EgovExceptionHandler.java
+++ b/Presentation/org.egovframe.rte.ptl.reactive/src/main/java/org/egovframe/rte/ptl/reactive/exception/EgovExceptionHandler.java
@@ -100,7 +100,7 @@ public class EgovExceptionHandler implements WebExceptionHandler {
         response.getHeaders().setContentType(new MediaType(MediaType.APPLICATION_JSON, StandardCharsets.UTF_8));
         Map<String, Object> map = new HashMap<>();
         map.put("timestamp", timestamp);
-        map.put("status", HttpStatus.valueOf(status));
+        map.put("status", status);
         map.put("code", code);
         map.put("message", message);
         JSONObject jsonObject = new JSONObject(map);

--- a/Presentation/org.egovframe.rte.ptl.reactive/src/test/java/org/egovframe/rte/ptl/reactive/exception/EgovExceptionHandlerTest.java
+++ b/Presentation/org.egovframe.rte.ptl.reactive/src/test/java/org/egovframe/rte/ptl/reactive/exception/EgovExceptionHandlerTest.java
@@ -10,8 +10,12 @@ import org.springframework.test.web.reactive.server.WebTestClient;
 import org.springframework.web.bind.annotation.GetMapping;
 import reactor.core.publisher.Mono;
 
+import org.json.simple.JSONObject;
+import org.json.simple.parser.JSONParser;
+
 import java.nio.charset.StandardCharsets;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ExtendWith(SpringExtension.class)
@@ -34,6 +38,25 @@ public class EgovExceptionHandlerTest {
                 .exchange()
                 .expectStatus().isNotFound()
                 .expectHeader().contentType(MediaType.parseMediaType("application/json;charset=UTF-8"));
+    }
+
+    @Test
+    public void responseBodyIsParseableJson() {
+        this.webTestClient.get()
+                .uri("/test")
+                .accept(MediaType.APPLICATION_JSON)
+                .exchange()
+                .expectBody()
+                .consumeWith(result -> {
+                    String body = new String(result.getResponseBody(), StandardCharsets.UTF_8);
+                    JSONObject json;
+                    try {
+                        json = (JSONObject) new JSONParser().parse(body);
+                    } catch (Exception e) {
+                        throw new AssertionError("application/json 으로 선언한 본문이 파싱되지 않는다: " + body, e);
+                    }
+                    assertEquals(404L, json.get("status"));
+                });
     }
 
     @Test


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

`EgovExceptionHandler` 가 만드는 예외 응답 본문이 JSON 으로 파싱되지 않습니다.

```java
private Mono<Void> handlerResponse(ServerHttpResponse response, String timestamp, int status, String code, String message) {
    response.setStatusCode(HttpStatus.valueOf(status));
    response.getHeaders().setContentType(new MediaType(MediaType.APPLICATION_JSON, StandardCharsets.UTF_8));
    Map<String, Object> map = new HashMap<>();
    map.put("timestamp", timestamp);
    map.put("status", HttpStatus.valueOf(status));   // :103
    ...
```

`status` 는 `int` 로 들어옵니다. `:99` 는 그 값을 그대로 HTTP 상태코드로 쓰는데, `:103` 은 같은 값을 `HttpStatus` enum 으로 바꿔 본문 맵에 넣습니다. json-simple 은 이 enum 을 `toString()` 결과 그대로, 따옴표 없이 씁니다.

`/test` 요청의 실제 응답 본문입니다.

```
{"code":"E007","message":"Page not found.","timestamp":"2026-09-03 07:40:46","status":404 NOT_FOUND}
```

`404 NOT_FOUND` 가 따옴표 없이 들어가 있습니다. 헤더는 `application/json;charset=UTF-8` 인데 본문은 어떤 JSON 파서로도 읽을 수 없습니다.

응답 형태를 정의하는 `EgovExceptionResponse:40` 은 `protected int status;` 로 선언하고 있습니다. 같은 메서드의 나머지 세 값은 선언 타입 그대로 들어가 정상 직렬화됩니다.

### AS-IS / TO-BE

```diff
-        map.put("status", HttpStatus.valueOf(status));
+        map.put("status", status);
```

`:99` 의 `HttpStatus.valueOf(status)` 는 상태코드 설정에 필요하므로 그대로 두었습니다.

수정 후 본문입니다.

```
{"code":"E007","message":"Page not found.","timestamp":"2026-09-03 07:41:12","status":404}
```

### 영향 범위

본문의 `status` 한 항목입니다. HTTP 상태코드, Content-Type, 나머지 세 항목은 그대로입니다.

지금 본문은 JSON 파서로 읽히지 않습니다. 이 응답을 파싱해서 쓰던 코드가 있었다면 이미 실패하고 있었을 것입니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

기존 `EgovExceptionHandlerTest` 는 상태코드와 Content-Type 을 보고, 본문은 `String.contains` 로만 확인해서 이 깨짐을 잡지 못했습니다. 본문을 실제로 파싱하는 케이스를 같은 클래스에 더했습니다. 파서는 핸들러가 직렬화에 쓰는 것과 같은 json-simple 을 씁니다.

```java
String body = new String(result.getResponseBody(), StandardCharsets.UTF_8);
JSONObject json;
try {
    json = (JSONObject) new JSONParser().parse(body);
} catch (Exception e) {
    throw new AssertionError("application/json 으로 선언한 본문이 파싱되지 않는다: " + body, e);
}
assertEquals(404L, json.get("status"));
```

수정 전에 실행하면 실패합니다.

```
$ mvn -pl Presentation/org.egovframe.rte.ptl.reactive test -Dtest=EgovExceptionHandlerTest
[ERROR] EgovExceptionHandlerTest.responseBodyIsParseableJson:50 application/json 으로 선언한 본문이 파싱되지 않는다: {"code":"E007","message":"Page not found.","timestamp":"2026-09-03 07:40:46","status":404 NOT_FOUND}
[ERROR] Tests run: 3, Failures: 1, Errors: 0, Skipped: 0
```

수정 후 모듈 전체입니다. 추가한 한 건을 포함해 25건에서 26건이 되었습니다.

```
$ mvn -pl Presentation/org.egovframe.rte.ptl.reactive test
[INFO] Tests run: 26, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

화면이 없는 실행환경 모듈이라 첨부하지 않았습니다.
