### PR TITLE
refactor: EgovSecurityConfiguration 의 읽히지 않는 securityConfigPath 필드 제거

### DIFF
--- a/Foundation/org.egovframe.rte.fdl.security/src/main/java/org/egovframe/rte/fdl/security/config/EgovSecurityConfiguration.java
+++ b/Foundation/org.egovframe.rte.fdl.security/src/main/java/org/egovframe/rte/fdl/security/config/EgovSecurityConfiguration.java
@@ -79,9 +79,6 @@ public class EgovSecurityConfiguration {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(EgovSecurityConfiguration.class);
 
-    @Value("${Globals.SecurityConfigPath:}")
-    private String securityConfigPath;
-
     @Autowired
     private ApplicationContext applicationContext;
 


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [ ] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [X] 기타 Others

## 수정된 소스 내용 Modified source

`EgovSecurityConfiguration` 은 `Globals.SecurityConfigPath` 를 `@Value` 로 필드에 주입받는데, 이 필드를 읽는 자리가 클래스 안에 없습니다.

이 프로퍼티를 실제로 쓰는 `@Bean` 두 개가 같은 이름의 `@Value` 파라미터를 따로 선언하고, 메서드 안에서는 그 파라미터가 필드를 가리기 때문입니다. 현재 main 기준으로 이 이름이 나오는 자리는 다섯 곳입니다.

```
$ grep -n securityConfigPath .../security/config/EgovSecurityConfiguration.java
83:    private String securityConfigPath;
96:            @Value("${Globals.SecurityConfigPath:}") String securityConfigPath) {
97:        return new EgovSecurityConfigReader(securityConfigPath, applicationContext);
102:            @Value("${Globals.SecurityConfigPath:}") String securityConfigPath) {
104:            EgovSecurityConfigReader reader = new EgovSecurityConfigReader(securityConfigPath, applicationContext);
```

83줄이 필드 선언이고, 96·97줄은 `egovSecurityConfigReader(...)`, 102·104줄은 `egovSecurityConfig(...)` 의 파라미터 선언과 그 파라미터를 넘기는 자리입니다. 필드를 읽는 줄은 없습니다.

바깥에서 읽는 경로도 없습니다. `private` 필드라 다른 클래스가 이름으로 참조할 수 없고, 저장소 전체 `git grep -n securityConfigPath` 는 열두 줄인데 위 다섯 줄 외 일곱 줄은 전부 테스트 쪽 `EgovSecurityTestConfig` 안의 동명 지역 변수입니다. `.java` 밖에서 잡히는 줄이 없으므로 XML·프로퍼티 설정이 이 이름으로 값을 넣는 경로도 없습니다.

리플렉션으로 우회해 읽는 곳도 모듈 안에 없습니다.

```
$ git grep -nE "getDeclaredField|getField\(|ReflectionTestUtils|ReflectionUtils" -- Foundation/org.egovframe.rte.fdl.security
(출력 없음)
```

### AS-IS / TO-BE

```diff
     private static final Logger LOGGER = LoggerFactory.getLogger(EgovSecurityConfiguration.class);
 
-    @Value("${Globals.SecurityConfigPath:}")
-    private String securityConfigPath;
-
     @Autowired
     private ApplicationContext applicationContext;
```

### 영향 범위

필드 선언 세 줄이 전부이고 같은 파일 안에서 끝납니다. 프로퍼티를 읽는 두 `@Bean` 파라미터는 그대로라 `Globals.SecurityConfigPath` 를 읽어 오는 동작은 변하지 않습니다. `@Value` import 도 그 두 파라미터가 계속 씁니다(수정 후 93·99줄).

동작이 변하지 않는 정리를 별도 PR 로 받은 선례가 있어(#247) 같은 결로 하나만 담았습니다. 같은 클래스에는 `loadUrlAuthorizationsFromDb`(main 기준 137줄)와 그 안에서만 불리는 `calculateUrlSpecificity`(188줄)가 묶음으로 남아 있는데 이 묶음을 부르는 곳이 없고, 같은 모양의 필드가 `EgovAccessConfiguration`(43줄)·`EgovCryptoConfiguration`(48줄)에도 있습니다. 성격과 모듈이 갈려 이 PR 에는 담지 않았습니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

새 테스트는 없습니다. 동작을 바꾸지 않는 삭제라 이 변경으로 상태가 갈리는 테스트를 쓸 수 없어, 기존 스위트로 회귀만 확인했습니다.

먼저 수정 전 기준선이 초록인지 확인했습니다.

```
$ mvn -pl Foundation/org.egovframe.rte.fdl.security test
[INFO] Tests run: 36, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```

필드를 지운 뒤 같은 명령의 결과가 같습니다.

```
$ mvn -pl Foundation/org.egovframe.rte.fdl.security test
[INFO] Tests run: 36, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

화면이 없는 실행환경 모듈이라 첨부하지 않았습니다.
