### PR TITLE
chore: spring-orm 이 그대로 제공하는 psl.orm 예외 2종에 @Deprecated 표기

### DIFF
--- a/Persistence/org.egovframe.rte.psl.dataaccess/src/main/java/org/egovframe/rte/psl/orm/ObjectOptimisticLockingFailureException.java
+++ b/Persistence/org.egovframe.rte.psl.dataaccess/src/main/java/org/egovframe/rte/psl/orm/ObjectOptimisticLockingFailureException.java
@@ -23,8 +23,11 @@ import org.springframework.dao.OptimisticLockingFailureException;
  *
  * @author Juergen Hoeller
  * @since 13.10.2003
+ * @deprecated in favor of {@link org.springframework.orm.ObjectOptimisticLockingFailureException org.springframework.orm.ObjectOptimisticLockingFailureException},
+ * which spring-orm still provides with the same API
  */
 @SuppressWarnings("serial")
+@Deprecated
 public class ObjectOptimisticLockingFailureException extends OptimisticLockingFailureException {
 
     private Object persistentClass;

--- a/Persistence/org.egovframe.rte.psl.dataaccess/src/main/java/org/egovframe/rte/psl/orm/ObjectRetrievalFailureException.java
+++ b/Persistence/org.egovframe.rte.psl.dataaccess/src/main/java/org/egovframe/rte/psl/orm/ObjectRetrievalFailureException.java
@@ -23,8 +23,11 @@ import org.springframework.dao.DataRetrievalFailureException;
  *
  * @author Juergen Hoeller
  * @since 13.10.2003
+ * @deprecated in favor of {@link org.springframework.orm.ObjectRetrievalFailureException org.springframework.orm.ObjectRetrievalFailureException},
+ * which spring-orm still provides with the same API
  */
 @SuppressWarnings("serial")
+@Deprecated
 public class ObjectRetrievalFailureException extends DataRetrievalFailureException {
 
     private Object persistentClass;


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [ ] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [X] 기타 Others

## 수정된 소스 내용 Modified source

`org.egovframe.rte.psl.orm` 은 Spring 의 `org.springframework.orm` 을 옮겨 온 패키지입니다. `psl/orm/package-info.java:2` 가 그대로 남아 있습니다.

```
 * Root package for Spring's O/R Mapping integration classes.
```

그 아래 `psl.orm.ibatis` 트리의 공개 타입 아홉 개는 전부 `@Deprecated` 입니다.

```
$ git grep -l '^@Deprecated' -- '*/psl/orm/ibatis/*' | wc -l
9
$ git grep -l 'as of Spring 3.2' -- '*/psl/orm/ibatis/*' | wc -l
9
```

아홉 개가 공통으로 들고 있는 사유의 첫 줄은 이렇습니다.

```
 * @deprecated as of Spring 3.2, in favor of the native Spring support
```

Spring 이 `org.springframework.orm.ibatis` 를 걷어낸 것이 그 사유입니다. 그런데 같은 패키지 뿌리의 `ObjectRetrievalFailureException` 과 `ObjectOptimisticLockingFailureException` 에는 표기가 없습니다. 이 둘은 Spring 이 걷어낸 적이 없어서 형제 아홉 개보다 중복이 더 분명한 쪽입니다.

이 모듈 `pom.xml:65` 가 `spring-orm` 을 스코프 없이(= compile) 선언하고 그 `spring-orm 6.2.11` 이 같은 이름의 클래스를 지금도 담고 있습니다.

```
$ javap -cp spring-orm-6.2.11.jar org.springframework.orm.ObjectRetrievalFailureException | grep 'public class'
public class org.springframework.orm.ObjectRetrievalFailureException extends org.springframework.dao.DataRetrievalFailureException {
```

상위 클래스가 사본과 같고 공개 멤버도 하나씩 대응합니다. `ObjectRetrievalFailureException` 은 양쪽 다 생성자 다섯 개, `ObjectOptimisticLockingFailureException` 은 양쪽 다 일곱 개이고, 접근자는 둘 다 `getPersistentClass()`·`getPersistentClassName()`·`getIdentifier()` 셋입니다.

저장소 안에서 이 두 타입을 import·throw·catch 하는 곳은 없습니다. 자기 선언 파일을 빼면 README 의 디렉터리 목록 두 줄이 남는 전부입니다.

```
$ git grep -n 'ObjectRetrievalFailureException\|ObjectOptimisticLockingFailureException' | grep -v 'psl/orm/Object'
Persistence/org.egovframe.rte.psl.dataaccess/README.md:37:    ├── ObjectRetrievalFailureException.java
Persistence/org.egovframe.rte.psl.dataaccess/README.md:38:    ├── ObjectOptimisticLockingFailureException.java
```

제거가 아니라 표기로 간 이유입니다. 저장소 안에 참조가 없더라도 이미 배포된 아티팩트의 public 타입이라 바깥 코드의 참조까지는 알 수 없고 삭제는 소스·바이너리 비호환이 됩니다. 이 저장소에서 `main` 의 공개 소스가 지워진 커밋은 `ac34b96`(v4.0.0 alpha)·`1da6c02`(v4.1.0 FINAL)·`4d97ab5`(v5.0.0 FINAL) 세 건이고 전부 릴리스 커밋입니다. 그래서 형제 아홉 개와 같은 자리에 표기만 했고 실제로 걷어내는 것은 다음 릴리스 경계에서 형제들과 함께 판단하시도록 남겨 두었습니다.

### AS-IS / TO-BE

```diff
  * @author Juergen Hoeller
  * @since 13.10.2003
+ * @deprecated in favor of {@link org.springframework.orm.ObjectRetrievalFailureException org.springframework.orm.ObjectRetrievalFailureException},
+ * which spring-orm still provides with the same API
  */
 @SuppressWarnings("serial")
+@Deprecated
 public class ObjectRetrievalFailureException extends DataRetrievalFailureException {
```

`ObjectOptimisticLockingFailureException` 에도 같은 자리에 같은 형태로 세 줄을 더했습니다. `{@link}` 에 라벨을 붙여 FQN 을 한 번 더 적은 것은, 라벨이 없으면 렌더된 문구가 이름만 남아 자기 자신을 가리키는 것처럼 읽히기 때문입니다.

### 영향 범위

생성자·메서드 본문은 건드리지 않았습니다. 애노테이션 한 줄과 Javadoc 태그가 더해진 전부라 동작은 그대로이고 이 저장소 안에는 참조가 없어 저장소 빌드에 새로 뜨는 deprecation 경고도 없습니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

```
$ mvn -o clean test -pl Persistence/org.egovframe.rte.psl.dataaccess
[INFO] Tests run: 126, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```

애노테이션을 도로 빼고 같은 명령을 돌려도 126건이 그대로 통과합니다. 동작이 갈라지는 지점이 없어서입니다. `@Deprecated` 가 붙어 있는지 단언하는 테스트는 수정을 그대로 되읊는 것이라 새로 넣지 않았습니다.

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

화면이 없는 실행환경 모듈이라 첨부하지 않았습니다.
