### PR TITLE
fix: setParameter 가 실패한 LobCreator 를 닫지도 등록하지도 않는 문제 수정

### DIFF
--- a/Persistence/org.egovframe.rte.psl.dataaccess/src/main/java/org/egovframe/rte/psl/orm/ibatis/support/AbstractLobTypeHandler.java
+++ b/Persistence/org.egovframe.rte.psl.dataaccess/src/main/java/org/egovframe/rte/psl/orm/ibatis/support/AbstractLobTypeHandler.java
@@ -97,11 +97,17 @@ public abstract class AbstractLobTypeHandler extends BaseTypeHandler {
         }
 
         final LobCreator lobCreator = this.lobHandler.getLobCreator();
+        boolean succeeded = false;
 
         try {
             setParameterInternal(ps, i, parameter, jdbcType, lobCreator);
+            succeeded = true;
         } catch (IOException ex) {
             throw new SQLException("I/O errors during LOB access: " + ex.getMessage());
+        } finally {
+            if (!succeeded) {
+                lobCreator.close();
+            }
         }
 
         TransactionSynchronizationManager.registerSynchronization(new LobCreatorSynchronization(lobCreator));

--- a/Persistence/org.egovframe.rte.psl.dataaccess/src/test/java/org/egovframe/rte/psl/orm/ibatis/support/LobCreatorCleanupTest.java
+++ b/Persistence/org.egovframe.rte.psl.dataaccess/src/test/java/org/egovframe/rte/psl/orm/ibatis/support/LobCreatorCleanupTest.java
@@ -1,0 +1,83 @@
+package org.egovframe.rte.psl.orm.ibatis.support;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.jdbc.support.lob.DefaultLobHandler;
+import org.springframework.jdbc.support.lob.LobCreator;
+import org.springframework.jdbc.support.lob.LobHandler;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Proxy;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * setParameter 가 만든 LobCreator 는 성공하든 실패하든 정리돼야 한다.
+ *
+ * <p>드라이버가 파라미터 설정을 거부하면 setParameterInternal 이 SQLException 을 던지는데,
+ * 이때도 LobCreator.close 가 불리거나 close 를 부르는 동기화가 등록돼 있어야
+ * 임시 LOB 이 남지 않는다.</p>
+ */
+public class LobCreatorCleanupTest {
+
+    @Test
+    public void testLobCreatorIsClosedWhenSetParameterFails() {
+        AtomicInteger closeCount = new AtomicInteger();
+        LobHandler lobHandler = countingLobHandler(closeCount);
+        BlobByteArrayTypeHandler typeHandler = new BlobByteArrayTypeHandler(lobHandler);
+        PreparedStatement ps = failingPreparedStatement();
+
+        TransactionSynchronizationManager.initSynchronization();
+        try {
+            assertThrows(SQLException.class,
+                    () -> typeHandler.setParameter(ps, 1, new byte[]{1, 2, 3}, "BLOB"));
+
+            for (TransactionSynchronization synchronization : TransactionSynchronizationManager.getSynchronizations()) {
+                synchronization.beforeCompletion();
+            }
+
+            assertEquals(1, closeCount.get(),
+                    "setParameter 가 실패해도 LobCreator 는 닫혀야 한다");
+        } finally {
+            TransactionSynchronizationManager.clearSynchronization();
+        }
+    }
+
+    private LobHandler countingLobHandler(AtomicInteger closeCount) {
+        LobCreator delegate = new DefaultLobHandler().getLobCreator();
+        LobCreator counting = (LobCreator) Proxy.newProxyInstance(
+                LobCreator.class.getClassLoader(),
+                new Class<?>[]{LobCreator.class},
+                (proxy, method, args) -> {
+                    if ("close".equals(method.getName())) {
+                        closeCount.incrementAndGet();
+                    }
+                    try {
+                        return method.invoke(delegate, args);
+                    } catch (InvocationTargetException ex) {
+                        throw ex.getCause();
+                    }
+                });
+        return (LobHandler) Proxy.newProxyInstance(
+                LobHandler.class.getClassLoader(),
+                new Class<?>[]{LobHandler.class},
+                (proxy, method, args) -> "getLobCreator".equals(method.getName()) ? counting : null);
+    }
+
+    private PreparedStatement failingPreparedStatement() {
+        return (PreparedStatement) Proxy.newProxyInstance(
+                PreparedStatement.class.getClassLoader(),
+                new Class<?>[]{PreparedStatement.class},
+                (proxy, method, args) -> {
+                    if ("setBytes".equals(method.getName())) {
+                        throw new SQLException("데이터 타입이 맞지 않습니다");
+                    }
+                    return null;
+                });
+    }
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

`AbstractLobTypeHandler.setParameter` 가 만든 `LobCreator` 를 실패 경로에서 닫지 않습니다.

```java
final LobCreator lobCreator = this.lobHandler.getLobCreator();          // :99

try {
    setParameterInternal(ps, i, parameter, jdbcType, lobCreator);       // :102
} catch (IOException ex) {
    throw new SQLException("I/O errors during LOB access: " + ex.getMessage());
}

TransactionSynchronizationManager.registerSynchronization(new LobCreatorSynchronization(lobCreator));  // :107
```

성공 경로는 :107 에서 동기화를 등록하고 그 동기화의 `beforeCompletion` 이 :192 에서 `close` 를 부릅니다. 이 클래스에서 `close` 를 부르는 자리는 :192 하나뿐입니다.

실패 경로는 :107 에 닿지 못합니다. `setParameterInternal` 이 `SQLException` 을 던지면 그대로 전파되고 `IOException` 은 :104 에서 `SQLException` 으로 바뀌어 다시 던져집니다. 어느 쪽이든 그 `LobCreator` 는 닫히지도, 나중에 닫아줄 동기화에 등록되지도 않습니다.

클래스 Javadoc(:36-37)이 트랜잭션 동기화를 요구하는 이유를 이렇게 적습니다.

```
For writing LOBs, an active Spring transaction synchronization is required,
to be able to register a synchronization that closes the LobCreator.
```

만든 `LobCreator` 는 닫는다는 자기 선언입니다. 같은 패키지의 형제 `BlobSerializableTypeHandler` 도 `ObjectOutputStream`(:116-117)과 `ObjectInputStream`(:144-145)을 `finally` 로 닫아 실패 경로까지 덮습니다.

이 동기화 클래스의 Javadoc(:173-174)은 "Invokes LobCreator.close to clean up temporary LOBs that might have been created." 입니다. 이 모듈이 쓰는 `spring-jdbc` 의 `DefaultLobHandler` 는 `createTemporaryLob` 을 켜면 `TemporaryLobCreator` 를 돌려주고, 그 `close` 가 만들어 둔 `Blob`·`Clob` 의 `free` 를 부릅니다. 닫히지 않으면 그만큼이 세션에 남습니다. 다만 실제 DB 세션에 남는 LOB 을 측정하지는 못했습니다.

### AS-IS / TO-BE

형제와 같이 `finally` 로 정리하되, 동기화 등록 전에 빠져나가는 경우로 한정했습니다.

```diff
 final LobCreator lobCreator = this.lobHandler.getLobCreator();
+boolean succeeded = false;

 try {
     setParameterInternal(ps, i, parameter, jdbcType, lobCreator);
+    succeeded = true;
 } catch (IOException ex) {
     throw new SQLException("I/O errors during LOB access: " + ex.getMessage());
+} finally {
+    if (!succeeded) {
+        lobCreator.close();
+    }
 }
```

성공 경로에서도 닫지 않는 이유는, `setParameter` 가 돌아온 뒤 실제 실행 시점에 드라이버가 `LobCreator` 가 넘긴 스트림을 읽기 때문입니다. 그 시점을 아는 것은 트랜잭션 동기화이므로 성공 경로는 지금처럼 등록만 하고 넘어갑니다.

### 영향 범위

동작이 달라지는 것은 `setParameterInternal` 이 예외를 던지는 경우뿐이고 성공 경로의 동작은 그대로입니다. 이 `setParameter` 는 `final` 이라 하위 클래스 3종(`BlobByteArrayTypeHandler`, `ClobStringTypeHandler`, `BlobSerializableTypeHandler`)이 모두 이 경로를 씁니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

드라이버가 `PreparedStatement.setBytes` 에서 `SQLException` 을 내도록 해 `BlobByteArrayTypeHandler.setParameter` 를 실제로 태우고 진짜 `DefaultLobCreator` 를 감싼 프록시로 `close` 호출 횟수를 셉니다. 실패 뒤 등록된 동기화의 `beforeCompletion` 까지 모두 실행한 다음 세기 때문에, 직접 닫든 동기화에 등록하든 어느 처방이어도 통과합니다. 미수정 코드는 둘 다 하지 않아 0 회입니다.

수정 전입니다.

```
$ mvn -o test -pl Persistence/org.egovframe.rte.psl.dataaccess -Dtest=LobCreatorCleanupTest -DfailIfNoTests=true
[ERROR]   LobCreatorCleanupTest.testLobCreatorIsClosedWhenSetParameterFails:44 setParameter 가 실패해도 LobCreator 는 닫혀야 한다 ==> expected: <1> but was: <0>
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0
[INFO] BUILD FAILURE
```

수정 후 모듈 전체입니다.

```
$ mvn -o test -pl Persistence/org.egovframe.rte.psl.dataaccess
[INFO] Tests run: 127, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

화면이 없는 실행환경 모듈이라 첨부하지 않았습니다.
