### PR TITLE
fix(cmmn): 서비스 로거와 추적 로케일 처리 수정

### DIFF
--- a/Foundation/org.egovframe.rte.fdl.cmmn/src/main/java/org/egovframe/rte/fdl/cmmn/EgovAbstractServiceImpl.java
+++ b/Foundation/org.egovframe.rte.fdl.cmmn/src/main/java/org/egovframe/rte/fdl/cmmn/EgovAbstractServiceImpl.java
@@ -40,12 +40,13 @@ import java.util.Locale;
  * 수정일		수정자				수정내용
  * ----------------------------------------------
  * 2014.06.01	Daniela Kwon		최초생성
+ *   2026-09-05  이백행          [2026년 컨트리뷰션] 서비스 로거와 추적 로케일 처리 수정
  * </pre>
  * @since 2014.06.01
  */
 public abstract class EgovAbstractServiceImpl {
 
-    protected Logger egovLogger = LoggerFactory.getLogger(EgovAbstractServiceImpl.class);
+    protected Logger egovLogger = LoggerFactory.getLogger(getClass());
 
     @Resource(name = "messageSource")
     private MessageSource messageSource;
@@ -150,7 +151,7 @@ public abstract class EgovAbstractServiceImpl {
      * @param msgArgs msgKey의 메세지에서 변수에 취환되는 값들
      */
     protected void leaveaTrace(String msgKey, String[] msgArgs) {
-        leaveaTrace(msgKey, msgArgs, null);
+        leaveaTrace(msgKey, msgArgs, LocaleContextHolder.getLocale());
     }
 
     /**

--- a/Foundation/org.egovframe.rte.fdl.cmmn/src/test/java/org/egovframe/rte/fdl/cmmn/EgovAbstractServiceImplTest.java
+++ b/Foundation/org.egovframe.rte.fdl.cmmn/src/test/java/org/egovframe/rte/fdl/cmmn/EgovAbstractServiceImplTest.java
@@ -1,0 +1,82 @@
+package org.egovframe.rte.fdl.cmmn;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Locale;
+
+import org.egovframe.rte.fdl.cmmn.trace.LeaveaTrace;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.springframework.context.MessageSource;
+import org.springframework.context.i18n.LocaleContextHolder;
+import org.springframework.test.util.ReflectionTestUtils;
+
+/**
+ * EgovAbstractServiceImpl의 로거 생성 및 추적 로케일 전달 동작을 검증한다.
+ * 
+ * @author 컨티리뷰션팀 이백행
+ * @since 2026-09-05
+ * @version 5.0.6
+ * @see
+ *
+ *      <pre>
+ *  == 개정이력(Modification Information) ==
+ *
+ *   수정일      수정자           수정내용
+ *  -------    --------    ---------------------------
+ *   2026-09-05  이백행          [2026년 컨트리뷰션] 최초 생성
+ *
+ *      </pre>
+ */
+class EgovAbstractServiceImplTest {
+
+	// 상위 클래스가 제공하는 로거는 실제 서비스 구현 클래스의 이름을 사용해야 한다.
+	@Test
+	void loggerUsesConcreteServiceClass() {
+		TestService service = new TestService();
+
+		assertEquals(TestService.class.getName(), service.logger().getName());
+	}
+
+	// 로케일을 생략한 추적 호출은 현재 스레드의 LocaleContext를 사용해야 한다.
+	@Test
+	void leaveaTraceUsesLocaleFromCurrentContext() {
+		TestService service = new TestService();
+		CapturingLeaveaTrace trace = new CapturingLeaveaTrace();
+		ReflectionTestUtils.setField(service, "traceObj", trace);
+		Locale locale = Locale.KOREA;
+		LocaleContextHolder.setLocale(locale);
+
+		try {
+			service.trace("trace.message");
+
+			assertEquals(locale, trace.locale);
+		} finally {
+			LocaleContextHolder.resetLocaleContext();
+		}
+	}
+
+	// protected API를 테스트하기 위한 최소 서비스 구현체이다.
+	private static class TestService extends EgovAbstractServiceImpl {
+
+		private Logger logger() {
+			return egovLogger;
+		}
+
+		private void trace(String msgKey) {
+			leaveaTrace(msgKey);
+		}
+	}
+
+	// LeaveaTrace에 전달된 로케일만 기록하는 테스트 대역이다.
+	private static class CapturingLeaveaTrace extends LeaveaTrace {
+
+		private Locale locale;
+
+		@Override
+		public void trace(Class<?> clazz, MessageSource messageSource, String messageKey, Object[] messageParameters,
+				Locale locale, Logger logger) {
+			this.locale = locale;
+		}
+	}
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [ ] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [x] 기타 Others

## 수정된 소스 내용 Modified source

검토자를 위해 수정된 소스 내용을 설명해 주세요. Please describe the modified source for reviewers.

## 변경 사항

- `EgovAbstractServiceImpl`의 로거를 실제 하위 서비스 클래스 기준으로 생성합니다.
- 기본 `leaveaTrace` 호출이 `LocaleContextHolder`의 현재 로케일을 사용하도록 수정합니다.
- 하위 서비스의 로거 이름과 추적 로케일 전달을 검증하는 회귀 테스트를 추가합니다.

## 변경 배경

기존에는 모든 하위 서비스가 `EgovAbstractServiceImpl` 로거 카테고리를 공유하여
로그가 발생한 실제 서비스 클래스를 구분하기 어려웠습니다.

또한 로케일을 명시하지 않는 `leaveaTrace` 오버로드가 최종 호출에 `null`을 전달하여
현재 요청의 로케일이 추적 메시지 처리에 반영되지 않았습니다.

## 변경 파일

- `src/main/java/org/egovframe/rte/fdl/cmmn/EgovAbstractServiceImpl.java`
  - 실제 하위 클래스 기반으로 로거 생성
  - 현재 LocaleContext의 로케일 전달
- `src/test/java/org/egovframe/rte/fdl/cmmn/EgovAbstractServiceImplTest.java`
  - 하위 클래스별 로거 이름 검증
  - 현재 로케일 전달 검증

## 테스트

다음 명령으로 관련 reactor 모듈 테스트를 실행했습니다.

```shell
mvn -pl Foundation/org.egovframe.rte.fdl.cmmn -am test
```

결과:
- BUILD SUCCESS
- egovframe-rte-fdl-cmmn: 44개 테스트 통과
- 실패 0건
- 오류 0건
- 건너뜀 0건
- 신규 회귀 테스트 2건 통과

영향 범위
- EgovAbstractServiceImpl을 상속하는 서비스의 로거 카테고리가 기반 클래스에서 실제 서비스 클래스로 변경됩니다.
- leaveaTrace 호출 시 스레드의 현재 로케일이 메시지 조회에 사용됩니다.
- 공개 API 시그니처 변경은 없습니다.

## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [x] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

EgovAbstractServiceImplTest

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

테스트 전과 후의 스크린샷 또는 캡처 영상을 이곳에 첨부해 주세요. Please attach screenshots or video captures of your before and after tests here.
