### PR TITLE
fix: ContentHandlerImpl 의 요소 시작·종료 로그가 안내 문구를 잃는 문제 수정

### DIFF
--- a/Foundation/org.egovframe.rte.fdl.xml/src/main/java/org/egovframe/rte/fdl/xml/impl/ContentHandlerImpl.java
+++ b/Foundation/org.egovframe.rte.fdl.xml/src/main/java/org/egovframe/rte/fdl/xml/impl/ContentHandlerImpl.java
@@ -68,7 +68,7 @@ public class ContentHandlerImpl implements ContentHandler {
      * @param name      - 전치수식자를 가지는 XML 1.0 수식명. 수식명을 사용할 수 없는 경우는 공문자열
      */
     public void endElement(String uri, String localName, String name) {
-        LOGGER.debug(name, "{}이 종료하였습니다.");
+        LOGGER.debug("{}이 종료하였습니다.", name);
     }
 
     /**
@@ -129,7 +129,7 @@ public class ContentHandlerImpl implements ContentHandler {
      * @param name      - 전치수식자 첨부의 수식명
      */
     public void startElement(String uri, String localName, String name, Attributes atts) {
-        LOGGER.debug(name, "{}이 시작되었습니다.");
+        LOGGER.debug("{}이 시작되었습니다.", name);
     }
 
     /**

--- a/Foundation/org.egovframe.rte.fdl.xml/src/test/java/org/egovframe/rte/fdl/xml/impl/ContentHandlerLogMessageTest.java
+++ b/Foundation/org.egovframe.rte.fdl.xml/src/test/java/org/egovframe/rte/fdl/xml/impl/ContentHandlerLogMessageTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2008-2024 MOIS(Ministry of the Interior and Safety).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.egovframe.rte.fdl.xml.impl;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.Logger;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.appender.AbstractAppender;
+import org.apache.logging.log4j.core.config.Property;
+import org.egovframe.rte.fdl.xml.EgovSAXValidatorService;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * ContentHandlerImpl 이 남기는 로그 메시지 검증
+ */
+public class ContentHandlerLogMessageTest {
+
+    /**
+     * SAX 파싱 중 ContentHandlerImpl 이 남긴 메시지를 모으는 Appender
+     */
+    private static class CapturingAppender extends AbstractAppender {
+
+        private final List<String> messages = new ArrayList<>();
+
+        CapturingAppender() {
+            super("contentHandlerCapture", null, null, true, Property.EMPTY_ARRAY);
+        }
+
+        @Override
+        public void append(LogEvent event) {
+            messages.add(event.getMessage().getFormattedMessage());
+        }
+    }
+
+    /**
+     * 요소의 시작과 종료 로그에 요소명과 안내 문구가 모두 남아야 한다.
+     */
+    @Test
+    public void elementLogKeepsBothNameAndText() throws Exception {
+        LoggerContext context = (LoggerContext) LogManager.getContext(false);
+        Logger logger = context.getLogger(ContentHandlerImpl.class.getName());
+        CapturingAppender appender = new CapturingAppender();
+        appender.start();
+        logger.addAppender(appender);
+
+        try {
+            EgovSAXValidatorService saxValidator = new EgovSAXValidatorService();
+            saxValidator.setXML("<person/>");
+            saxValidator.parse(false);
+        } finally {
+            logger.removeAppender(appender);
+            appender.stop();
+        }
+
+        assertEquals(
+                List.of("XML이 시작되었습니다.", "person이 시작되었습니다.", "person이 종료하였습니다.", "XML이 종료되었습니다."),
+                appender.messages);
+    }
+
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

`ContentHandlerImpl` 의 `startElement`(:132)·`endElement`(:71) 이 slf4j 에 포맷 문자열과 값을 뒤바꿔 넘깁니다.

```java
LOGGER.debug(name, "{}이 시작되었습니다.");
```

slf4j 는 첫 인자를 포맷으로 봅니다. 요소명에는 `{}` 가 없어 채울 자리가 없고, 뒤에 온 안내 문구는 들어갈 곳이 없어 버려집니다. 남는 것은 요소명뿐입니다.

`<person/>` 을 `EgovSAXValidatorService.parse(false)` 로 파싱했을 때 로거에 실제로 나간 메시지입니다.

```
수정 전: XML이 시작되었습니다. / person / person / XML이 종료되었습니다.
수정 후: XML이 시작되었습니다. / person이 시작되었습니다. / person이 종료하였습니다. / XML이 종료되었습니다.
```

문구 취향 문제가 아니라 호출자가 넘긴 인자 하나가 폐기되는 것이고, 문서 단위 이벤트와 요소 단위 이벤트가 같은 클래스 안에서 갈립니다. 같은 클래스의 `startDocument`(:121)·`endDocument`(:60) 는 `"XML이 시작되었습니다."` / `"XML이 종료되었습니다."` 를 그대로 남깁니다.

모듈 전체로 넓혀도 어긋나는 것은 이 두 줄뿐입니다. 인자를 두 개 이상 넘기는 `LOGGER.debug` 는 이 모듈 `src/main` 에 7곳이고(`git grep -c 'LOGGER\.debug(.*,' -- Foundation/org.egovframe.rte.fdl.xml/src/main`), 그중 5곳 — `AbstractXMLUtility`:334·:339, `EgovDOMValidatorService`:131, `EgovSAXValidatorService`:117, `EgovDOMFactoryServiceImpl`:72 — 은 포맷 문자열이 첫 인자입니다.

죽은 코드는 아닙니다. `EgovSAXValidatorService.parse(boolean)` 이 :97-98 에서 이 핸들러를 SAX 파서에 걸어 두므로 파싱되는 요소마다 두 메서드가 불립니다.

### AS-IS / TO-BE

형제 호출에 인자 순서를 맞췄습니다.

```diff
 public void endElement(String uri, String localName, String name) {
-    LOGGER.debug(name, "{}이 종료하였습니다.");
+    LOGGER.debug("{}이 종료하였습니다.", name);
 }

 public void startElement(String uri, String localName, String name, Attributes atts) {
-    LOGGER.debug(name, "{}이 시작되었습니다.");
+    LOGGER.debug("{}이 시작되었습니다.", name);
 }
```

### 영향 범위

인자 순서 두 줄입니다. 문구·로그 레벨·조건 분기는 그대로이고, 두 메서드는 로깅 외에 하는 일이 없습니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

`ContentHandlerLogMessageTest` 를 더했습니다. 핸들러를 직접 부르지 않고 `EgovSAXValidatorService` 로 실제 파싱을 통과시킨 뒤, `ContentHandlerImpl` 로거에 잠시 붙인 appender 가 모은 메시지를 목록으로 단언합니다. 도달 경로까지 함께 보이려고 이 형태를 택했습니다.

인자 순서를 도로 되돌리면 실패합니다.

```
$ mvn -o test -pl Foundation/org.egovframe.rte.fdl.xml -Dtest=ContentHandlerLogMessageTest
[ERROR] ContentHandlerLogMessageTest.elementLogKeepsBothNameAndText:74 expected: <[XML이 시작되었습니다., person이 시작되었습니다., person이 종료하였습니다., XML이 종료되었습니다.]> but was: <[XML이 시작되었습니다., person, person, XML이 종료되었습니다.]>
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0
[INFO] BUILD FAILURE
```

수정 후 모듈 전체입니다. 기존 3건은 그대로입니다.

```
$ mvn -o test -pl Foundation/org.egovframe.rte.fdl.xml
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

화면이 없는 실행환경 모듈이라 첨부하지 않았습니다.
