### PR TITLE
fix: EgovLoginFailHandler 가 로그인 실패 URL 대신 접근거부 URL 로 보내는 문제 수정

### DIFF
--- a/Foundation/org.egovframe.rte.fdl.security/src/main/java/org/egovframe/rte/fdl/security/bean/EgovLoginFailHandler.java
+++ b/Foundation/org.egovframe.rte.fdl.security/src/main/java/org/egovframe/rte/fdl/security/bean/EgovLoginFailHandler.java
@@ -51,12 +51,12 @@ public class EgovLoginFailHandler implements AuthenticationFailureHandler {
     @Override
     public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response, AuthenticationException exception) throws IOException, ServletException {
         if (ObjectUtils.isEmpty(config)) {
-            throw new NoSuchBeanDefinitionException("### EgovLoginFailHandler getAccessDeniedUrl not found.");
+            throw new NoSuchBeanDefinitionException("### EgovLoginFailHandler getLoginFailureUrl not found.");
         }
 
         String failureUrl;
-        if (StringUtils.hasText(config.getAccessDeniedUrl())) {
-            failureUrl = config.getAccessDeniedUrl();
+        if (StringUtils.hasText(config.getLoginFailureUrl())) {
+            failureUrl = config.getLoginFailureUrl();
         } else {
             failureUrl = DEFAULT_LOGIN_FAILURE_URL;
         }

--- a/Foundation/org.egovframe.rte.fdl.security/src/test/java/org/egovframe/rte/fdl/security/bean/EgovLoginFailHandlerTest.java
+++ b/Foundation/org.egovframe.rte.fdl.security/src/test/java/org/egovframe/rte/fdl/security/bean/EgovLoginFailHandlerTest.java
@@ -1,0 +1,44 @@
+package org.egovframe.rte.fdl.security.bean;
+
+import org.egovframe.rte.fdl.security.config.EgovSecurityConfig;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.authentication.BadCredentialsException;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class EgovLoginFailHandlerTest {
+
+    @Test
+    public void onAuthenticationFailure_usesLoginFailureUrl() throws Exception {
+        EgovSecurityConfig config = new EgovSecurityConfig();
+        config.setLoginFailureUrl("/uat/uia/loginFail.do");
+        // 접근거부 URL 은 로그인 실패와 다른 화면이다. 둘을 구분해 두고 어느 쪽으로 가는지 본다.
+        config.setAccessDeniedUrl("/system/accessDenied.do");
+
+        EgovLoginFailHandler handler = new EgovLoginFailHandler(config);
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        handler.onAuthenticationFailure(request, response, new BadCredentialsException("bad"));
+
+        assertEquals("/uat/uia/loginFail.do", response.getForwardedUrl());
+    }
+
+    @Test
+    public void onAuthenticationFailure_fallsBackToDefaultUrl_whenLoginFailureUrlBlank() throws Exception {
+        EgovSecurityConfig config = new EgovSecurityConfig();
+        config.setLoginFailureUrl(" ");
+        config.setAccessDeniedUrl("/system/accessDenied.do");
+
+        EgovLoginFailHandler handler = new EgovLoginFailHandler(config);
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        assertDoesNotThrow(() -> handler.onAuthenticationFailure(request, response, new BadCredentialsException("bad")));
+        assertEquals("/index.html", response.getForwardedUrl());
+    }
+
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

`EgovLoginFailHandler`가 로그인 실패 URL 대신 접근거부 URL로 보냅니다.

클래스 이름도, 기본값 상수 이름도 로그인 실패를 가리킵니다.

```java
// EgovLoginFailHandler.java:38
private static final String DEFAULT_LOGIN_FAILURE_URL = "/index.html";
```

그런데 설정에서 읽는 값은 접근거부 URL입니다.

```java
// EgovLoginFailHandler.java:53-62
if (ObjectUtils.isEmpty(config)) {
    throw new NoSuchBeanDefinitionException("### EgovLoginFailHandler getAccessDeniedUrl not found.");
}

String failureUrl;
if (StringUtils.hasText(config.getAccessDeniedUrl())) {
    failureUrl = config.getAccessDeniedUrl();
} else {
    failureUrl = DEFAULT_LOGIN_FAILURE_URL;
}
```

`EgovSecurityConfig`에는 로그인 실패용 항목이 따로 있고, 필터체인의 `formLogin`도 그 값을 씁니다.

```java
// EgovSecurityConfig.java:56-57, :182-184
@JsonProperty("loginFailureUrl")
private String loginFailureUrl;

public String getLoginFailureUrl() {
    return loginFailureUrl;
}

// EgovSecurityConfiguration.java:442
.failureUrl(securityConfig.getLoginFailureUrl())
```

쌍둥이인 `EgovAccessDeniedHandler`도 같은 자리에서 `getAccessDeniedUrl()`을 읽습니다. 접근거부 핸들러니 그쪽은 맞는 값이고, 두 핸들러가 결과적으로 같은 프로퍼티 하나를 읽습니다.

두 URL을 다르게 두고 로그인 실패를 일으키면 접근거부 화면으로 갑니다.

```
[ERROR] EgovLoginFailHandlerTest.onAuthenticationFailure_usesLoginFailureUrl:27
        expected: </uat/uia/loginFail.do> but was: </system/accessDenied.do>
[ERROR] EgovLoginFailHandlerTest.onAuthenticationFailure_fallsBackToDefaultUrl_whenLoginFailureUrlBlank:41
        expected: </index.html> but was: </system/accessDenied.do>
[ERROR] Tests run: 2, Failures: 2, Errors: 0, Skipped: 0
```

두 번째 단언에서 보듯 로그인 실패 URL을 비워도 `DEFAULT_LOGIN_FAILURE_URL` 폴백에 닿지 못합니다. 접근거부 URL이 설정돼 있으면 그쪽이 먼저 걸리기 때문입니다.

AS-IS / TO-BE

```diff
     if (ObjectUtils.isEmpty(config)) {
-        throw new NoSuchBeanDefinitionException("### EgovLoginFailHandler getAccessDeniedUrl not found.");
+        throw new NoSuchBeanDefinitionException("### EgovLoginFailHandler getLoginFailureUrl not found.");
     }
 
     String failureUrl;
-    if (StringUtils.hasText(config.getAccessDeniedUrl())) {
-        failureUrl = config.getAccessDeniedUrl();
+    if (StringUtils.hasText(config.getLoginFailureUrl())) {
+        failureUrl = config.getLoginFailureUrl();
     } else {
         failureUrl = DEFAULT_LOGIN_FAILURE_URL;
     }
```

### 영향 범위

이 핸들러가 forward하는 경로 하나입니다. 설정이 비어 있을 때 `DEFAULT_LOGIN_FAILURE_URL`로 떨어지는 폴백과 계정 열거 방지 메시지 처리는 그대로입니다.

`EgovSecurityConfiguration`은 이 클래스를 `@Bean`으로 노출합니다(`:347`). 자동 배선되는 자리가 없어, 값이 달라지는 쪽은 이 빈을 직접 주입해 쓰는 코드입니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

`EgovAccessDeniedHandlerTest`와 같은 형태로 `EgovLoginFailHandlerTest`를 추가했습니다. 두 URL을 다르게 설정하고 어느 쪽으로 forward하는지, 로그인 실패 URL이 비었을 때 기본값으로 떨어지는지 봅니다.

```
$ mvn -pl Foundation/org.egovframe.rte.fdl.security test
[INFO] Tests run: 38, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```

읽는 프로퍼티를 되돌리면 위 RED가 다시 나옵니다.

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

화면이 없는 실행환경 모듈이라 첨부하지 않았습니다.
