### PR TITLE
fix: 최대값 초과 예외 메시지에 치환 인자가 빠져 {0} 이 그대로 노출되는 문제 수정

### DIFF
--- a/Foundation/org.egovframe.rte.fdl.idgnr/src/main/java/org/egovframe/rte/fdl/idgnr/impl/AbstractDataBlockIdGnrService.java
+++ b/Foundation/org.egovframe.rte.fdl.idgnr/src/main/java/org/egovframe/rte/fdl/idgnr/impl/AbstractDataBlockIdGnrService.java
@@ -116,7 +116,7 @@ public abstract class AbstractDataBlockIdGnrService extends AbstractDataIdGnrSer
         long id = mFirstLong + mAllocated;
         if (id < 0) {
             LOGGER.debug(messageSource.getMessage("error.idgnr.greater.maxid", new String[]{"Long"}, Locale.getDefault()));
-            throw new FdlException(messageSource, "error.idgnr.greater.maxid");
+            throw new FdlException(messageSource, "error.idgnr.greater.maxid", new String[]{"Long"}, null);
         }
 
         mAllocated++;

--- a/Foundation/org.egovframe.rte.fdl.idgnr/src/main/java/org/egovframe/rte/fdl/idgnr/impl/AbstractIdGnrService.java
+++ b/Foundation/org.egovframe.rte.fdl.idgnr/src/main/java/org/egovframe/rte/fdl/idgnr/impl/AbstractIdGnrService.java
@@ -133,7 +133,7 @@ public abstract class AbstractIdGnrService implements EgovIdGnrService, Applicat
 
             if (bd.compareTo(BIG_DECIMAL_MAX_LONG) > 0) {
                 LOGGER.debug(messageSource.getMessage("error.idgnr.greater.maxid", new String[]{"Long"}, Locale.getDefault()));
-                throw new FdlException(messageSource, "error.idgnr.greater.maxid");
+                throw new FdlException(messageSource, "error.idgnr.greater.maxid", new String[]{"Long"}, null);
             }
 
             nextId = bd.longValue();
@@ -145,7 +145,7 @@ public abstract class AbstractIdGnrService implements EgovIdGnrService, Applicat
 
         if (nextId > maxId) {
             LOGGER.debug(messageSource.getMessage("error.idgnr.greater.maxid", new String[]{"Long"}, Locale.getDefault()));
-            throw new FdlException(messageSource, "error.idgnr.greater.maxid");
+            throw new FdlException(messageSource, "error.idgnr.greater.maxid", new String[]{"Long"}, null);
         }
 
         return nextId;

