### PR TITLE
fix: primitive float 필드가 sqlTypes 표기 불일치로 JDBC 배치 쓰기에서 SQLException 이 나는 문제 수정

### DIFF
--- a/Batch/org.egovframe.rte.bat.core/src/main/java/org/egovframe/rte/bat/core/item/database/support/EgovMethodMapItemPreparedStatementSetter.java
+++ b/Batch/org.egovframe.rte.bat.core/src/main/java/org/egovframe/rte/bat/core/item/database/support/EgovMethodMapItemPreparedStatementSetter.java
@@ -70,7 +70,7 @@ public class EgovMethodMapItemPreparedStatementSetter<T> extends EgovItemPrepare
                     ps.setBoolean(i + 1, (Boolean) reflector.invokeGettterMethod(item, params[i], methodMap));
                 } else if (sqlTypes[i].equals("long")) {
                     ps.setLong(i + 1, (Long) reflector.invokeGettterMethod(item, params[i], methodMap));
-                } else if (sqlTypes[i].equals("Float")) {
+                } else if (sqlTypes[i].equals("float") || sqlTypes[i].equals("Float")) {
                     ps.setFloat(i + 1, (Float) reflector.invokeGettterMethod(item, params[i], methodMap));
                 } else if (sqlTypes[i].equals("BigDecimal")) {
                     ps.setBigDecimal(i + 1, (BigDecimal) reflector.invokeGettterMethod(item, params[i], methodMap));

--- a/Batch/org.egovframe.rte.bat.core/src/test/java/org/egovframe/rte/bat/core/item/database/EgovMethodMapFloatSqlTypeTest.java
+++ b/Batch/org.egovframe.rte.bat.core/src/test/java/org/egovframe/rte/bat/core/item/database/EgovMethodMapFloatSqlTypeTest.java
@@ -1,0 +1,216 @@
+/*
+ * Copyright 2008-2024 MOIS(Ministry of the Interior and Safety).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.egovframe.rte.bat.core.item.database;
+
+import org.egovframe.rte.bat.core.item.database.support.EgovMethodMapItemPreparedStatementSetter;
+import org.egovframe.rte.bat.core.reflection.EgovReflectionSupport;
+import org.junit.jupiter.api.Test;
+import org.springframework.batch.item.Chunk;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.PreparedStatementCallback;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * sqlTypes 산출부와 소비부의 float 타입 표기 일치 검증.
+ *
+ * <pre>
+ * 산출부 EgovReflectionSupport.getSqlTypeArray 는 Class.getSimpleName() 을 쓰므로
+ * primitive 필드에 대해 "int", "double", "long" 처럼 소문자 이름을 낸다.
+ * primitive float 도 마찬가지로 "float" 이 산출되며, 소비부
+ * EgovMethodMapItemPreparedStatementSetter 가 이를 받아 ps.setFloat 으로 넘겨야 한다.
+ * </pre>
+ *
+ * @author 배치실행개발팀
+ * @since 2026.09.03
+ */
+class EgovMethodMapFloatSqlTypeTest {
+
+    /** primitive float 과, 정상 동작하는 형제 primitive(double)를 함께 담은 VO. */
+    public static class PrimitiveFloatVo {
+        private double score;
+        private float rate;
+
+        public PrimitiveFloatVo(double score, float rate) {
+            this.score = score;
+            this.rate = rate;
+        }
+
+        public double getScore() {
+            return score;
+        }
+
+        public float getRate() {
+            return rate;
+        }
+    }
+
+    /** wrapper Float 필드 VO. 기존 동작 보존 확인용. */
+    public static class WrapperFloatVo {
+        private Float ratio;
+
+        public WrapperFloatVo(Float ratio) {
+            this.ratio = ratio;
+        }
+
+        public Float getRatio() {
+            return ratio;
+        }
+    }
+
+    /** ps.setXxx 호출을 (메소드명, 인덱스, 값) 으로 기록하는 PreparedStatement 대역. */
+    private static class RecordingPsHandler implements InvocationHandler {
+        private final List<Object[]> calls = new ArrayList<Object[]>();
+
+        @Override
+        public Object invoke(Object proxy, Method method, Object[] args) {
+            String name = method.getName();
+            if (name.startsWith("set") && args != null && args.length == 2) {
+                calls.add(new Object[]{name, args[0], args[1]});
+                return null;
+            }
+            if ("hashCode".equals(name)) {
+                return System.identityHashCode(proxy);
+            }
+            if ("equals".equals(name)) {
+                return proxy == args[0];
+            }
+            if ("toString".equals(name)) {
+                return "RecordingPs";
+            }
+            return null;
+        }
+    }
+
+    private static PreparedStatement newRecordingPs(RecordingPsHandler handler) {
+        return (PreparedStatement) Proxy.newProxyInstance(
+                RecordingPsHandler.class.getClassLoader(),
+                new Class<?>[]{PreparedStatement.class}, handler);
+    }
+
+    /**
+     * 산출부가 낸 sqlTypes 를 그대로 소비부에 넘겼을 때, primitive float 이
+     * 형제 primitive 와 동일하게 ps.setFloat 으로 설정되어야 한다.
+     */
+    @Test
+    void primitiveFloatIsSetLikeSiblingPrimitives() throws Exception {
+        String[] params = {"score", "rate"};
+        PrimitiveFloatVo item = new PrimitiveFloatVo(88.5d, 1.25f);
+
+        EgovReflectionSupport<PrimitiveFloatVo> support = new EgovReflectionSupport<PrimitiveFloatVo>();
+        support.generateGetterMethodMap(params, item);
+        Map<String, Method> methodMap = support.getMethodMap();
+        String[] sqlTypes = support.getSqlTypeArray(params, item);
+
+        // 산출부는 primitive 를 소문자 이름으로 낸다.
+        assertEquals("double", sqlTypes[0]);
+        assertEquals("float", sqlTypes[1]);
+
+        RecordingPsHandler handler = new RecordingPsHandler();
+        PreparedStatement ps = newRecordingPs(handler);
+
+        new EgovMethodMapItemPreparedStatementSetter<PrimitiveFloatVo>()
+                .setValues(item, ps, params, sqlTypes, methodMap);
+
+        assertEquals(2, handler.calls.size());
+
+        assertEquals("setDouble", handler.calls.get(0)[0]);
+        assertEquals(1, handler.calls.get(0)[1]);
+        assertEquals(88.5d, handler.calls.get(0)[2]);
+
+        assertEquals("setFloat", handler.calls.get(1)[0]);
+        assertEquals(2, handler.calls.get(1)[1]);
+        assertEquals(1.25f, handler.calls.get(1)[2]);
+    }
+
+    /**
+     * wrapper Float 필드는 기존과 동일하게 ps.setFloat 으로 설정되어야 한다.
+     */
+    @Test
+    void wrapperFloatIsStillSet() throws Exception {
+        String[] params = {"ratio"};
+        WrapperFloatVo item = new WrapperFloatVo(2.5f);
+
+        EgovReflectionSupport<WrapperFloatVo> support = new EgovReflectionSupport<WrapperFloatVo>();
+        support.generateGetterMethodMap(params, item);
+        Map<String, Method> methodMap = support.getMethodMap();
+        String[] sqlTypes = support.getSqlTypeArray(params, item);
+
+        assertEquals("Float", sqlTypes[0]);
+
+        RecordingPsHandler handler = new RecordingPsHandler();
+        PreparedStatement ps = newRecordingPs(handler);
+
+        new EgovMethodMapItemPreparedStatementSetter<WrapperFloatVo>()
+                .setValues(item, ps, params, sqlTypes, methodMap);
+
+        assertEquals(1, handler.calls.size());
+        assertEquals("setFloat", handler.calls.get(0)[0]);
+        assertEquals(1, handler.calls.get(0)[1]);
+        assertEquals(2.5f, handler.calls.get(0)[2]);
+    }
+
+    /**
+     * EgovJdbcBatchItemWriter.write() 를 경유하는 실제 청크 쓰기 경로에서도 primitive float 이
+     * ps.setFloat 으로 설정되어야 한다. sqlTypes 산출과 소비가 모두 프레임워크 내부에서 일어난다.
+     * PreparedStatement 대역은 형제 테스트의 FakePsHandler 를 재사용한다.
+     */
+    @Test
+    void primitiveFloatIsSetThroughWriter() throws Exception {
+        final EgovJdbcBatchWriteReflectionTest.FakePsHandler handler =
+                new EgovJdbcBatchWriteReflectionTest.FakePsHandler();
+
+        EgovJdbcBatchItemWriter<PrimitiveFloatVo> writer = new EgovJdbcBatchItemWriter<PrimitiveFloatVo>();
+        writer.setSql("insert into sample (score, rate) values (?, ?)");
+        writer.setParams(new String[]{"score", "rate"});
+        writer.setItemPreparedStatementSetter(new EgovMethodMapItemPreparedStatementSetter<PrimitiveFloatVo>());
+        writer.setSimpleJdbcTemplate(new JdbcTemplate() {
+            @Override
+            public <X> X execute(String sql, PreparedStatementCallback<X> action) {
+                try {
+                    return action.doInPreparedStatement((PreparedStatement) Proxy.newProxyInstance(
+                            EgovMethodMapFloatSqlTypeTest.class.getClassLoader(),
+                            new Class<?>[]{PreparedStatement.class}, handler));
+                } catch (SQLException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        });
+        writer.afterPropertiesSet();
+
+        writer.write(new Chunk<PrimitiveFloatVo>(List.of(new PrimitiveFloatVo(88.5d, 1.25f))));
+
+        assertEquals(2, handler.calls.size());
+
+        assertEquals("setDouble", handler.calls.get(0)[0]);
+        assertEquals(1, handler.calls.get(0)[1]);
+        assertEquals(88.5d, handler.calls.get(0)[2]);
+
+        assertEquals("setFloat", handler.calls.get(1)[0]);
+        assertEquals(2, handler.calls.get(1)[1]);
+        assertEquals(1.25f, handler.calls.get(1)[2]);
+    }
+
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

`EgovJdbcBatchItemWriter` 로 primitive `float` 필드가 있는 VO 를 쓰면 `java.sql.SQLException` 이 납니다.

sqlTypes 를 만드는 쪽은 `Class.getSimpleName()` 을 씁니다. primitive 필드는 `"int"`·`"double"`·`"long"` 처럼 소문자 이름이 나오고, primitive `float` 도 `"float"` 이 나옵니다.

```java
// EgovReflectionSupport.java:247
sqlTypes[i] = item.getClass().getDeclaredField(params[i]).getType().getSimpleName().toString();
```

받는 쪽 분기는 이렇습니다.

```
$ git grep -n 'sqlTypes\[i\].equals' .../item/database/support/EgovMethodMapItemPreparedStatementSetter.java
57:  if (sqlTypes[i].equals("String")) {
59:  } else if (sqlTypes[i].equals("int")) {
61:  } else if (sqlTypes[i].equals("double")) {
63:  } else if (sqlTypes[i].equals("Date")) {
65:  } else if (sqlTypes[i].equals("byte")) {
67:  } else if (sqlTypes[i].equals("short")) {
69:  } else if (sqlTypes[i].equals("boolean")) {
71:  } else if (sqlTypes[i].equals("long")) {
73:  } else if (sqlTypes[i].equals("Float")) {
75:  } else if (sqlTypes[i].equals("BigDecimal")) {
77:  } else if (sqlTypes[i].equals("byte[]")) {
```

primitive 를 받는 분기 여섯 개(`int`·`double`·`byte`·`short`·`boolean`·`long`)는 모두 소문자 이름으로 비교하는데, 73줄만 wrapper 이름인 `"Float"` 로 비교합니다. 그래서 산출값 `"float"` 은 어느 분기에도 걸리지 않고 80줄의 `throw new SQLException()` 으로 떨어집니다. 메시지도 원인도 없는 예외라 로그만 보면 무엇이 문제인지 알 수 없습니다.

죽은 경로가 아닙니다. `params` 를 설정한 정상 쓰기 흐름에서 산출과 소비가 한 메서드 안에 이어져 있고, `getSqlTypeArray` 를 부르는 운영 코드는 이 한 곳뿐입니다.

```java
// EgovJdbcBatchItemWriter.java:176
local = new SqlTypeCache(itemClass, reflector.getSqlTypeArray(params, firstItem));
// EgovJdbcBatchItemWriter.java:184
itemPreparedStatementSetter.setValues(item, ps, params, sqlTypes, methodMap);
```

같은 `EgovReflectionSupport` 안의 읽기 경로는 primitive `float` 을 지원 대상으로 봅니다.

```java
// EgovReflectionSupport.java:270  (parsingFromString)
} else if (type == float.class) {
    parsingValue = Float.parseFloat(tokenValue);
```

### AS-IS / TO-BE

```diff
                 } else if (sqlTypes[i].equals("long")) {
                     ps.setLong(i + 1, (Long) reflector.invokeGettterMethod(item, params[i], methodMap));
-                } else if (sqlTypes[i].equals("Float")) {
+                } else if (sqlTypes[i].equals("float") || sqlTypes[i].equals("Float")) {
                     ps.setFloat(i + 1, (Float) reflector.invokeGettterMethod(item, params[i], methodMap));
```

`"Float"` 를 `"float"` 으로 바꾸지 않고 `"float"` 을 OR 로 더했습니다. `setValues` 는 공개 메서드라 sqlTypes 를 직접 넘기는 호출자가 있을 수 있고, wrapper `Float` 필드는 수정 전에도 정상 동작하기 때문입니다. 치환하면 그 동작이 사라집니다.

### 영향 범위

운영 코드는 이 한 줄입니다. `else if` 조건을 넓히기만 해서 기존에 매치되던 입력의 동작은 바뀌지 않고, 그동안 `SQLException` 으로 떨어지던 `"float"` 만 `ps.setFloat` 으로 들어갑니다. 나머지 분기와 산출부는 손대지 않았습니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

`EgovMethodMapFloatSqlTypeTest` 를 3건 추가했습니다. sqlTypes 를 손으로 만들지 않고 실제 `getSqlTypeArray` 산출값을 그대로 소비부에 넘깁니다.

- `primitiveFloatIsSetLikeSiblingPrimitives` — 128·129줄에서 `assertEquals("double", sqlTypes[0])`·`assertEquals("float", sqlTypes[1])` 로 산출 표기를 먼저 확정하고, 형제 `double` 과 같은 자리에서 `ps.setFloat` 이 호출되는지 봅니다.
- `wrapperFloatIsStillSet` — 161줄 `assertEquals("Float", sqlTypes[0])`. wrapper 경로가 그대로인지 확인합니다.
- `primitiveFloatIsSetThroughWriter` (181줄) — `setValues` 를 직접 부르지 않고 `EgovJdbcBatchItemWriter.write()` 를 경유합니다. `PreparedStatement` 대역은 형제 테스트 `EgovJdbcBatchWriteReflectionTest:155` 의 `FakePsHandler` 를 그대로 씁니다.

수정한 한 줄을 `sqlTypes[i].equals("Float")` 로 되돌리면 두 건이 실패합니다.

```
$ mvn -o test -pl Batch/org.egovframe.rte.bat.core -Dtest=EgovMethodMapFloatSqlTypeTest -DfailIfNoTests=false
[INFO] Running org.egovframe.rte.bat.core.item.database.EgovMethodMapFloatSqlTypeTest
[ERROR] Tests run: 3, Failures: 0, Errors: 2, Skipped: 0, Time elapsed: 0.178 s <<< FAILURE!
[ERROR]   EgovMethodMapFloatSqlTypeTest.primitiveFloatIsSetLikeSiblingPrimitives:135 » SQL
[ERROR]   EgovMethodMapFloatSqlTypeTest.primitiveFloatIsSetThroughWriter:203 » Runtime java.sql.SQLException
[ERROR] Tests run: 3, Failures: 0, Errors: 2, Skipped: 0
[INFO] BUILD FAILURE
```

두 건 모두 같은 자리에서 던져집니다.

```
java.sql.SQLException
	at org.egovframe.rte.bat.core.item.database.support.EgovMethodMapItemPreparedStatementSetter.setValues(EgovMethodMapItemPreparedStatementSetter.java:80)
```

수정본으로 되돌린 뒤 모듈 전체입니다.

```
$ mvn -o test -pl Batch/org.egovframe.rte.bat.core
[INFO] Tests run: 89, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

화면이 없는 실행환경 모듈이라 첨부하지 않았습니다.
