### PR TITLE
fix: DOM 검증기가 스키마 등록 여부를 XML 파일 유무로 판단하는 문제 수정

### DIFF
--- a/Foundation/org.egovframe.rte.fdl.xml/src/main/java/org/egovframe/rte/fdl/xml/EgovDOMValidatorService.java
+++ b/Foundation/org.egovframe.rte.fdl.xml/src/main/java/org/egovframe/rte/fdl/xml/EgovDOMValidatorService.java
@@ -85,7 +85,7 @@ public class EgovDOMValidatorService extends AbstractXMLUtility {
             factory.setNamespaceAware(true);
             factory.setValidating(isValid);
 
-            if (!ObjectUtils.isEmpty(getXMLFile())) {
+            if (!ObjectUtils.isEmpty(getSCHEMAFile())) {
                 factory.setAttribute("http://java.sun.com/xml/jaxp/properties/schemaLanguage", "http://www.w3.org/2001/XMLSchema");
                 factory.setAttribute("http://java.sun.com/xml/jaxp/properties/schemaSource", getSCHEMAFile());
             }

--- a/Foundation/org.egovframe.rte.fdl.xml/src/test/java/org/egovframe/rte/fdl/xml/EgovDOMValidatorSchemaSourceTest.java
+++ b/Foundation/org.egovframe.rte.fdl.xml/src/test/java/org/egovframe/rte/fdl/xml/EgovDOMValidatorSchemaSourceTest.java
@@ -1,0 +1,86 @@
+package org.egovframe.rte.fdl.xml;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+/**
+ * {@link EgovDOMValidatorService}가 스키마 등록 여부를 스키마 파일로 판단하는지 검증한다.
+ *
+ * <p>형제인 {@link EgovSAXValidatorService}는 {@code getSCHEMAFile()}이 있을 때만 스키마 검증을
+ * 켠다. DOM 쪽은 같은 자리에서 {@code getXMLFile()}을 보므로, XML을 파일로 주면 스키마가 없어도
+ * 스키마 모드가 켜지고 문자열로 주면 스키마를 줘도 등록되지 않는다. XML을 어떤 형태로 주는지는
+ * 검증 방식을 바꾸는 조건이 아니므로, 두 입력 형태의 결과가 같은지로 확인한다.</p>
+ */
+class EgovDOMValidatorSchemaSourceTest {
+
+    private static final String XML = "<person><name>x</name></person>";
+
+    private static final String XSD =
+            "<?xml version=\"1.0\"?>\n"
+                    + "<xs:schema xmlns:xs=\"http://www.w3.org/2001/XMLSchema\">\n"
+                    + "  <xs:element name=\"person\">\n"
+                    + "    <xs:complexType><xs:sequence>\n"
+                    + "      <xs:element name=\"name\" type=\"xs:string\"/>\n"
+                    + "    </xs:sequence></xs:complexType>\n"
+                    + "  </xs:element>\n"
+                    + "</xs:schema>\n";
+
+    /**
+     * parse(true) 결과를 비교 가능한 문자열로 만든다. 정상 종료면 반환값, 예외면 예외 타입과 메시지다.
+     */
+    private String outcome(EgovDOMValidatorService validator) {
+        try {
+            return "returned " + validator.parse(true);
+        } catch (Exception e) {
+            return e.getClass().getName() + ": " + e.getMessage();
+        }
+    }
+
+    private Path write(Path dir, String name, String content) throws Exception {
+        Path path = dir.resolve(name);
+        Files.write(path, content.getBytes(StandardCharsets.UTF_8));
+        return path;
+    }
+
+    @Test
+    @DisplayName("스키마 파일이 없으면 XML을 파일로 줘도 스키마 검증이 켜지지 않는다")
+    void schemaModeStaysOffWithoutSchemaFile(@TempDir Path tempDir) throws Exception {
+        Path xmlFile = write(tempDir, "person.xml", XML);
+
+        EgovDOMValidatorService fromFile = new EgovDOMValidatorService();
+        fromFile.setXMLFile(xmlFile.toString());
+
+        EgovDOMValidatorService fromString = new EgovDOMValidatorService();
+        fromString.setXML(XML);
+
+        String fileOutcome = outcome(fromFile);
+        // cvc-* 는 XML Schema 검증 오류 코드다. 스키마를 준 적이 없으므로 나오면 안 된다.
+        assertFalse(fileOutcome.contains("cvc-"), "스키마 없이 스키마 검증이 수행되었다: " + fileOutcome);
+        assertEquals(outcome(fromString), fileOutcome);
+    }
+
+    @Test
+    @DisplayName("스키마 파일을 주면 XML을 문자열로 줘도 스키마가 등록된다")
+    void schemaFileIsRegisteredForStringXml(@TempDir Path tempDir) throws Exception {
+        Path xmlFile = write(tempDir, "person.xml", XML);
+        Path schemaFile = write(tempDir, "person.xsd", XSD);
+
+        EgovDOMValidatorService fromFile = new EgovDOMValidatorService();
+        fromFile.setXMLFile(xmlFile.toString());
+        fromFile.setSCHEMAFile(schemaFile.toString());
+
+        EgovDOMValidatorService fromString = new EgovDOMValidatorService();
+        fromString.setXML(XML);
+        fromString.setSCHEMAFile(schemaFile.toString());
+
+        assertEquals(outcome(fromFile), outcome(fromString));
+    }
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

`EgovDOMValidatorService.parse()` 가 JAXP 스키마 검증을 켜는 조건과 그때 넘기는 값이 서로 다른 프로퍼티입니다.

```java
// EgovDOMValidatorService.java:88
if (!ObjectUtils.isEmpty(getXMLFile())) {
    factory.setAttribute("http://java.sun.com/xml/jaxp/properties/schemaLanguage", "http://www.w3.org/2001/XMLSchema");
    factory.setAttribute("http://java.sun.com/xml/jaxp/properties/schemaSource", getSCHEMAFile());
}
```

형제인 `EgovSAXValidatorService` 는 같은 자리에서 스키마 파일이 있는지만 봅니다.

```java
// EgovSAXValidatorService.java:91
if (getSCHEMAFile() != null) {
    parser.setFeature("http://apache.org/xml/features/validation/schema", true);
    parser.setFeature("http://apache.org/xml/features/validation/schema-full-checking", true);
    parser.setProperty("http://apache.org/xml/properties/schema/external-noNamespaceSchemaLocation", getSCHEMAFile());
}
```

XML 을 파일로 주는지 문자열로 주는지는 스키마 검증 여부를 정하는 조건이 아니라서, DOM 쪽은 두 방향으로 어긋납니다.

스키마를 준 적이 없는데 스키마 검증이 켜집니다. XML 을 `setXMLFile()` 로 주고 `parse(true)` 를 부르면 `cvc-elt.1.a: 'person' 요소의 선언을 찾을 수 없습니다` 가 나옵니다. `cvc-` 는 XML Schema 검증 오류 코드입니다. 조건이 `getXMLFile()` 이라, 같은 XML 을 `setXML()` 로 주면 이 검증은 켜지지 않습니다.

반대로 스키마를 줘도 무시됩니다. XML 을 `setXML()` 로 주고 `setSCHEMAFile()` 을 부른 뒤 `parse(true)` 를 부르면 스키마가 등록되지 않아 `문서가 부적합함: 문법을 찾을 수 없습니다` 가 나옵니다. 같은 입력에서 SAX 쪽은 스키마 등록을 시도합니다.

### AS-IS / TO-BE

값으로 이미 쓰고 있는 프로퍼티를 조건에도 씁니다. 형제 SAX 쪽과 같은 조건입니다.

```diff
-            if (!ObjectUtils.isEmpty(getXMLFile())) {
+            if (!ObjectUtils.isEmpty(getSCHEMAFile())) {
```

### 영향 범위

저장소 안에서 `setSCHEMAFile()` 을 부르는 코드는 이 PR 이 추가한 테스트뿐입니다.

스키마를 주지 않고 XML 을 파일로 주던 호출자는 `parse(true)` 에서 `cvc-` 계열 스키마 오류 대신, 같은 XML 을 문자열로 줬을 때와 같은 결과를 받습니다. 둘 다 검증에 실패하는 입력이라 성공·실패 판정은 달라지지 않습니다.

스키마를 주면서 XML 을 문자열로 주던 호출자는 지금까지 스키마가 무시됐으므로, 앞으로는 XML 을 파일로 줬을 때와 같은 결과가 됩니다. 다만 이 클래스는 XXE 방지로 외부 개체 해석을 막고 있어(`:94-95`, `:147-148`), 스키마 등록을 시도하면 스키마 로딩 단계에서 `SAXException: External entity resolution is disabled for security (XXE prevention)` 로 끝납니다. 이 호출자가 받는 예외가 `ValidatorException` 에서 `SAXException` 으로 바뀌고, 스키마 검증이 실제로 동작하게 되는 것은 아닙니다. XXE 설정과 스키마 등록이 부딪히는 것은 SAX 쪽도 같아 이 수정 밖의 일로 두었습니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

XML 을 파일로 준 결과와 문자열로 준 결과가 같은지 비교하는 테스트를 더했습니다. 로케일에 따라 메시지가 달라지므로 문자열을 그대로 단정하지 않고 두 실행 결과를 서로 비교했고, 스키마를 주지 않은 경우는 `cvc-` 코드가 나오는지로 봅니다.

수정을 되돌리면 두 건 모두 실패합니다.

```
$ mvn -o test -pl Foundation/org.egovframe.rte.fdl.xml -Dtest=EgovDOMValidatorSchemaSourceTest
[ERROR] EgovDOMValidatorSchemaSourceTest.schemaModeStaysOffWithoutSchemaFile:66 스키마 없이 스키마 검증이 수행되었다: org.egovframe.rte.fdl.xml.exception.ValidatorException: Parsing error:  cvc-elt.1.a: 'person' 요소의 선언을 찾을 수 없습니다.<br/> ==> expected: <false> but was: <true>
[ERROR] Tests run: 2, Failures: 2, Errors: 0, Skipped: 0
```

수정 후 모듈 전체입니다. 기존 3건은 그대로 통과합니다.

```
$ mvn -o test -pl Foundation/org.egovframe.rte.fdl.xml
[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

화면이 없는 실행환경 모듈이라 첨부하지 않았습니다.
