### PR TITLE
fix: access 설정의 dataSource 가 빈 문자열이면 폴백 대신 기동이 죽는 문제 수정

### DIFF
--- a/Foundation/org.egovframe.rte.fdl.access/src/main/java/org/egovframe/rte/fdl/access/bean/DataSourceFactoryBean.java
+++ b/Foundation/org.egovframe.rte.fdl.access/src/main/java/org/egovframe/rte/fdl/access/bean/DataSourceFactoryBean.java
@@ -21,6 +21,7 @@ import org.springframework.beans.factory.FactoryBean;
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
+import org.springframework.util.StringUtils;
 
 import javax.sql.DataSource;
 
@@ -53,7 +54,7 @@ public class DataSourceFactoryBean implements FactoryBean<DataSource>, Applicati
     @Override
     public DataSource getObject() throws Exception {
         EgovAccessConfig config = context.getBean(EgovAccessConfig.class);
-        if (config.getDataSource() != null) {
+        if (StringUtils.hasText(config.getDataSource())) {
             return (DataSource) context.getBean(config.getDataSource());
         } else {
             if (context.containsBean(DEF_DATASOURCE_NAME)) {

--- a/Foundation/org.egovframe.rte.fdl.access/src/test/java/org/egovframe/rte/fdl/access/bean/DataSourceFactoryBeanBlankNameTest.java
+++ b/Foundation/org.egovframe.rte.fdl.access/src/test/java/org/egovframe/rte/fdl/access/bean/DataSourceFactoryBeanBlankNameTest.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2008-2024 MOIS(Ministry of the Interior and Safety).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.egovframe.rte.fdl.access.bean;
+
+import org.apache.commons.dbcp2.BasicDataSource;
+import org.egovframe.rte.fdl.access.config.EgovAccessConfig;
+import org.egovframe.rte.fdl.access.config.EgovAccessConfiguration;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.support.PropertySourcesPlaceholderConfigurer;
+import org.springframework.core.env.MapPropertySource;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.jdbc.datasource.SimpleDriverDataSource;
+import org.springframework.jdbc.datasource.init.ScriptUtils;
+
+import javax.sql.DataSource;
+import java.io.File;
+import java.io.FileWriter;
+import java.sql.Connection;
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+/**
+ * egov-access-config.properties 의 dataSource 를 값 없이 둔 설정에 대한 테스트
+ */
+public class DataSourceFactoryBeanBlankNameTest {
+
+    @Configuration
+    static class BeanOnlyContext {
+        @Bean(name = "dataSource")
+        public DataSource dataSource() {
+            return new SimpleDriverDataSource();
+        }
+
+        @Bean
+        public EgovAccessConfig egovAccessConfig() {
+            EgovAccessConfig config = new EgovAccessConfig();
+            config.setDataSource("");
+            return config;
+        }
+    }
+
+    @Configuration
+    static class StartupContext {
+        @Bean
+        public static PropertySourcesPlaceholderConfigurer placeholderConfigurer() {
+            return new PropertySourcesPlaceholderConfigurer();
+        }
+
+        @Bean(name = "dataSource")
+        public DataSource dataSource() {
+            BasicDataSource ds = new BasicDataSource();
+            ds.setDriverClassName("org.hsqldb.jdbcDriver");
+            ds.setUrl("jdbc:hsqldb:mem:blankdatasourcetestdb");
+            ds.setUsername("sa");
+            ds.setPassword("");
+            ds.setDefaultAutoCommit(true);
+            try (Connection conn = ds.getConnection()) {
+                ScriptUtils.executeSqlScript(conn, new ClassPathResource("META-INF/testdata/testdb.sql"));
+            } catch (Exception e) {
+                throw new IllegalStateException("db init failed", e);
+            }
+            return ds;
+        }
+    }
+
+    /**
+     * 설정의 dataSource 가 빈 문자열이면 기본 dataSource bean 으로 폴백한다.
+     */
+    @Test
+    public void blankDataSourceNameFallsBackToDefaultBean() {
+        try (AnnotationConfigApplicationContext ctx = new AnnotationConfigApplicationContext(BeanOnlyContext.class)) {
+            DataSourceFactoryBean factory = new DataSourceFactoryBean();
+            factory.setApplicationContext(ctx);
+
+            DataSource dataSource = assertDoesNotThrow(factory::getObject);
+            assertSame(ctx.getBean("dataSource"), dataSource);
+        }
+    }
+
+    /**
+     * dataSource 를 값 없이 둔 설정 파일로도 EgovAccessConfiguration 이 기동한다.
+     */
+    @Test
+    public void contextStartsWithBlankDataSourceName() throws Exception {
+        File configFile = File.createTempFile("egov-access-config", ".properties");
+        configFile.deleteOnExit();
+        try (FileWriter writer = new FileWriter(configFile)) {
+            writer.write("id=egovAccessConfig\n");
+            writer.write("globalAuthen=session\n");
+            writer.write("mappingPath=/**/*.do\n");
+            writer.write("dataSource=\n");
+            writer.write("loginUrl=/uat/uia/egovLoginUsr.do\n");
+            writer.write("accessDeniedUrl=/uat/uia/egovLoginUsr.do?auth_error=1\n");
+            writer.write("requestMatcherType=ant\n");
+            writer.write("sqlAuthorityUser=SELECT USER_ID AS userid, AUTHOR_CODE AS authority FROM AUTHORITIES\n");
+            writer.write("sqlRoleAndUrl=SELECT r.ROLE_PTTRN AS url, a.AUTHOR_CODE AS authority FROM ROLES r INNER JOIN AUTHROLES a ON r.ROLE_CODE = a.ROLE_CODE ORDER BY r.ROLE_SORT\n");
+        }
+
+        AnnotationConfigApplicationContext ctx = new AnnotationConfigApplicationContext();
+        ctx.getEnvironment().getPropertySources().addFirst(new MapPropertySource("blankDataSource",
+                Collections.singletonMap("Globals.AccessConfigPath", "file:" + configFile.getAbsolutePath())));
+        ctx.register(StartupContext.class, EgovAccessConfiguration.class);
+        try {
+            assertDoesNotThrow(ctx::refresh);
+            assertEquals("", ctx.getBean(EgovAccessConfig.class).getDataSource());
+            assertSame(ctx.getBean("dataSource"), ctx.getBean("accessDataSourceFactoryBean"));
+        } finally {
+            ctx.close();
+        }
+    }
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

`egov-access-config.properties` 에 `dataSource=` 한 줄을 값 없이 두면 애플리케이션이 기동하지 못합니다.

`EgovAccessConfigReader.mapPropertiesToBean` 은 properties 의 모든 키를 리플렉션 setter 로 넣고, 값 검사는 `if (value == null) continue;`(`EgovAccessConfigReader.java:127`) 하나뿐입니다. 그래서 빈 문자열이 그대로 `setDataSource` 로 들어가 `createDefaultConfig` 가 넣어둔 기본값 `"dataSource"`(`:233`) 를 덮습니다.

`DataSourceFactoryBean` 은 이 값을 `!= null` 로만 보고 bean 이름으로 넘겨 `context.getBean("")` 을 부릅니다.

```
NoSuchBeanDefinitionException: No bean named '' available
```

`EgovAccessConfiguration.egovAccessDao`(`EgovAccessConfiguration.java:94`) 가 이 팩토리빈을 부르기 때문에 예외 하나로 끝나지 않고 컨텍스트 기동 자체가 실패합니다. 컨텍스트에 이름이 `dataSource` 인 bean 이 멀쩡히 있어도 그렇습니다.

값을 비운 설정이 가야 할 곳은 이미 코드 안에 있습니다. 그 아래 `else` 가 `containsBean(DEF_DATASOURCE_NAME)` 폴백이 있고 `DEF_DATASOURCE_NAME` 은 `"dataSource"` 이며, `createDefaultConfig` 가 지정하는 기본값도 같은 이름입니다. 빈 문자열만 그 갈래로 못 갑니다.

같은 패키지에서 `EgovAccessConfig` 를 읽어 갈라지는 팩토리빈은 이 클래스를 포함해 셋이고, 나머지 둘은 같은 자리에서 `StringUtils.hasText` 를 씁니다.

```java
// AuthorityUserFactoryBean.java:54
if (StringUtils.hasText(config.getSqlAuthorityUser())) {

// RoleAndUrlFactoryBean.java:55
if (StringUtils.hasText(config.getSqlRoleAndUrl())) {
```

형제 모듈의 같은 이름 클래스인 `fdl.security` 의 `DataSourceFactoryBean.java:67` 도 `!ObjectUtils.isEmpty(config.getDataSource())` 로 보아 빈 문자열을 같은 `"dataSource"` 폴백으로 보냅니다. 표기는 같은 패키지 형제 둘에 맞췄습니다.

### AS-IS / TO-BE

```diff
 public DataSource getObject() throws Exception {
     EgovAccessConfig config = context.getBean(EgovAccessConfig.class);
-    if (config.getDataSource() != null) {
+    if (StringUtils.hasText(config.getDataSource())) {
         return (DataSource) context.getBean(config.getDataSource());
     } else {
         if (context.containsBean(DEF_DATASOURCE_NAME)) {
```

`org.springframework.util.StringUtils` import 한 줄을 함께 더했습니다.

### 영향 범위

동작이 달라지는 입력은 설정의 `dataSource` 가 빈 문자열이거나 공백뿐인 경우입니다. 값이 있으면 종전과 같고, `null` 이면 종전에도 폴백했습니다. 빈 문자열은 앞서 본 대로 예외가 되므로, 새로 폴백을 타는 입력은 이전에 기동을 못 하던 입력입니다.

`hasText` 는 `"   "` 도 값 없음으로 봅니다. 공백을 bean 이름으로 쓰던 설정이라면 동작이 달라지는데, Spring bean 이름 관례상 현실적이지 않다고 보았습니다. `fdl.security` 쪽 `ObjectUtils.isEmpty` 는 이 값을 이름으로 쓰므로 두 모듈의 공백 처리가 미세하게 갈리는데, 표기 통일은 이 수정 밖의 일로 보았습니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

`DataSourceFactoryBeanBlankNameTest` 2건을 더했습니다. 하나는 팩토리빈이 폴백하는지, 하나는 `dataSource=` 를 담은 설정 파일로 `EgovAccessConfiguration` 이 기동하는지 봅니다. 기동 쪽은 `config.getDataSource()` 가 정말 빈 문자열인지도 함께 고정해, 재현 전제가 무너지면 테스트가 알리도록 했습니다.

수정을 도로 빼면 둘 다 실패합니다.

```
$ mvn -pl Foundation/org.egovframe.rte.fdl.access test -Dtest=DataSourceFactoryBeanBlankNameTest
[ERROR]   DataSourceFactoryBeanBlankNameTest.blankDataSourceNameFallsBackToDefaultBean:94 Unexpected exception thrown: org.springframework.beans.factory.NoSuchBeanDefinitionException: No bean named '' available
[ERROR]   DataSourceFactoryBeanBlankNameTest.contextStartsWithBlankDataSourceName:123 Unexpected exception thrown: org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'egovAccessDao' defined in org.egovframe.rte.fdl.access.config.EgovAccessConfiguration: ... Factory method 'egovAccessDao' threw exception with message: Error creating bean with name 'accessDataSourceFactoryBean': FactoryBean threw exception on object creation
[ERROR] Tests run: 2, Failures: 2, Errors: 0, Skipped: 0
```

수정 후 모듈 전체입니다.

```
$ mvn -pl Foundation/org.egovframe.rte.fdl.access test
[INFO] Tests run: 13, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

화면이 없는 실행환경 모듈이라 첨부하지 않았습니다.
