### PR TITLE
fix: 구분자를 생략한 getTokens 가 원소 타입을 감춰 호출자가 캐스팅해야 하는 문제 수정

### DIFF
--- a/Foundation/org.egovframe.rte.fdl.string/src/main/java/org/egovframe/rte/fdl/string/EgovStringUtil.java
+++ b/Foundation/org.egovframe.rte.fdl.string/src/main/java/org/egovframe/rte/fdl/string/EgovStringUtil.java
@@ -976,7 +976,7 @@ public final class EgovStringUtil {
      * @param lst using commas as separators
      * @return List result
      */
-    public static List<?> getTokens(String lst) {
+    public static List<String> getTokens(String lst) {
         return getTokens(lst, ",");
     }
 

--- a/Foundation/org.egovframe.rte.fdl.string/src/test/java/org/egovframe/rte/fdl/string/EgovStringUtilTest.java
+++ b/Foundation/org.egovframe.rte.fdl.string/src/test/java/org/egovframe/rte/fdl/string/EgovStringUtilTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.time.Duration;
+import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -453,6 +454,18 @@ public class EgovStringUtilTest {
         String str = "a,b,c,d";
         // 2. get token list
         assertEquals(4, EgovStringUtil.getTokens(str).size());
+    }
+
+    /**
+     * 구분자를 생략한 getTokens는 구분자를 넘기는 오버로드에 그대로 위임하므로
+     * 두 오버로드의 결과는 같고, 원소 타입도 String으로 받을 수 있어야 한다.
+     */
+    @Test
+    public void testGetTokensDefaultSeparatorElementType() {
+        String str = "a,b,c,d";
+        List<String> tokens = EgovStringUtil.getTokens(str);
+        assertEquals(EgovStringUtil.getTokens(str, ","), tokens);
+        assertEquals("a", tokens.get(0));
     }
 
     /**


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

`EgovStringUtil` 의 `getTokens` 두 오버로드가 같은 객체를 돌려주면서 반환 타입만 다릅니다.

구분자를 받는 쪽은 `ArrayList<String>` 에 `st.nextToken().trim()` 결과만 담아 `List<String>` 으로 선언합니다. 구분자를 생략하는 쪽은 그 메서드에 그대로 위임하는데, 반환 타입이 `List<?>` 입니다.

```java
// EgovStringUtil.java:956
public static List<String> getTokens(String lst, String separator) {
    List<String> tokens = new ArrayList<String>();

// EgovStringUtil.java:979
public static List<?> getTokens(String lst) {
    return getTokens(lst, ",");
}
```

그래서 구분자를 생략한 쪽만 호출자가 원소를 String 으로 쓰지 못합니다. `List<String> tokens = EgovStringUtil.getTokens(str);` 가 컴파일되지 않고, 캐스팅으로 우회하면 unchecked 경고가 남습니다. 같은 목록을 주는 `getTokens(str, ",")` 에는 이 제약이 없습니다.

이 클래스에서 와일드카드를 쓰는 자리는 979줄 하나뿐이고, 나머지 제네릭 선언은 모두 `List<String>` 입니다.

```
$ git show origin/main:.../EgovStringUtil.java | grep -nE "List<|Map<|<\?>"
956:    public static List<String> getTokens(String lst, String separator) {
957:        List<String> tokens = new ArrayList<String>();
979:    public static List<?> getTokens(String lst) {
```

### AS-IS / TO-BE

위임받는 메서드의 선언에 맞췄습니다.

```diff
-public static List<?> getTokens(String lst) {
+public static List<String> getTokens(String lst) {
     return getTokens(lst, ",");
 }
```

### 영향 범위

public API 의 시그니처 변경이라 호환성을 따로 확인했습니다.

바이너리 호환은 유지됩니다. `javap -p -s` 로 본 메서드 디스크립터가 수정 전후 같아서, 이미 컴파일된 호출자는 재컴파일 없이 그대로 링크됩니다. 바뀌는 것은 Signature 속성뿐입니다.

```
수정 전  public static java.util.List<?> getTokens(java.lang.String);
           descriptor: (Ljava/lang/String;)Ljava/util/List;
수정 후  public static java.util.List<java.lang.String> getTokens(java.lang.String);
           descriptor: (Ljava/lang/String;)Ljava/util/List;
```

소스 호환도 `List<?> l = getTokens(s)` 와 `(List<String>) getTokens(s)` 가 모두 그대로 컴파일됩니다. 막히는 형태는 `(List<Integer>) getTokens(s)` 처럼 String 이 아닌 타입 인자로 캐스팅해 둔 코드인데, 실제 원소가 String 이므로 그런 코드는 이미 런타임에 `ClassCastException` 이 납니다.

저장소 안에서 이 오버로드를 부르는 곳은 기존 테스트 `testGetTokens` 한 줄뿐이고 `size()` 만 씁니다. 다만 `mvn install` 을 돌리지 않아 다른 모듈을 재컴파일해 확인하지는 못했습니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

`EgovStringUtilTest` 에 두 오버로드의 결과가 같은지와 원소를 String 으로 받을 수 있는지 보는 케이스를 더했습니다.

수정 전에는 이 테스트가 컴파일 단계에서 걸립니다.

```
$ mvn -o test -pl Foundation/org.egovframe.rte.fdl.string -Dtest=EgovStringUtilTest
[ERROR] .../EgovStringUtilTest.java:[466,55] incompatible types: java.util.List<capture#1 of ?> cannot be converted to java.util.List<java.lang.String>
[INFO] 1 error
[INFO] BUILD FAILURE
```

수정 후 모듈 전체입니다.

```
$ mvn -o test -pl Foundation/org.egovframe.rte.fdl.string
[INFO] Tests run: 60, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

화면이 없는 실행환경 모듈이라 첨부하지 않았습니다.
