### PR TITLE
fix: EgovIndexFileWriter 가 초기 파일명 생성 시 지정한 확장자를 .csv 로 대체하는 문제 수정

### DIFF
--- a/Batch/org.egovframe.rte.bat.core/src/main/java/org/egovframe/rte/bat/core/item/file/EgovIndexFileWriter.java
+++ b/Batch/org.egovframe.rte.bat.core/src/main/java/org/egovframe/rte/bat/core/item/file/EgovIndexFileWriter.java
@@ -332,20 +332,11 @@ public class EgovIndexFileWriter<T> implements ItemStreamWriter<T> {
 
     // (+1) 옵션이고 기존 파일이 없는 경우 초기 파일명을 생성한다.
     private String generateInitialIndexFilename(String resourceFileName) {
-        // 파일명에서 확장자 추출 (괄호 이전 부분에서)
-        String baseFileName = resourceFileName;
-        int parenIndex = resourceFileName.indexOf('(');
-        if (parenIndex > 0) {
-            baseFileName = resourceFileName.substring(0, parenIndex);
-        }
-
+        // 파일명 규칙("파일명" + "_NDX" + "(순번)" + ".확장자")에 따라 (순번) 뒷부분을 확장자로 사용한다.
         String extension = "";
-        int lastDotIndex = baseFileName.lastIndexOf('.');
-        if (lastDotIndex > 0) {
-            extension = baseFileName.substring(lastDotIndex);
-        } else {
-            // 확장자가 없으면 기본적으로 .csv 사용
-            extension = ".csv";
+        int closeParenIndex = resourceFileName.indexOf(')');
+        if (closeParenIndex > 0) {
+            extension = resourceFileName.substring(closeParenIndex + 1);
         }
 
         // 현재 시간을 기반으로 초기 인덱스 생성 (YYYYMMDDhhmmss 형식)

--- a/Batch/org.egovframe.rte.bat.core/src/test/java/org/egovframe/rte/bat/core/item/file/EgovIndexFileWriterInitialExtensionTest.java
+++ b/Batch/org.egovframe.rte.bat.core/src/test/java/org/egovframe/rte/bat/core/item/file/EgovIndexFileWriterInitialExtensionTest.java
@@ -1,0 +1,69 @@
+package org.egovframe.rte.bat.core.item.file;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.StepExecution;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * {@link EgovIndexFileWriter}가 (+1) 옵션으로 초기 파일명을 만들 때
+ * indexResource에 지정된 확장자를 그대로 사용하는지 검증한다.
+ *
+ * <p>configureWriterIndexResouce()가 검증하는 파일명 규칙은
+ * "파일명" + "_NDX" + "(순번)" + ".확장자"이고, (순번) 앞부분은 {@code [a-zA-Z0-9_]+}로
+ * 제한되어 점을 포함할 수 없다. 기존 파일이 있을 때 쓰이는 generateNewIndexFilename()은
+ * (순번) 뒷부분을 확장자로 보존하므로, 초기 파일명도 같은 자리에서 확장자를 가져와야
+ * 디렉토리 상태와 무관하게 같은 확장자가 나온다.</p>
+ */
+class EgovIndexFileWriterInitialExtensionTest {
+
+    @TempDir
+    Path tempDir;
+
+    /** beforeStep() 공개 진입점으로 인덱스 리소스를 구성하고 확정된 파일명을 돌려준다. */
+    private String resolveFilename(String indexResource) throws Exception {
+        EgovIndexFileWriter<Object> writer = new EgovIndexFileWriter<>();
+        writer.setIndexResource(indexResource);
+        writer.beforeStep(new StepExecution("indexFileWriterStep", new JobExecution(1L)));
+
+        assertNotNull(writer.getResource(), "resource가 설정되어야 한다");
+        return writer.getResource().getFilename();
+    }
+
+    @Test
+    @DisplayName("기존 파일이 없어도 지정한 확장자(.txt)로 초기 파일명을 만든다")
+    void initialFilenameKeepsConfiguredExtension() throws Exception {
+        String filename = resolveFilename(tempDir.toString() + "/DATA_NDX(1).txt");
+
+        assertEquals(".txt", filename.substring(filename.lastIndexOf('.')),
+                "indexResource에 지정한 확장자를 그대로 사용해야 한다 : " + filename);
+    }
+
+    @Test
+    @DisplayName("확장자를 생략하면 초기 파일명에도 확장자가 붙지 않는다")
+    void initialFilenameKeepsOmittedExtension() throws Exception {
+        // 파일명 규칙 4) ".확장자" 생략 가능
+        String filename = resolveFilename(tempDir.toString() + "/DATA_NDX(1)");
+
+        assertEquals("DATA_NDX_", filename.substring(0, "DATA_NDX_".length()));
+        assertEquals(-1, filename.indexOf('.'),
+                "확장자를 지정하지 않았으므로 확장자가 붙지 않아야 한다 : " + filename);
+    }
+
+    @Test
+    @DisplayName("기존 파일이 있으면 확장자가 보존된다(형제 경로 기준)")
+    void nextFilenameKeepsExtension() throws Exception {
+        Files.createFile(new File(tempDir.toFile(), "DATA_NDX_20260101000000.txt").toPath());
+
+        assertEquals("DATA_NDX_20260101000001.txt",
+                resolveFilename(tempDir.toString() + "/DATA_NDX(1).txt"));
+    }
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

`EgovIndexFileWriter` 가 (+1) 옵션으로 초기 파일명을 만들 때 `indexResource` 에 지정한 확장자를 쓰지 않고 `.csv` 로 바꿉니다.

같은 클래스가 `configureWriterIndexResouce()` 에서 검증하는 파일명 규칙은 확장자를 `(순번)` 뒤에 둡니다.

```java
// EgovIndexFileWriter.java:194
// "파일명" + "_NDX" + "(순번)" + ".확장자"
// ...
// 4) ".확장자" 생략 가능
Pattern p = Pattern.compile("^[a-zA-Z0-9_]+" + INDEX_FILE_UNIQUE_KEY + "\\([+-]?[0-9]+\\)[a-zA-Z0-9_.]*$");
```

`(` 앞부분은 `[a-zA-Z0-9_]+` 라서 점을 포함할 수 없는데, `generateInitialIndexFilename()` 은 확장자를 괄호 앞부분에서 찾습니다. 199줄 정규식을 통과한 값만 251줄에서 이 메서드로 가므로 `baseFileName.lastIndexOf('.')` 는 항상 -1 이고 `else` 의 `.csv` 만 남습니다.

기존 파일이 있을 때 쓰이는 형제 경로 `generateNewIndexFilename()` 은 규칙대로 일련번호 뒷부분에서 확장자를 가져옵니다.

```java
// EgovIndexFileWriter.java:358
String extValue = "";
if (arrFileNamePart[1].length() > INDEX_NUMBER_LENGTH) {
    extValue = arrFileNamePart[1].substring(INDEX_NUMBER_LENGTH);
}
```

그래서 같은 `indexResource` 설정이 디렉토리 상태에 따라 다른 확장자를 만듭니다. `DATA_NDX(+1).txt` 를 지정해도 빈 디렉토리의 첫 실행은 `.csv` 를 만들고, 형제 경로가 그 `.csv` 를 이어받으므로 이후로도 `.txt` 는 나오지 않습니다. 반대로 `.txt` 파일이 이미 있는 디렉토리에서는 `.txt` 가 유지됩니다.

### 동작이 바뀌는 지점

저장소 자체 테스트 잡 `DelimitedToDelimitedJobIndexReaderJob.java:68` 의 `writer.setIndexResource("target/test-outputs/csvData_NDX(+1)")` 는 확장자를 지정하지 않아 `target/test-outputs` 가 비어 있는 첫 실행에서 산출 파일명이 바뀝니다. 실측 결과 수정 전에는 `csvData_NDX_20260903104941.csv`, 수정 후에는 `csvData_NDX_20260903105007` 로 확장자가 붙지 않습니다. (각각 디렉토리를 비운 뒤 실행해 측정했고, 14자리 숫자는 실행 시각입니다.)

두 번째 실행부터는 `generateNewIndexFilename()` 경로라 기존 파일의 확장자를 그대로 이어받습니다.

확장자를 붙이지 않는 쪽이 규칙에 맞다고 본 근거는 규칙 4) 가 확장자 생략을 허용한다는 점, 그리고 형제 경로도 순번 뒤가 비면 `extValue = ""` 로 두어 확장자를 붙이지 않는다는 점입니다.

확장자가 비어 있을 때만 `.csv` 를 유지하는 좁은 수정은, `csvData_NDX(+1)` 이 빈 디렉토리에서는 `.csv`, 확장자 없는 파일이 있는 디렉토리에서는 확장자 없음이 되어 디렉토리 상태 의존이 남으므로 택하지 않았습니다.

### AS-IS / TO-BE

```diff
 private String generateInitialIndexFilename(String resourceFileName) {
-    // 파일명에서 확장자 추출 (괄호 이전 부분에서)
-    String baseFileName = resourceFileName;
-    int parenIndex = resourceFileName.indexOf('(');
-    if (parenIndex > 0) {
-        baseFileName = resourceFileName.substring(0, parenIndex);
-    }
-
+    // 파일명 규칙("파일명" + "_NDX" + "(순번)" + ".확장자")에 따라 (순번) 뒷부분을 확장자로 사용한다.
     String extension = "";
-    int lastDotIndex = baseFileName.lastIndexOf('.');
-    if (lastDotIndex > 0) {
-        extension = baseFileName.substring(lastDotIndex);
-    } else {
-        // 확장자가 없으면 기본적으로 .csv 사용
-        extension = ".csv";
+    int closeParenIndex = resourceFileName.indexOf(')');
+    if (closeParenIndex > 0) {
+        extension = resourceFileName.substring(closeParenIndex + 1);
     }
```

`indexOf(')')` 가 -1 인 입력은 199줄 정규식이 251줄 전에 걸러내지만 기존 코드의 `if (... > 0)` 방어 형태는 그대로 두었습니다.

### 영향 범위

`generateInitialIndexFilename()` 호출부는 `configureWriterIndexResouce():251` 한 곳뿐이고 진입 조건은 249줄의 `indexKeyNo == 1 && (ArrayUtils.isEmpty(fileInfoList) || fileInfoList.length == 0)` 입니다. (+1) 옵션이면서 대상 디렉토리에 인덱스 파일이 없는 첫 실행에만 해당하고 형제 경로 `generateNewIndexFilename()` 은 손대지 않았습니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

`EgovIndexFileWriterInitialExtensionTest` 를 더했습니다. 공개 진입점 `@BeforeStep beforeStep()` 으로 구동해 확장자를 지정한 경우, 생략한 경우, 기존 파일이 있는 형제 경로 세 가지를 봅니다.

수정 전 코드로 되돌려 모듈 전체를 돌리면 앞의 두 건이 실패합니다.

```
$ mvn -o test -pl Batch/org.egovframe.rte.bat.core
[ERROR] Tests run: 3, Failures: 2, Errors: 0, Skipped: 0, Time elapsed: 0.008 s <<< FAILURE! -- in org.egovframe.rte.bat.core.item.file.EgovIndexFileWriterInitialExtensionTest
[ERROR] Failures:
[ERROR]   EgovIndexFileWriterInitialExtensionTest.initialFilenameKeepsConfiguredExtension:46 indexResource에 지정한 확장자를 그대로 사용해야 한다 : DATA_NDX_20260903104941.csv ==> expected: <.txt> but was: <.csv>
[ERROR]   EgovIndexFileWriterInitialExtensionTest.initialFilenameKeepsOmittedExtension:57 확장자를 지정하지 않았으므로 확장자가 붙지 않아야 한다 : DATA_NDX_20260903104941.csv ==> expected: <-1> but was: <23>
[ERROR] Tests run: 89, Failures: 2, Errors: 0, Skipped: 0
[INFO] BUILD FAILURE
```

수정 후 모듈 전체입니다.

```
$ mvn -o test -pl Batch/org.egovframe.rte.bat.core
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.004 s -- in org.egovframe.rte.bat.core.item.file.EgovIndexFileWriterInitialExtensionTest
...
[INFO] Tests run: 89, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```

`EgovIndexFileWriter` 를 직접 쓰는 `EgovIndexFileWriterResourceLoaderTest` 와 위 잡을 컨텍스트로 실행하는 `EgovIndexFileReaderWriterTest` 도 통과합니다.

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

화면이 없는 실행환경 모듈이라 첨부하지 않았습니다.