--- a/Foundation/org.egovframe.rte.fdl.idgnr/src/test/java/org/egovframe/rte/fdl/idgnr/impl/MaxIdMessageArgsTest.java
+++ b/Foundation/org.egovframe.rte.fdl.idgnr/src/test/java/org/egovframe/rte/fdl/idgnr/impl/MaxIdMessageArgsTest.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2008-2024 MOIS(Ministry of the Interior and Safety).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.egovframe.rte.fdl.idgnr.impl;
+
+import org.egovframe.rte.fdl.cmmn.exception.FdlException;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.MessageSource;
+import org.springframework.context.support.ReloadableResourceBundleMessageSource;
+
+import java.math.BigDecimal;
+import java.util.Locale;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * MaxIdMessageArgsTest 클래스
+ * <p>
+ * 최대값 초과로 ID 생성이 중단될 때 사용자에게 전달되는 예외 메시지가 로그와 같은
+ * 치환 인자를 받는지 검증한다.
+ * <p>
+ * == 개정이력(Modification Information) ==
+ * <p>
+ * 수정일      수정자           수정내용
+ * -------    --------    ---------------------------
+ * 2026.09.03  개발팀          최초 생성
+ */
+public class MaxIdMessageArgsTest {
+
+    private static final String MAX_ID_KEY = "error.idgnr.greater.maxid";
+
+    private static MessageSource messageSource() {
+        ReloadableResourceBundleMessageSource messageSource = new ReloadableResourceBundleMessageSource();
+        messageSource.setBasename("classpath:/org/egovframe/rte/fdl/idgnr/messages/idgnr");
+        messageSource.setDefaultEncoding("UTF-8");
+        messageSource.setUseCodeAsDefaultMessage(true);
+        return messageSource;
+    }
+
+    /**
+     * 예외 메시지가 치환되지 않은 자리표시자를 남기지 않고 로그 메시지와 같은지 확인한다.
+     */
+    private static void assertMessageIsFormatted(MessageSource messageSource, FdlException exception) {
+        assertFalse(exception.getMessage().contains("{0}"), "예외 메시지에 치환되지 않은 자리표시자가 남아있다.");
+        assertEquals(messageSource.getMessage(MAX_ID_KEY, new String[]{"Long"}, Locale.getDefault()), exception.getMessage());
+    }
+
+    /**
+     * 다음 ID 가 요청한 타입의 최대값을 넘을 때의 예외 메시지를 확인한다.
+     */
+    @Test
+    public void testNextIdGreaterThanMaxIdMessageIsFormatted() {
+        MessageSource messageSource = messageSource();
+        CounterIdGnrService service = new CounterIdGnrService(messageSource);
+        service.setCounter(Byte.MAX_VALUE);
+
+        FdlException exception = assertThrows(FdlException.class, service::getNextByteId);
+
+        assertMessageIsFormatted(messageSource, exception);
+    }
+
+    /**
+     * BigDecimal 로 채번한 다음 ID 가 long 범위를 넘을 때의 예외 메시지를 확인한다.
+     */
+    @Test
+    public void testBigDecimalGreaterThanLongMessageIsFormatted() {
+        MessageSource messageSource = messageSource();
+        CounterIdGnrService service = new CounterIdGnrService(messageSource);
+        service.setCounter(Long.MAX_VALUE);
+        service.setUseBigDecimals(true);
+
+        FdlException exception = assertThrows(FdlException.class, service::getNextLongId);
+
+        assertMessageIsFormatted(messageSource, exception);
+    }
+
+    /**
+     * 할당받은 블럭에서 채번한 ID 가 long 범위를 넘을 때의 예외 메시지를 확인한다.
+     */
+    @Test
+    public void testBlockAllocationOverflowMessageIsFormatted() throws Exception {
+        MessageSource messageSource = messageSource();
+        BlockIdGnrService service = new BlockIdGnrService(messageSource);
+        service.setBlockSize(2);
+        service.afterPropertiesSet();
+        assertEquals(Long.MAX_VALUE, service.getNextLongId());
+
+        FdlException exception = assertThrows(FdlException.class, service::getNextLongId);
+
+        assertMessageIsFormatted(messageSource, exception);
+    }
+
+    private static class CounterIdGnrService extends AbstractIdGnrService {
+
+        private BigDecimal counter = BigDecimal.ZERO;
+
+        CounterIdGnrService(MessageSource messageSource) {
+            this.messageSource = messageSource;
+        }
+
+        void setCounter(long counter) {
+            this.counter = BigDecimal.valueOf(counter);
+        }
+
+        @Override
+        protected BigDecimal getNextBigDecimalIdInner() throws FdlException {
+            counter = counter.add(BigDecimal.ONE);
+            return counter;
+        }
+
+        @Override
+        protected long getNextLongIdInner() throws FdlException {
+            return getNextBigDecimalIdInner().longValue();
+        }
+    }
+
+    private static class BlockIdGnrService extends AbstractDataBlockIdGnrService {
+
+        BlockIdGnrService(MessageSource messageSource) {
+            this.messageSource = messageSource;
+        }
+
+        @Override
+        protected BigDecimal allocateBigDecimalIdBlock(int blockSize) throws FdlException {
+            return BigDecimal.valueOf(allocateLongIdBlock(blockSize));
+        }
+
+        @Override
+        protected long allocateLongIdBlock(int blockSize) throws FdlException {
+            return Long.MAX_VALUE;
+        }
+    }
+
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

`error.idgnr.greater.maxid` 는 `idgnr.properties`·`idgnr_ko.properties`·`idgnr_en.properties` 6행 모두 `{0}` 자리표시자를 들고 있습니다. 그런데 이 키로 예외를 던지는 자리는 한 줄 위 로그에만 인자를 넘깁니다.

```java
// AbstractIdGnrService.java:135-136
LOGGER.debug(messageSource.getMessage("error.idgnr.greater.maxid", new String[]{"Long"}, Locale.getDefault()));
throw new FdlException(messageSource, "error.idgnr.greater.maxid");
```

`FdlException` 은 `messageSource.getMessage(messageKey, messageParameters, defaultMessage, locale)` 로 메시지를 만듭니다(`FdlException:169`). `messageParameters` 가 `null` 이면 Spring 이 `MessageFormat` 을 건너뛰고 프로퍼티 원문을 그대로 돌려줍니다. 그래서 로그에는 치환된 문자열이 남는데 사용자가 받는 `getMessage()` 에는 `{0}` 이 남고, `getMessageParameters()` 도 `null` 입니다.

같은 자리가 `AbstractIdGnrService:136`·`AbstractIdGnrService:148`·`AbstractDataBlockIdGnrService:119` 세 곳입니다.

죽은 코드는 아닙니다. `getNextLongIdChecked` 는 `public final` 인 `getNextLongId()`·`getNextIntegerId()`·`getNextShortId()`·`getNextByteId()` 넷이 부릅니다(`AbstractIdGnrService:181,191,201,211`). 채번값이 요청 타입의 최대값을 넘으면 148줄, `useBigDecimals` 를 켠 상태에서 `long` 범위를 넘으면 136줄, 할당받은 블럭에서 채번한 값이 넘칠 때가 `AbstractDataBlockIdGnrService:119` 입니다.

### AS-IS / TO-BE

같은 모듈에서 `{0}` 이 있는 키로 `FdlException` 을 만드는 자리는 11곳인데, 인자를 넘기지 않는 것은 `error.idgnr.greater.maxid` 세 곳뿐입니다. 나머지 8곳(`EgovUUIdGnrServiceImpl` 의 `error.idgnr.not.supported` 6곳, `EgovTableIdGnrServiceImpl` 의 `error.idgnr.select.idblock`·`error.idgnr.update.idblock`)은 모두 인자를 넘깁니다. 그 형태에 맞춰 로그가 쓰던 인자를 예외에도 넘겼습니다.

```diff
 LOGGER.debug(messageSource.getMessage("error.idgnr.greater.maxid", new String[]{"Long"}, Locale.getDefault()));
-throw new FdlException(messageSource, "error.idgnr.greater.maxid");
+throw new FdlException(messageSource, "error.idgnr.greater.maxid", new String[]{"Long"}, null);
```

세 곳 모두 같은 형태이고, 여기 쓴 생성자는 `FdlException:138` 에 이미 있습니다.

### 영향 범위

바뀌는 것은 `FdlException.getMessage()` 가 돌려주는 문자열과 `getMessageParameters()` 뿐입니다. 던지는 조건·예외 타입·제어흐름은 그대로입니다.

인자 `"Long"` 은 한 줄 위 로그가 이미 쓰던 값 그대로입니다. `getNextLongIdChecked` 는 `maxId` 값만 받고 요청 타입 이름을 모르기 때문에, `getNextByteId` 처럼 다른 타입으로 들어온 호출에도 `Long` 이 실립니다. 타입명까지 맞추려면 이 `protected final` 메서드의 시그니처를 바꿔야 해서, 이번에는 로그와 예외가 같은 문자열을 내도록 맞추는 데까지만 했습니다.

`MessageFormat` 을 타게 되면 작은따옴표 이스케이프 규칙이 생기는데, 세 프로퍼티의 이 메시지에는 작은따옴표가 없어 해당하지 않습니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

세 지점을 공개 API 로 각각 도달시키는 `MaxIdMessageArgsTest` 를 더했습니다. 수정 전에는 셋 다 실패하고, 같은 시점의 로그는 치환된 채 찍힙니다.

```
$ mvn -o test -pl Foundation/org.egovframe.rte.fdl.idgnr -Dtest=MaxIdMessageArgsTest
[INFO] Running org.egovframe.rte.fdl.idgnr.impl.MaxIdMessageArgsTest
2026-09-03 14:40:45,033 DEBUG [org.egovframe.rte.fdl.idgnr.impl.AbstractIdGnrService] [IDGeneration Service] ID를 제공 할 수 없음. ID가 더 이상 최대 값 Long에 도달하여 유효합니다.
[ERROR]   MaxIdMessageArgsTest.testNextIdGreaterThanMaxIdMessageIsFormatted:73->assertMessageIsFormatted:58 예외 메시지에 치환되지 않은 자리표시자가 남아있다. ==> expected: <false> but was: <true>
[ERROR] Tests run: 3, Failures: 3, Errors: 0, Skipped: 0
```

수정 후 모듈 전체입니다.

```
$ mvn -o test -pl Foundation/org.egovframe.rte.fdl.idgnr
[INFO] Tests run: 45, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

화면이 없는 실행환경 모듈이라 첨부하지 않았습니다.
