### PR TITLE
fix: Reader·Writer 설정 안내 예외가 실제로 읽지 않는 Job 파라미터 키를 알려주는 문제 수정

### DIFF
--- a/Batch/org.egovframe.rte.bat.core/src/main/java/org/egovframe/rte/bat/item/DefaultItemReader.java
+++ b/Batch/org.egovframe.rte.bat.core/src/main/java/org/egovframe/rte/bat/item/DefaultItemReader.java
@@ -193,9 +193,9 @@ public class DefaultItemReader<T> implements ItemStreamReader<T> {
                 String tempParams = jobParameters.getString(stepName + READER_PARAMS_KEY);
                 String type = jobParameters.getString(stepName + READER_VO_TYPE_KEY);
                 if (this.sql == null || type == null) {
-                    throw new RuntimeException(stepName + "스텝의 Writer 설정에서 sql, type 는 필수입니다. 다음 처럼 설정하세요.\n"
-                            + stepName + ".writer.sql=select ID, NAME, CREDIT from CUSTOMER "
-                            + stepName + ".writer.params=credit,name "
+                    throw new RuntimeException(stepName + "스텝의 Reader 설정에서 sql, type 는 필수입니다. 다음 처럼 설정하세요.\n"
+                            + stepName + READER_SQL_KEY + "=select ID, NAME, CREDIT from CUSTOMER "
+                            + stepName + READER_PARAMS_KEY + "=credit,name "
                             + stepName + READER_VO_TYPE_KEY + "=aa.bb.TestVo");
                 }
                 if (tempParams != null) {

--- a/Batch/org.egovframe.rte.bat.core/src/main/java/org/egovframe/rte/bat/item/DefaultItemWriter.java
+++ b/Batch/org.egovframe.rte.bat.core/src/main/java/org/egovframe/rte/bat/item/DefaultItemWriter.java
@@ -154,17 +154,17 @@ public class DefaultItemWriter<T> implements ItemStreamWriter<T> {
                     this.delimiter = jobParameters.getString(stepName + WRITER_DELIMITER_KEY);
                     if (this.resourceName == null || this.delimiter == null || this.names == null) {
                         throw new RuntimeException(stepName + "스텝의 Writer 설정에서 resourceName, delimiter, names는 필수입니다. 다음 처럼 설정하세요.\n"
-                                + stepName + ".writer.resourceName=file:./inputs/csvData.csv "
-                                + stepName + ".writer.delimiter=, "
-                                + stepName + ".writer.fieldNames=name,age ");
+                                + stepName + WRITER_RESOURCE_NAME_KEY + "=file:./inputs/csvData.csv "
+                                + stepName + WRITER_DELIMITER_KEY + "=, "
+                                + stepName + WRITER_FIELD_NAMES_KEY + "=name,age ");
                     }
                 } else {
                     this.ranges = jobParameters.getString(stepName + WRITER_FIELD_RANGES_KEY);
                     if (this.resourceName == null || ranges == null || this.names == null) {
-                        throw new RuntimeException(stepName + "스텝의 Reader 설정에서 resourceName, fieldRanges, names는 필수입니다. 다음 처럼 설정하세요.\n"
-                                + stepName + ".writer.resourceName=./target/test-outputs/txtOutput.txt "
-                                + stepName + ".writer.fieldRanges=9,2 "
-                                + stepName + ".writer.fieldNames=name,age ");
+                        throw new RuntimeException(stepName + "스텝의 Writer 설정에서 resourceName, fieldRanges, names는 필수입니다. 다음 처럼 설정하세요.\n"
+                                + stepName + WRITER_RESOURCE_NAME_KEY + "=./target/test-outputs/txtOutput.txt "
+                                + stepName + WRITER_FIELD_RANGES_KEY + "=9,2 "
+                                + stepName + WRITER_FIELD_NAMES_KEY + "=name,age ");
                     }
                     String[] rangeArray = ranges.split(",");
                     this.fieldRanges = new int[rangeArray.length];
@@ -179,14 +179,14 @@ public class DefaultItemWriter<T> implements ItemStreamWriter<T> {
                 tempParams = jobParameters.getString(stepName + WRITER_PARAMS_KEY);
                 if (this.sql == null || tempParams == null) {
                     throw new RuntimeException(stepName + "스텝의 Writer 설정에서 sql, params는 필수입니다. 다음 처럼 설정하세요.\n"
-                            + stepName + ".writer.sql=UPDATE CUSTOMER set credit =? where name =? "
-                            + stepName + ".writer.params=credit,name ");
+                            + stepName + WRITER_SQL_KEY + "=UPDATE CUSTOMER set credit =? where name =? "
+                            + stepName + WRITER_PARAMS_KEY + "=credit,name ");
                 }
                 this.params = tempParams.split(",");
             }
         } else {
             throw new RuntimeException(stepName
-                    + ".writerResourceType=delimitedFile'처럼, 출력 리소스 타입을 Job 파라미터로 입력하세요.\n"
+                    + WRITER_RESOURCE_TYPE_KEY + "=delimitedFile'처럼, 출력 리소스 타입을 Job 파라미터로 입력하세요.\n"
                     + "리소스 타입 종류) delimitedFile, fixedLengthFile, jdbcDb");
         }
     }

