### PR TITLE
fix: getFormatStringWithDate 의 형식 오류 메시지가 입력값 대신 null 을 알리는 문제 수정

### DIFF
--- a/Foundation/org.egovframe.rte.fdl.string/src/main/java/org/egovframe/rte/fdl/string/EgovDateUtil.java
+++ b/Foundation/org.egovframe.rte.fdl.string/src/main/java/org/egovframe/rte/fdl/string/EgovDateUtil.java
@@ -376,7 +376,7 @@ public class EgovDateUtil {
         } else if (date.length() == 17) {
             format = "yyyyMMddHHmmssSSS";
         } else {
-            throw new ParseException(" wrong date format!:\"" + format + "\"", 0);
+            throw new ParseException(" wrong date format!:\"" + date + "\"", 0);
         }
 
         return format;

--- a/Foundation/org.egovframe.rte.fdl.string/src/test/java/org/egovframe/rte/fdl/string/EgovDateUtilTest.java
+++ b/Foundation/org.egovframe.rte.fdl.string/src/test/java/org/egovframe/rte/fdl/string/EgovDateUtilTest.java
@@ -300,6 +300,18 @@ public class EgovDateUtilTest {
     }
 
     /**
+     * [Flow #-6-1] Negative Case : 인식하지 못한 길이의 일자 문자열에 대한 예외 메시지 확인
+     */
+    @Test
+    public void testTimeCountUnknownLengthMessage() {
+        // 길이가 4, 8, 12, 14, 17 중 어느 것도 아니면 형식을 정할 수 없어 ParseException 이 난다.
+        ParseException e = assertThrows(ParseException.class, () -> EgovDateUtil.getTimeCount("2009040112", "2009040113"));
+
+        // 형제인 dateFormatCheck() 과 같이 어긋난 입력값을 알려야 한다.
+        assertTrue(e.getMessage().contains("2009040112"), "예외 메시지: " + e.getMessage());
+    }
+
+    /**
      * [Flow #-7] Positive Case : 시작일자와 종료일자 사이의 해당 요일이 몇번 있는지 계산한다.
      */
     @Test


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

`EgovDateUtil.getFormatStringWithDate(String)` 가 길이를 알아보지 못한 입력에 던지는 예외 메시지가, 입력값이 아니라 `null` 을 알립니다.

```java
// EgovDateUtil.java:365
protected static String getFormatStringWithDate(String date) throws ParseException {
    String format = null;

    if (date.length() == 4) {
        format = "HHmm";
    } else if (date.length() == 8) {
    ...
    } else if (date.length() == 17) {
        format = "yyyyMMddHHmmssSSS";
    } else {
        throw new ParseException(" wrong date format!:\"" + format + "\"", 0);
    }
```

`format` 은 366줄에서 `null` 로 초기화되고 368~377줄의 다섯 분기에서만 값을 받습니다. `else` 에 닿았다는 사실이 곧 `format` 이 `null` 이라는 뜻이라, 이 메시지는 어떤 입력을 주든 ` wrong date format!:"null"` 입니다. 간헐적으로 `null` 이 찍히는 것이 아니라 상수입니다.

같은 클래스의 `throw` 여섯 곳을 전수로 봤습니다.

```
:332  "date string to check is null"                          어느 인자가 null 인지 지목
:336  "format string to check date is null"                   어느 인자가 null 인지 지목
:344  " wrong date:\"" + source + "\" with format \"" ...      어긋난 입력값을 그대로
:348  "Out of bound date:\"" + source + "\" with format \"" ... 어긋난 입력값을 그대로
:379  " wrong date format!:\"" + format + "\""                 입력 date 를 버림
:432  "... 이어야 합니다. 입력값: " + yoil                       어긋난 입력값을 그대로
```

셋은 어긋난 입력값을 싣고 둘은 어느 인자가 `null` 인지 지목합니다. 대입되지 않은 지역변수를 메시지에 담는 곳은 379줄 하나입니다.

공개 경로는 `public static long getTimeCount(String from, String to)`(388줄) 입니다. 형식 문자열 없이 부르는 이 오버로드가 389줄에서 `from` 으로 형식을 정하므로, 길이가 4·8·12·14·17 이 아닌 `from` 을 주면 이 `else` 로 떨어집니다. 형식을 인자로 받는 3인자 오버로드(396줄)는 이 메서드를 거치지 않습니다.

### AS-IS / TO-BE

```diff
     } else {
-        throw new ParseException(" wrong date format!:\"" + format + "\"", 0);
+        throw new ParseException(" wrong date format!:\"" + date + "\"", 0);
     }
```

### 영향 범위

예외 타입과 오프셋(0), 던지는 시점은 그대로이고 메시지 문자열만 달라집니다. 저장소 안에서 이 문자열을 대조하는 코드는 없습니다 — `git grep 'wrong date format'` 이 이 `throw` 한 줄만 냅니다.

메시지에 실리는 값은 형식 판별에 이미 실패한 일자 문자열입니다. 형제인 `dateFormatCheck()` 가 344·348줄에서 같은 성격의 값을 그대로 싣고 있어 드러나는 정보의 성격은 달라지지 않습니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

기존 `EgovDateUtilTest` 에 회귀 테스트를 더했습니다. `getTimeCount("2009040112", "2009040113")` 의 `from` 은 길이가 10이라 형식을 정할 수 없습니다.

수정을 되돌리면 실패합니다.

```
$ mvn -o test -pl Foundation/org.egovframe.rte.fdl.string -Dtest=EgovDateUtilTest#testTimeCountUnknownLengthMessage -DfailIfNoTests=false
[ERROR] EgovDateUtilTest.testTimeCountUnknownLengthMessage:311 예외 메시지:  wrong date format!:"null" ==> expected: <true> but was: <false>
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0
```

같은 상태로 모듈 전체를 돌리면 기존 59건은 모두 통과하고 이 신규 1건만 실패합니다.

수정 후 모듈 전체입니다.

```
$ mvn -o test -pl Foundation/org.egovframe.rte.fdl.string
[INFO] Tests run: 60, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

화면이 없는 실행환경 모듈이라 첨부하지 않았습니다.
