### PR TITLE
fix: EgovPartitionFlatFileItemWriter 예외 로그가 인자 하나를 버려 예외 메시지가 사라지는 문제 수정

### DIFF
--- a/Batch/org.egovframe.rte.bat.core/src/main/java/org/egovframe/rte/bat/core/item/file/EgovPartitionFlatFileItemWriter.java
+++ b/Batch/org.egovframe.rte.bat.core/src/main/java/org/egovframe/rte/bat/core/item/file/EgovPartitionFlatFileItemWriter.java
@@ -584,7 +584,7 @@ public class EgovPartitionFlatFileItemWriter<T> extends ExecutionContextUserSupp
                     try {
                         stream.close();
                     } catch (IOException e) {
-                        LOGGER.debug("EgovPartitionFlatFileItemWriter initializeBufferedWriter() : {}", e.getClass().getName(), e.getMessage());
+                        LOGGER.debug("EgovPartitionFlatFileItemWriter initializeBufferedWriter() : {} : {}", e.getClass().getName(), e.getMessage());
                     }
                 }
             }


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

`EgovPartitionFlatFileItemWriter.OutputState.initializeBufferedWriter()` 의 `finally` 에서 `stream.close()` 가 `IOException` 을 던질 때 찍는 로그가 플레이스홀더 하나에 인자 둘을 넘깁니다.

```java
LOGGER.debug("EgovPartitionFlatFileItemWriter initializeBufferedWriter() : {}", e.getClass().getName(), e.getMessage());
```

slf4j 는 자리가 남지 않은 인자를 버립니다. 마지막 인자가 `Throwable` 이 아니라 `String` 이라 스택트레이스로도 취급되지 않아 예외 메시지가 로그에서 사라집니다.

같은 파일의 형제 catch 는 두 값을 모두 찍습니다.

```java
LOGGER.debug("[{}] EgovPartitionFlatFileItemWriter closeStream() : {}", e.getClass().getName(), e.getMessage());
```

이 줄은 이미 한 번 고쳐졌습니다. `708baad`(#249, 2026-07-28 머지)가 플레이스홀더를 하나 늘렸습니다.

```diff
-LOGGER.debug("EgovPartitionFlatFileItemWriter initializeBufferedWriter() : {}", ...);
+LOGGER.debug("EgovPartitionFlatFileItemWriter initializeBufferedWriter() : {} : {}", ...);
```

그 뒤 `73f7d40`("NCSC&NIA 보안점검 적용")이 같은 줄을 되돌렸습니다. 그 커밋은 29개 파일을 함께 바꿨고 이 파일에서는 이 한 줄만 건드렸습니다. 형제 catch 는 손대지 않아 지금도 두 값을 찍습니다.

되돌림이 예외 메시지를 로그에서 빼려는 조치는 아니었습니다. 같은 커밋은 `EgovDOMValidatorService` 에서 `e.getMessage()` 를 찍던 `debug` 세 줄을 지우면서 그 값을 던지는 예외의 메시지로 옮겼습니다.

```diff
-throw new ValidatorException("Parser configuration error");
+throw new ValidatorException("Parser configuration error: " + e.getMessage());
```

같은 커밋이 `EgovSAXValidatorService` 의 로그도 예외 클래스명과 메시지를 모두 찍는 형태로 바꿨고, 그 줄은 현재 `main` 에 그대로 있습니다.

```diff
-LOGGER.debug("SAX parser does not support one or more XXE-related features: {}", e.getMessage());
+LOGGER.debug("[{}] EgovSAXValidatorService Parser() : {}", e.getClass().getName(), e.getMessage());
```

AS-IS

```java
LOGGER.debug("EgovPartitionFlatFileItemWriter initializeBufferedWriter() : {}", e.getClass().getName(), e.getMessage());
```

TO-BE

```java
LOGGER.debug("EgovPartitionFlatFileItemWriter initializeBufferedWriter() : {} : {}", e.getClass().getName(), e.getMessage());
```

### 영향 범위

로그 문자열만 달라지고 제어 흐름은 그대로입니다. 이 `catch` 는 초기화 도중 예외가 나서 `finally` 가 `stream.close()` 를 부르고 그 `close()` 마저 실패할 때만 탑니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

새 테스트는 추가하지 않았습니다. `LOGGER` 출력을 잡아 어서션하는 테스트가 이 모듈에 없어 아래 두 가지로 확인했습니다.

모듈이 쓰는 `slf4j-api-2.0.17` 의 `MessageFormatter.arrayFormat` 으로 두 형식에 같은 인자를 넣어 결과 문자열을 비교했습니다.

```
EgovPartitionFlatFileItemWriter initializeBufferedWriter() : java.io.IOException
EgovPartitionFlatFileItemWriter initializeBufferedWriter() : java.io.IOException : Stream closed: /data/part-3.dat
```

첫 줄이 수정 전, 둘째 줄이 수정 후입니다. 수정 전에는 `e.getMessage()` 가 결과에 들어가지 않습니다.

모듈 테스트도 돌렸습니다.

```
$ mvn -B -pl Batch/org.egovframe.rte.bat.core test
[INFO] Tests run: 86, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

서버 측 로깅이라 브라우저 테스트는 진행하지 않았습니다.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

화면이 없는 실행환경 모듈이라 첨부하지 않았습니다. 검증은 위 「JUnit 테스트」 절의 출력으로 대신합니다.