--- a/Batch/org.egovframe.rte.bat.core/src/test/java/org/egovframe/rte/bat/item/DefaultItemGuidanceKeyTest.java
+++ b/Batch/org.egovframe.rte.bat.core/src/test/java/org/egovframe/rte/bat/item/DefaultItemGuidanceKeyTest.java
@@ -1,0 +1,164 @@
+package org.egovframe.rte.bat.item;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.JobParametersBuilder;
+import org.springframework.batch.core.StepExecution;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * DefaultItemReader / DefaultItemWriter 가 설정 누락 시 던지는 안내 예외 테스트.
+ *
+ * <p>안내문이 알려준 Job 파라미터 키를 그대로 설정했을 때 설정이 실제로 끝나는지 확인한다.
+ * 안내문에서 키를 뽑아 되먹이므로, 안내문과 실제로 읽는 키가 어긋나면 실패한다.</p>
+ *
+ * @author 기여자
+ * @version 1.0
+ * @since 2026.09.03
+ */
+public class DefaultItemGuidanceKeyTest {
+
+    private static final String STEP_NAME = "step1";
+
+    /** 안내문이 예시로 드는 VO 클래스. 실재하지 않으므로 되먹일 때 로드 가능한 클래스로 치환한다. */
+    private static final String GUIDED_VO_TYPE = "aa.bb.TestVo";
+
+    private static final Pattern GUIDED_PARAMETER =
+            Pattern.compile("(" + Pattern.quote(STEP_NAME) + "\\.[\\w.]+)=(\\S*)");
+
+    /** Job 파라미터로 Writer 설정을 시도하고, 실패하면 예외 메시지를 돌려준다. */
+    private String configureWriter(Map<String, String> jobParameters) throws ClassNotFoundException {
+        try {
+            new DefaultItemWriter<Object>().beforeStep(stepExecution(jobParameters));
+            return null;
+        } catch (RuntimeException e) {
+            return e.getMessage();
+        }
+    }
+
+    /** Job 파라미터로 Reader 설정을 시도하고, 실패하면 예외 메시지를 돌려준다. */
+    private String configureReader(Map<String, String> jobParameters) {
+        try {
+            new DefaultItemReader<Object>().beforeStep(stepExecution(jobParameters));
+            return null;
+        } catch (RuntimeException e) {
+            return e.getMessage();
+        }
+    }
+
+    private StepExecution stepExecution(Map<String, String> jobParameters) {
+        JobParametersBuilder builder = new JobParametersBuilder();
+        for (Map.Entry<String, String> entry : jobParameters.entrySet()) {
+            builder.addString(entry.getKey(), entry.getValue());
+        }
+        return new JobExecution(1L, builder.toJobParameters()).createStepExecution(STEP_NAME);
+    }
+
+    /** 안내문에 적힌 'key=value' 를 그대로 Job 파라미터로 만든다. */
+    private Map<String, String> guidedParameters(String message) {
+        Map<String, String> jobParameters = new LinkedHashMap<String, String>();
+        Matcher matcher = GUIDED_PARAMETER.matcher(message);
+        while (matcher.find()) {
+            String value = matcher.group(2);
+            jobParameters.put(matcher.group(1), GUIDED_VO_TYPE.equals(value) ? Object.class.getName() : value);
+        }
+        return jobParameters;
+    }
+
+    @Test
+    @DisplayName("Writer 리소스 타입 안내문의 키로 설정하면 같은 안내문이 다시 나오지 않는다")
+    public void writerResourceTypeGuidance() throws ClassNotFoundException {
+        String message = configureWriter(new LinkedHashMap<String, String>());
+        assertNotNull(message, "리소스 타입을 빼면 안내 예외가 나야 한다");
+
+        Map<String, String> guided = guidedParameters(message);
+        assertFalse(guided.isEmpty(), "안내문에 Job 파라미터 키가 있어야 한다: " + message);
+
+        Map<String, String> jobParameters = new LinkedHashMap<String, String>();
+        for (String key : guided.keySet()) {
+            jobParameters.put(key, "delimitedFile");
+        }
+        String repeated = configureWriter(jobParameters);
+        assertFalse(repeated != null && repeated.contains("리소스 타입 종류"),
+                "안내문이 알려준 키로 설정했는데 같은 안내문이 되풀이된다: " + repeated);
+    }
+
+    @Test
+    @DisplayName("Writer delimitedFile 안내문의 키로 설정하면 설정이 끝난다")
+    public void writerDelimitedFileGuidance() throws ClassNotFoundException {
+        Map<String, String> jobParameters = new LinkedHashMap<String, String>();
+        jobParameters.put(STEP_NAME + ".writer.resource.type", "delimitedFile");
+
+        String message = configureWriter(jobParameters);
+        assertNotNull(message, "필수 설정을 빼면 안내 예외가 나야 한다");
+
+        jobParameters.putAll(guidedParameters(message));
+        assertNull(configureWriter(jobParameters),
+                "안내문대로 설정했는데도 실패한다:\n" + message);
+    }
+
+    @Test
+    @DisplayName("Writer fixedLengthFile 안내문의 키로 설정하면 설정이 끝난다")
+    public void writerFixedLengthFileGuidance() throws ClassNotFoundException {
+        Map<String, String> jobParameters = new LinkedHashMap<String, String>();
+        jobParameters.put(STEP_NAME + ".writer.resource.type", "fixedLengthFile");
+
+        String message = configureWriter(jobParameters);
+        assertNotNull(message, "필수 설정을 빼면 안내 예외가 나야 한다");
+
+        jobParameters.putAll(guidedParameters(message));
+        assertNull(configureWriter(jobParameters),
+                "안내문대로 설정했는데도 실패한다:\n" + message);
+    }
+
+    @Test
+    @DisplayName("Writer jdbcDb 안내문의 키로 설정하면 설정이 끝난다")
+    public void writerJdbcDbGuidance() throws ClassNotFoundException {
+        Map<String, String> jobParameters = new LinkedHashMap<String, String>();
+        jobParameters.put(STEP_NAME + ".writer.resource.type", "jdbcDb");
+
+        String message = configureWriter(jobParameters);
+        assertNotNull(message, "필수 설정을 빼면 안내 예외가 나야 한다");
+
+        jobParameters.putAll(guidedParameters(message));
+        assertNull(configureWriter(jobParameters),
+                "안내문대로 설정했는데도 실패한다:\n" + message);
+    }
+
+    @Test
+    @DisplayName("Reader jdbcDb 안내문의 키로 설정하면 설정이 끝난다")
+    public void readerJdbcDbGuidance() {
+        Map<String, String> jobParameters = new LinkedHashMap<String, String>();
+        jobParameters.put(STEP_NAME + ".reader.resource.type", "jdbcDb");
+
+        String message = configureReader(jobParameters);
+        assertNotNull(message, "필수 설정을 빼면 안내 예외가 나야 한다");
+
+        jobParameters.putAll(guidedParameters(message));
+        assertNull(configureReader(jobParameters),
+                "안내문대로 설정했는데도 실패한다:\n" + message);
+    }
+
+    @Test
+    @DisplayName("Reader delimitedFile 안내문의 키로 설정하면 설정이 끝난다")
+    public void readerDelimitedFileGuidance() {
+        Map<String, String> jobParameters = new LinkedHashMap<String, String>();
+        jobParameters.put(STEP_NAME + ".reader.resource.type", "delimitedFile");
+
+        String message = configureReader(jobParameters);
+        assertNotNull(message, "필수 설정을 빼면 안내 예외가 나야 한다");
+
+        jobParameters.putAll(guidedParameters(message));
+        assertNull(configureReader(jobParameters),
+                "안내문대로 설정했는데도 실패한다:\n" + message);
+    }
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

`DefaultItemWriter`·`DefaultItemReader` 의 설정 안내 예외가 그 클래스가 실제로 읽지 않는 Job 파라미터 키를 알려 줘서, 안내대로 설정해도 같은 예외가 되풀이됩니다.

| 안내문의 키(`<스텝>` 뒤) | 실제로 읽는 키 |
| --- | --- |
| `.writer.resourceName` | `.writer.resource.name` |
| `.writer.fieldNames` | `.writer.field.names` |
| `.writer.fieldRanges` | `.writer.field.ranges` |
| `.writerResourceType` | `.writer.resource.type` |
| `.writer.sql` (Reader jdbcDb 분기) | `.reader.sql` |

오른쪽은 상수 선언 그대로입니다(`DefaultItemWriter.java:57-60`, `DefaultItemReader.java:65`). `DefaultItemReader` 안내문 네 곳 중 세 곳은 이 상수를 이어 붙이고(161-165), jdbcDb 분기만 키를 따로 적어 어긋났습니다.

### AS-IS / TO-BE

안내문이 키 상수를 이어 붙이게 바꿨습니다. `writerJdbcDbGuidance` 분기의 `.writer.sql`·`.writer.params` 는 수정 전에도 맞았지만 리터럴이 다시 어긋나지 않게 같이 통일했습니다.

```diff
 // DefaultItemWriter.java:188-190
 throw new RuntimeException(stepName
-        + ".writerResourceType=delimitedFile'처럼, 출력 리소스 타입을 Job 파라미터로 입력하세요.\n"
+        + WRITER_RESOURCE_TYPE_KEY + "=delimitedFile'처럼, 출력 리소스 타입을 Job 파라미터로 입력하세요.\n"
         + "리소스 타입 종류) delimitedFile, fixedLengthFile, jdbcDb");
```

```diff
 // DefaultItemReader.java:196-199
-throw new RuntimeException(stepName + "스텝의 Writer 설정에서 sql, type 는 필수입니다. 다음 처럼 설정하세요.\n"
-        + stepName + ".writer.sql=select ID, NAME, CREDIT from CUSTOMER "
-        + stepName + ".writer.params=credit,name "
+throw new RuntimeException(stepName + "스텝의 Reader 설정에서 sql, type 는 필수입니다. 다음 처럼 설정하세요.\n"
+        + stepName + READER_SQL_KEY + "=select ID, NAME, CREDIT from CUSTOMER "
+        + stepName + READER_PARAMS_KEY + "=credit,name "
         + stepName + READER_VO_TYPE_KEY + "=aa.bb.TestVo");
```

`DefaultItemWriter.java` 156·164·181 도 같은 형태로 바꿨습니다.

안내문 두 곳이 Reader 와 Writer 를 서로 바꿔 적고 있어 함께 맞췄습니다(Writer fixedLengthFile "스텝의 Reader 설정에서", Reader jdbcDb "스텝의 Writer 설정에서"). 나머지 네 곳(Reader 161·170, Writer 156·181)은 원래 맞아서 손대지 않았습니다.

### 영향 범위

바뀐 것은 예외 메시지 문자열뿐이고 읽는 키와 분기 조건은 그대로입니다. 수정 후 남은 `".reader`·`".writer` 리터럴은 상수 선언(Reader 58-66, Writer 56-63)과 XML 조립용 bean id 뿐입니다.

두 클래스를 부르는 곳은 이번에 더한 테스트뿐이고, `README.md` 28·29 줄 목록에만 이름이 있습니다. 옛 문자열을 검사하는 테스트도 없습니다.

나눠서 받고 싶으시면 `DefaultItemReader` 쪽 변경과 `readerJdbcDbGuidance` 테스트를 빼면 됩니다. 같은 결함이라 한 커밋으로 묶었습니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

안내문에서 키를 뽑아 되먹이는 `DefaultItemGuidanceKeyTest`(6건)를 추가했습니다. 수정 전(`origin/main`)에는 여섯 건 중 네 건이 실패합니다.

```
$ mvn -o test -pl Batch/org.egovframe.rte.bat.core -Dtest=DefaultItemGuidanceKeyTest
[ERROR] Failures:
[ERROR]   DefaultItemGuidanceKeyTest.readerJdbcDbGuidance:147 안내문대로 설정했는데도 실패한다:
step1스텝의 Writer 설정에서 sql, type 는 필수입니다. 다음 처럼 설정하세요.
step1.writer.sql=select ID, NAME, CREDIT from CUSTOMER step1.writer.params=credit,name step1.reader.vo.type=aa.bb.TestVo ==> expected: <null> but was: <...>
[ERROR]   DefaultItemGuidanceKeyTest.writerDelimitedFileGuidance:105 안내문대로 설정했는데도 실패한다:
step1스텝의 Writer 설정에서 resourceName, delimiter, names는 필수입니다. 다음 처럼 설정하세요.
step1.writer.resourceName=file:./inputs/csvData.csv step1.writer.delimiter=, step1.writer.fieldNames=name,age  ==> expected: <null> but was: <...>
[ERROR]   DefaultItemGuidanceKeyTest.writerFixedLengthFileGuidance:119 안내문대로 설정했는데도 실패한다:
step1스텝의 Reader 설정에서 resourceName, fieldRanges, names는 필수입니다. 다음 처럼 설정하세요.
step1.writer.resourceName=./target/test-outputs/txtOutput.txt step1.writer.fieldRanges=9,2 step1.writer.fieldNames=name,age  ==> expected: <null> but was: <...>
[ERROR]   DefaultItemGuidanceKeyTest.writerResourceTypeGuidance:91 안내문이 알려준 키로 설정했는데 같은 안내문이 되풀이된다: step1.writerResourceType=delimitedFile'처럼, 출력 리소스 타입을 Job 파라미터로 입력하세요.
리소스 타입 종류) delimitedFile, fixedLengthFile, jdbcDb ==> expected: <false> but was: <true>
[ERROR] Tests run: 6, Failures: 4, Errors: 0, Skipped: 0
```

나머지 두 건(`writerJdbcDbGuidance`·`readerDelimitedFileGuidance`)은 원래 키가 맞아 수정 전에도 통과합니다. 수정 후 모듈 전체입니다.

```
$ mvn -o test -pl Batch/org.egovframe.rte.bat.core
[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.196 s -- in DefaultItemGuidanceKeyTest
...
[INFO] Tests run: 92, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

화면이 없는 실행환경 모듈이라 첨부하지 않았습니다.
