### PR TITLE
fix: ServiceExceptionHandlerTests 가 실행되지 않고, 실행 시 로케일에 의존하던 문제 수정

### DIFF
--- a/Foundation/org.egovframe.rte.fdl.cmmn/src/test/java/org/egovframe/rte/bsl/exception/ServiceExceptionHandlerTest.java
+++ b/Foundation/org.egovframe.rte.fdl.cmmn/src/test/java/org/egovframe/rte/bsl/exception/ServiceExceptionHandlerTest.java
@@ -1,13 +1,18 @@
 package org.egovframe.rte.bsl.exception;
 
 import jakarta.annotation.Resource;
+
+import java.util.Locale;
 import org.egovframe.rte.fdl.cmmn.aspect.ExceptionTransfer;
 import org.egovframe.rte.fdl.cmmn.config.CmmnTestConfig;
 import org.egovframe.rte.fdl.cmmn.exception.EgovBizException;
 import org.egovframe.rte.fdl.cmmn.trace.LeaveaTrace;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.context.ApplicationContext;
+import org.springframework.context.i18n.LocaleContextHolder;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
@@ -16,7 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration(classes = CmmnTestConfig.class)
-public class ServiceExceptionHandlerTests {
+public class ServiceExceptionHandlerTest {
 
     @Resource(name = "helloService")
     private HelloService helloService;
@@ -26,6 +31,21 @@ public class ServiceExceptionHandlerTests {
 
     @Resource
     private ApplicationContext applicationContext;
+
+    /**
+     * processException() 은 LocaleContextHolder.getLocale() 로 메시지를 해석하며,
+     * 미지정 시 JVM 기본 로케일(Locale)로 폴백한다. 아래 단언은 한국어 메시지를 기대하므로
+     * 실행 환경의 기본 로케일에 좌우되지 않도록 스레드 범위로 고정한다.
+     */
+    @BeforeEach
+    public void pinLocale() {
+        LocaleContextHolder.setLocale(Locale.KOREA);
+    }
+
+    @AfterEach
+    public void resetLocale() {
+        LocaleContextHolder.resetLocaleContext();
+    }
 
     @Test
     public void testBizUnCheckedException() throws Exception {


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

`fdl.cmmn` 의 `ServiceExceptionHandlerTests` 에 **두 가지 결함이 겹쳐** 있습니다.

### ① 테스트가 한 번도 실행되지 않고 있습니다

루트 `pom.xml` 의 surefire include 패턴은 `**/*Test.java` **하나뿐**입니다.

```xml
<includes>
    <include>**/*Test.java</include>
</includes>
```

그런데 이 파일만 `ServiceExceptionHandlerTests.java` 로 **복수형 `Tests`** 이어서 패턴에
걸리지 않습니다. 컴파일은 되므로 빌드는 정상 성공하고 실패도 나지 않기 때문에
**아무 신호 없이 조용히 건너뛰어집니다.**

`ExceptionTransfer` 의 예외 전이 동작(`EgovBizException` 래핑 · `getWrappedException()` 보존 ·
`countOfTheExceptionHandlerService()`)을 검증하는 테스트여서, 그동안 이 영역의 회귀 감시에
공백이 있었습니다.

> 저장소 전체를 확인한 결과, `@Test` 를 가지고 있으면서 `*Test.java` 규약에서 벗어난 파일은
> 이 한 건뿐이었습니다.

### ② 개명해서 실행시키면 이번에는 로케일(Locale)에 따라 실패합니다

단순히 개명만 하면 **한국어 로케일이 아닌 환경에서 2건이 실패합니다.**

```
ServiceExceptionHandlerTest.testBizException:48
    expected: <해당 데이터가 없습니다.> but was: <no data found.>
ServiceExceptionHandlerTest.testBiz2Exception:62
    expected: <해당 데이터가 없습니다.> but was: <no data found.>
```

검증 대상인 `EgovAbstractServiceImpl.processException()` 은 메시지를
**`LocaleContextHolder.getLocale()`** 로 해석합니다.

```java
protected Exception processException(final String msgKey, final String[] msgArgs, final Exception exception) {
    return processException(msgKey, msgArgs, exception, LocaleContextHolder.getLocale());
}
```

`LocaleContextHolder` 에 로케일이 설정돼 있지 않으면 **JVM 기본 로케일로 폴백**하므로,
`info.nodata.msg` 가 기본 로케일에 따라 `messages/message-common_ko.properties`(한국어) 또는
`messages/message-common_en.properties`(영어)로 갈립니다. 그런데 테스트 단언은 한국어
문자열을 하드코딩하고 있어, **한국어 로케일 환경에서만 통과**합니다.

현재 CI 매트릭스가 `ubuntu-latest`·`macos-latest`·`windows-latest` 를 모두 도는 만큼,
개명만 하고 이 부분을 두면 비한국어 로케일 러너에서 실패하게 됩니다.

### 변경 내용

- `ServiceExceptionHandlerTests.java` → **`ServiceExceptionHandlerTest.java`** (rename)
  - 클래스 선언도 동일하게 변경 (파일명–클래스명 일치 유지)
- `@BeforeEach` / `@AfterEach` 로 **`LocaleContextHolder` 를 `Locale.KOREA` 에 고정하고 해제**

```java
    /**
     * processException() 은 LocaleContextHolder.getLocale() 로 메시지를 해석하며,
     * 미지정 시 JVM 기본 로케일로 폴백한다. 아래 단언은 한국어 메시지를 기대하므로
     * 실행 환경의 기본 로케일에 좌우되지 않도록 스레드 범위로 고정한다.
     */
    @BeforeEach
    public void pinLocale() {
        LocaleContextHolder.setLocale(Locale.KOREA);
    }

    @AfterEach
    public void resetLocale() {
        LocaleContextHolder.resetLocaleContext();
    }
```

**`Locale.setDefault` 대신 `LocaleContextHolder` 를 쓴 이유**는 두 가지입니다.
① 검증 대상인 `processException()` 이 실제로 참조하는 경로가 `LocaleContextHolder` 이고,
② `LocaleContextHolder` 는 스레드 범위라 **JVM 전역 상태를 바꾸지 않아** 다른 테스트의
실행 순서에 영향을 주지 않습니다.

**테스트 본문의 단언과 검증 대상(main) 코드는 수정하지 않았습니다.**

## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [X] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

잠들어 있던 3건이 살아나며, **한국어·비한국어 로케일 양쪽에서 전건 통과**합니다.

```
mvn -B -Dfile.encoding=UTF-8 -Duser.timezone=Asia/Seoul -pl :egovframe-rte-fdl-cmmn -am clean test
```

| 환경 | 기본 로케일 | fdl.cmmn 실행 건수 | 결과 |
|---|---|---:|---|
| 개명 **전** (Windows) | ko_KR | 42 | 통과 — 단 로그에 `ServiceExceptionHandler` 가 **등장하지 않음**(미실행) |
| 개명만 (Linux) | C.UTF-8 | 45 | **Failures: 2** — 로케일 의존 노출 |
| **최종** (Windows) | ko_KR | **45** | `Tests run: 45, Failures: 0, Errors: 0, Skipped: 0` |
| **최종** (Linux) | C.UTF-8 | **45** | `Tests run: 45, Failures: 0, Errors: 0, Skipped: 0` |

```
[INFO] Running org.egovframe.rte.bsl.exception.ServiceExceptionHandlerTest
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0 -- in org.egovframe.rte.bsl.exception.ServiceExceptionHandlerTest
[INFO] BUILD SUCCESS
```

**수동 확인**
- 개명 전 실행 로그에 해당 클래스명이 전혀 나타나지 않는 것으로 미실행을 확인
- 개명 후 `Running ...ServiceExceptionHandlerTest` 줄이 생기는 것으로 실행 개시를 확인
- Linux(Ubuntu 22.04 / OpenJDK 17.0.20 / ext4 / `LANG=C.UTF-8`)에서 교차 검증해
  로케일 의존 해소를 확인

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

해당 없음 — 테스트 코드 수정이며 화면 동작과 무관합니다.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

해당 없음 — 위 JUnit 실행 결과(Windows·Linux 양쪽 45/0/0)로 갈음합니다.

---

<sub>base: `eGovFramework:main` @ `cd9fd9c` (2026-09-05 fetch 기준) · 단일 커밋</sub>
