### PR TITLE
feat(exception): BaseRuntimeException 대체를 위한 EgovRuntimeException 추가

### DIFF
--- a/Foundation/org.egovframe.rte.fdl.cmmn/src/main/java/org/egovframe/rte/fdl/cmmn/exception/EgovRuntimeException.java
+++ b/Foundation/org.egovframe.rte.fdl.cmmn/src/main/java/org/egovframe/rte/fdl/cmmn/exception/EgovRuntimeException.java
@@ -34,6 +34,7 @@ import java.util.Locale;
  * 수정일		수정자				수정내용
  * ----------------------------------------------
  * 2017.07.25	장동한				최초생성
+ *   2026-09-05  이백행          [2026년 컨트리뷰션] BaseRuntimeException 대체를 위한 EgovRuntimeException 추가
  * </pre>
  * @since 2017.07.25
  */

--- a/Foundation/org.egovframe.rte.fdl.cmmn/src/main/java/org/egovframe/rte/fdl/cmmn/exception/EgovRuntimeException.java
+++ b/Foundation/org.egovframe.rte.fdl.cmmn/src/main/java/org/egovframe/rte/fdl/cmmn/exception/EgovRuntimeException.java
@@ -1,0 +1,225 @@
+/*
+ * Copyright 2008-2024 MOIS(Ministry of the Interior and Safety).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.egovframe.rte.fdl.cmmn.exception;
+
+import org.springframework.context.MessageSource;
+
+import java.text.MessageFormat;
+import java.util.Locale;
+
+/**
+ * EgovRuntimeException 은 EgovBizException의 상위클래스이다.
+ *
+ * <p><b>NOTE:</b> Exception Handling 상의 EgovRuntimeException 은
+ * 상속받은 자식 Exception에 대한 throw시 service > controller 전달 할수 있도록 구성 되어 있다.
+ *
+ * @author 장동한
+ * @version 1.0
+ * <pre>
+ * 개정이력(Modification Information)
+ *
+ * 수정일		수정자				수정내용
+ * ----------------------------------------------
+ * 2017.07.25	장동한				최초생성
+ * </pre>
+ * @since 2017.07.25
+ */
+public class EgovRuntimeException extends RuntimeException {
+
+    private static final long serialVersionUID = 1L;
+
+    protected String message = null;
+    protected String messageKey = null;
+    protected Object[] messageParameters = null;
+    protected Exception wrappedException = null;
+
+    /**
+     * EgovRuntimeException 기본 생성자.
+     */
+    public EgovRuntimeException() {
+        this("EgovRuntimeException without message", null, null);
+    }
+
+    /**
+     * EgovRuntimeException 생성자.
+     *
+     * @param defaultMessage 메세지 지정
+     */
+    public EgovRuntimeException(String defaultMessage) {
+        this(defaultMessage, null, null);
+    }
+
+    /**
+     * EgovRuntimeException 생성자.
+     *
+     * @param wrappedException 원인 Exception
+     */
+    public EgovRuntimeException(Throwable wrappedException) {
+        this("EgovRuntimeException without message", null, wrappedException);
+    }
+
+    /**
+     * EgovRuntimeException 생성자.
+     *
+     * @param defaultMessage   메세지 지정
+     * @param wrappedException 원인 Exception
+     */
+    public EgovRuntimeException(String defaultMessage, Throwable wrappedException) {
+        this(defaultMessage, null, wrappedException);
+    }
+
+    /**
+     * EgovRuntimeException 생성자.
+     *
+     * @param defaultMessage    메세지 지정(변수지정)
+     * @param messageParameters 치환될 메세지 리스트
+     * @param wrappedException  원인 Exception
+     */
+    public EgovRuntimeException(String defaultMessage, Object[] messageParameters, Throwable wrappedException) {
+        super(wrappedException);
+        String userMessage = defaultMessage;
+        if (messageParameters != null) {
+            userMessage = MessageFormat.format(defaultMessage, messageParameters);
+        }
+        this.message = userMessage;
+        if (wrappedException instanceof Exception exception) {
+            this.wrappedException = exception;
+        }
+    }
+
+    /**
+     * EgovRuntimeException 생성자.
+     *
+     * @param messageSource 메세지 리소스
+     * @param messageKey    메세지키값
+     */
+    public EgovRuntimeException(MessageSource messageSource, String messageKey) {
+        this(messageSource, messageKey, null, null, Locale.getDefault(), null);
+    }
+
+    /**
+     * EgovRuntimeException 생성자.
+     *
+     * @param messageSource 메세지 리소스
+     * @param messageKey    메세지키값
+     */
+    public EgovRuntimeException(MessageSource messageSource, String messageKey, Throwable wrappedException) {
+        this(messageSource, messageKey, null, null, Locale.getDefault(), wrappedException);
+    }
+
+    /**
+     * EgovRuntimeException 생성자.
+     *
+     * @param messageSource    메세지 리소스
+     * @param messageKey       메세지키값
+     * @param locale           국가/언어지정
+     * @param wrappedException 원인 Exception
+     */
+    public EgovRuntimeException(MessageSource messageSource, String messageKey, Locale locale, Throwable wrappedException) {
+        this(messageSource, messageKey, null, null, locale, wrappedException);
+    }
+
+    /**
+     * EgovRuntimeException 생성자.
+     *
+     * @param messageSource     메세지 리소스
+     * @param messageKey        메세지키값
+     * @param messageParameters 치환될 메세지 리스트
+     * @param locale            국가/언어지정
+     * @param wrappedException  원인 Exception
+     */
+    public EgovRuntimeException(MessageSource messageSource, String messageKey, Object[] messageParameters, Locale locale, Throwable wrappedException) {
+        this(messageSource, messageKey, messageParameters, null, locale, wrappedException);
+    }
+
+    /**
+     * EgovRuntimeException 생성자.
+     *
+     * @param messageSource     메세지 리소스
+     * @param messageKey        메세지키값
+     * @param messageParameters 치환될 메세지 리스트
+     * @param wrappedException  원인 Exception
+     */
+    public EgovRuntimeException(MessageSource messageSource, String messageKey, Object[] messageParameters, Throwable wrappedException) {
+        this(messageSource, messageKey, messageParameters, null, Locale.getDefault(), wrappedException);
+    }
+
+    /**
+     * EgovRuntimeException 생성자.
+     *
+     * @param messageSource     메세지 리소스
+     * @param messageKey        메세지키값
+     * @param messageParameters 치환될 메세지 리스트
+     * @param defaultMessage    메세지 지정(변수지정)
+     * @param wrappedException  원인 Exception
+     */
+    public EgovRuntimeException(MessageSource messageSource, String messageKey, Object[] messageParameters, String defaultMessage, Throwable wrappedException) {
+        this(messageSource, messageKey, messageParameters, defaultMessage, Locale.getDefault(), wrappedException);
+    }
+
+    /**
+     * EgovRuntimeException 생성자.
+     *
+     * @param messageSource     메세지 리소스
+     * @param messageKey        메세지키값
+     * @param messageParameters 치환될 메세지 리스트
+     * @param defaultMessage    메세지 지정(변수지정)
+     * @param locale            국가/언어지정
+     * @param wrappedException  원인 Exception
+     */
+    public EgovRuntimeException(MessageSource messageSource, String messageKey, Object[] messageParameters, String defaultMessage, Locale locale, Throwable wrappedException) {
+        super(wrappedException);
+        this.messageKey = messageKey;
+        this.messageParameters = messageParameters;
+        this.message = messageSource.getMessage(messageKey, messageParameters, defaultMessage, locale);
+        if (wrappedException instanceof Exception exception) {
+            this.wrappedException = exception;
+        }
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+    public String getMessageKey() {
+        return messageKey;
+    }
+
+    public void setMessageKey(String messageKey) {
+        this.messageKey = messageKey;
+    }
+
+    public Object[] getMessageParameters() {
+        return messageParameters;
+    }
+
+    public void setMessageParameters(Object[] messageParameters) {
+        this.messageParameters = messageParameters;
+    }
+
+    public Throwable getWrappedException() {
+        return wrappedException;
+    }
+
+    public void setWrappedException(Exception wrappedException) {
+        this.wrappedException = wrappedException;
+    }
+
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [ ] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [X] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

향후 `BaseRuntimeException`을 deprecated 처리하고
`EgovRuntimeException`으로 대체하기 위한 신규 예외 클래스를 추가했습니다.

`EgovRuntimeException`은 기존 `BaseRuntimeException`과 동일한 예외 처리 기능을 제공합니다.

- 기본 메시지와 메시지 매개변수를 이용한 메시지 생성을 지원합니다.
- Spring `MessageSource`와 `Locale`을 이용한 다국어 메시지 조회를 지원합니다.
- 원인 예외를 표준 `cause`와 `wrappedException`으로 보관합니다.
- 메시지 키, 치환 매개변수, 기본 메시지, 지역 및 원인 예외를 조합할 수 있는 생성자를 제공합니다.

이번 변경에서는 기존 API와의 호환성을 위해 `BaseRuntimeException`을
변경하거나 deprecated 처리하지 않습니다. 기존 사용처의 변경과
deprecated 처리는 후속 작업으로 진행할 예정입니다.

### 변경 파일

- `src/main/java/org/egovframe/rte/fdl/cmmn/exception/EgovRuntimeException.java`

## JUnit 테스트 JUnit tests

- [ ] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

> `mvn -DskipTests compile`을 실행했으나,
> `org.egovframe.rte:egovframe-rte-fdl-logging:5.0.0` 의존성을
> Maven Central에서 확인할 수 없어 컴파일 단계에 진입하지 못했습니다.

## 테스트 브라우저 Test Browser

브라우저와 관련 없는 Java 공통 예외 클래스 변경입니다.

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [X] 기타 Others — 해당 없음

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

백엔드 공통 예외 클래스 추가이므로 첨부할 UI 화면이 없습니다.