### PR TITLE
feat: HTML 출력 정제 EgovHtmlSanitizer 추가

### DIFF
--- a/Presentation/org.egovframe.rte.ptl.mvc/pom.xml
+++ b/Presentation/org.egovframe.rte.ptl.mvc/pom.xml
@@ -30,6 +30,7 @@
         <jakarta.servlet.jsp.version>4.0.0</jakarta.servlet.jsp.version>
         <log4j2.version>2.25.3</log4j2.version>
         <slf4j.version>2.0.17</slf4j.version>
+        <jsoup.version>1.21.1</jsoup.version>
         <commons.beanutils.version>1.11.0</commons.beanutils.version>
         <commons.validator.version>1.9.0</commons.validator.version>
         <easymock.version>5.3.0</easymock.version>
@@ -118,6 +119,14 @@
             <groupId>commons-beanutils</groupId>
             <artifactId>commons-beanutils</artifactId>
             <version>${commons.beanutils.version}</version>
+        </dependency>
+        <!-- EgovHtmlSanitizer 전용 - optional 이므로 전이되지 않는다.
+             정제 기능을 쓰는 애플리케이션만 jsoup 을 직접 선언하면 된다. -->
+        <dependency>
+            <groupId>org.jsoup</groupId>
+            <artifactId>jsoup</artifactId>
+            <version>${jsoup.version}</version>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>commons-validator</groupId>

--- a/Presentation/org.egovframe.rte.ptl.mvc/src/main/java/org/egovframe/rte/ptl/mvc/filter/EgovHtmlSanitizePolicy.java
+++ b/Presentation/org.egovframe.rte.ptl.mvc/src/main/java/org/egovframe/rte/ptl/mvc/filter/EgovHtmlSanitizePolicy.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2009-2026 MOIS(Ministry of the Interior and Safety).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.egovframe.rte.ptl.mvc.filter;
+
+import org.jsoup.safety.Safelist;
+
+/**
+ * {@link EgovHtmlSanitizer} 가 사용하는 HTML 출력 정제 정책.
+ *
+ * <p>정책은 "어떤 태그·속성까지 안전한 것으로 보고 남길 것인가"의 허용 목록(Safelist)이다.
+ * 목록에 없는 것은 전부 제거되는 <b>화이트리스트 방식</b>이므로, 새로운 공격 패턴을
+ * 일일이 차단 목록에 추가할 필요가 없다.</p>
+ *
+ * <p>어떤 정책이든 {@code <script>}, 이벤트 핸들러 속성({@code onclick} 등),
+ * {@code javascript:} 프로토콜 URL 은 허용 목록에 없으므로 항상 제거된다.
+ * 정책 간 차이는 "정상적인 서식을 얼마나 남기는가"뿐이다.</p>
+ *
+ * <pre>
+ * &lt;&lt; 개정이력(Modification Information) &gt;&gt;
+ *
+ *  수정일        수정자        수정내용
+ *  ----------  --------    ---------------------------
+ *  2026.08.28  실행환경팀     최초 생성 (A-01: 공통컴포넌트 EgovHtmlSanitizer 설계 차용,
+ *                            단일 고정 정책을 용도별 선택형으로 재구성)
+ * </pre>
+ *
+ * @author 실행환경 개발팀
+ * @since 5.1
+ * @see EgovHtmlSanitizer
+ */
+public enum EgovHtmlSanitizePolicy {
+
+	/**
+	 * 태그를 전부 제거하고 텍스트만 남긴다.
+	 * 댓글·제목·검색어처럼 HTML 서식이 필요 없는 필드에 사용한다.
+	 * (남는 텍스트는 HTML 조각으로서 안전하도록 엔티티 이스케이프된 상태다)
+	 */
+	TEXT_ONLY,
+
+	/**
+	 * 단순 강조 태그만 허용: {@code b, em, i, strong, u}.
+	 * 링크·이미지·블록 요소는 제거된다.
+	 */
+	SIMPLE_TEXT,
+
+	/**
+	 * 기본 서식 허용: 문단·목록·링크 등
+	 * ({@code a, b, blockquote, br, cite, code, dd, dl, dt, em, i, li, ol, p,
+	 * pre, q, small, span, strike, strong, sub, sup, u, ul}).
+	 * 이미지는 제거된다. 링크에는 {@code rel="nofollow"} 가 부여된다.
+	 */
+	BASIC,
+
+	/**
+	 * {@link #BASIC} + 이미지({@code img} 의 src·크기 속성) 허용.
+	 */
+	BASIC_WITH_IMAGES,
+
+	/**
+	 * 리치 텍스트 에디터(CKEditor 등) 콘텐츠용 — <b>기본 정책</b>.
+	 * 표({@code table} 계열)·제목({@code h1~h6})·이미지까지 허용하고,
+	 * {@code img} 의 {@code style} 속성은 width/height 선언만 남긴다
+	 * ({@link EgovHtmlSanitizer} 의 style 재필터).
+	 * 게시판 본문 등 에디터로 작성한 HTML 을 그대로 출력하는 화면에 사용한다.
+	 */
+	RICH_TEXT;
+
+	/**
+	 * 정책에 해당하는 jsoup Safelist 를 새로 만들어 반환한다.
+	 *
+	 * <p>Safelist 는 가변 객체이므로 호출마다 새 인스턴스를 만들어
+	 * 공유 상태 변이를 차단한다. 컨텍스트 상대경로 URL
+	 * (예: {@code /utl/web/imageSrc.do?...})이 절대경로로 바뀌지 않도록
+	 * 모든 정책에 {@code preserveRelativeLinks} 를 적용한다.</p>
+	 *
+	 * @return 이 정책의 Safelist (매 호출 새 인스턴스)
+	 */
+	Safelist newSafelist() {
+		switch (this) {
+			case TEXT_ONLY:
+				return Safelist.none();
+			case SIMPLE_TEXT:
+				return Safelist.simpleText();
+			case BASIC:
+				return Safelist.basic().preserveRelativeLinks(true);
+			case BASIC_WITH_IMAGES:
+				return Safelist.basicWithImages().preserveRelativeLinks(true);
+			case RICH_TEXT:
+			default:
+				return Safelist.relaxed()
+						.addAttributes("img", "style")
+						.preserveRelativeLinks(true);
+		}
+	}
+
+}

--- a/Presentation/org.egovframe.rte.ptl.mvc/src/main/java/org/egovframe/rte/ptl/mvc/filter/EgovHtmlSanitizer.java
+++ b/Presentation/org.egovframe.rte.ptl.mvc/src/main/java/org/egovframe/rte/ptl/mvc/filter/EgovHtmlSanitizer.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright 2009-2026 MOIS(Ministry of the Interior and Safety).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.egovframe.rte.ptl.mvc.filter;
+
+import java.util.regex.Pattern;
+
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.safety.Safelist;
+
+/**
+ * HTML <b>출력 정제(Sanitizer)</b> 유틸 — 신뢰할 수 없는 HTML 에서 XSS 위험 요소만
+ * 선별 제거하고 안전한 서식은 남긴다.
+ *
+ * <p><b>입력 필터({@link HTMLTagFilter})와의 역할 구분:</b> 입력 필터는 요청 파라미터의
+ * {@code <} 를 {@code &lt;} 로 전부 인코딩하므로 HTML 서식 자체를 쓸 수 없게 된다.
+ * 리치 텍스트 에디터(CKEditor 등)로 작성한 게시물 본문처럼 <b>HTML 을 허용해야 하는
+ * 콘텐츠</b>는 입력 인코딩 대신 이 정제기로 위험 요소만 걸러 출력한다.
+ * 두 수단은 상호 보완 관계다 — 서식이 필요 없는 필드는 입력 필터(또는
+ * {@link EgovHtmlSanitizePolicy#TEXT_ONLY}), 서식이 필요한 본문은 이 정제기.</p>
+ *
+ * <p><b>동작 방식:</b> jsoup 의 Safelist(화이트리스트) 정제를 사용한다. 허용 목록에 없는
+ * 태그·속성·프로토콜은 전부 제거되므로 {@code <script>}, 이벤트 핸들러({@code onclick} 등),
+ * {@code javascript:} URL, 변형 공격({@code <scr<script>ipt>} 류)이 모두 무력화된다.
+ * 정책별 허용 범위는 {@link EgovHtmlSanitizePolicy} 참조.</p>
+ *
+ * <p><b>의존성:</b> 이 클래스는 <b>jsoup 을 필요로 한다</b>(모듈 pom 에 optional 선언 —
+ * 의존성 격리 원칙). 사용하는 애플리케이션은 {@code org.jsoup:jsoup} 을 직접 추가해야
+ * 하며, 없으면 클래스 로딩 시 {@code NoClassDefFoundError} 가 발생한다.
+ * ptl.mvc 의 다른 기능은 jsoup 없이 동작한다.</p>
+ *
+ * <p><b>사용 시점:</b> 저장 시 1회 정제(저장 데이터 자체를 안전하게) 또는 출력 직전 정제
+ * 중 택일한다. 저장 시 정제가 일반적으로 우수하다 — 조회마다의 파싱 비용이 없고,
+ * API 등 다른 출력 경로도 함께 보호된다.</p>
+ *
+ * <pre>
+ * &lt;&lt; 개정이력(Modification Information) &gt;&gt;
+ *
+ *  수정일        수정자        수정내용
+ *  ----------  --------    ---------------------------
+ *  2026.08.28  실행환경팀     최초 생성 (A-01: 공통컴포넌트 EgovHtmlSanitizer 의 검증된
+ *                            설계(상대경로 보존·style 재필터)를 차용하되, 단일 고정 정책을
+ *                            용도별 정책 선택형으로 재구성 — 코드 직접 이식 아님)
+ * </pre>
+ *
+ * @author 실행환경 개발팀
+ * @since 5.1
+ * @see EgovHtmlSanitizePolicy
+ * @see HTMLTagFilter
+ */
+public final class EgovHtmlSanitizer {
+
+	/**
+	 * style 속성에서 허용하는 CSS 선언 — width/height 의 px/% 값만.
+	 * 그 외 선언(position, expression, url() 등)은 클릭재킹·레거시 IE 스크립트 실행 등의
+	 * 위험이 있어 전부 제거한다.
+	 */
+	private static final Pattern SAFE_STYLE_DECLARATION =
+			Pattern.compile("^(width|height)\\s*:\\s*\\d{1,4}(px|%)?$", Pattern.CASE_INSENSITIVE);
+
+	/**
+	 * jsoup 의 프로토콜 검증은 {@code Element.absUrl()} 로 절대경로 변환이 가능해야
+	 * 동작하므로, {@code /utl/web/imageSrc.do?...} 같은 컨텍스트 상대경로도 검증을
+	 * 통과하도록 임의의 baseUri 를 부여한다. 정책의 {@code preserveRelativeLinks} 설정으로
+	 * 실제 출력값은 절대경로로 바뀌지 않고 원본 상대경로가 그대로 유지된다.
+	 */
+	private static final String DUMMY_BASE_URI = "http://localhost/";
+
+	private EgovHtmlSanitizer() {
+	}
+
+	/**
+	 * 기본 정책({@link EgovHtmlSanitizePolicy#RICH_TEXT})으로 HTML 을 정제한다.
+	 * 리치 텍스트 에디터로 저장한 게시물 본문을 조회 화면에 출력할 때 사용한다.
+	 *
+	 * @param html 신뢰할 수 없는(사용자가 입력한) 원본 HTML — null/공백 허용
+	 * @return 위험 요소가 제거된 안전한 HTML (입력이 null 또는 공백이면 빈 문자열)
+	 */
+	public static String sanitize(String html) {
+		return sanitize(html, EgovHtmlSanitizePolicy.RICH_TEXT);
+	}
+
+	/**
+	 * 지정 정책으로 HTML 을 정제한다.
+	 *
+	 * @param html   신뢰할 수 없는 원본 HTML — null/공백 허용
+	 * @param policy 허용 범위 정책 (null 이면 {@link EgovHtmlSanitizePolicy#RICH_TEXT})
+	 * @return 위험 요소가 제거된 안전한 HTML (입력이 null 또는 공백이면 빈 문자열)
+	 */
+	public static String sanitize(String html, EgovHtmlSanitizePolicy policy) {
+		EgovHtmlSanitizePolicy effective = (policy != null) ? policy : EgovHtmlSanitizePolicy.RICH_TEXT;
+		return sanitize(html, effective.newSafelist());
+	}
+
+	/**
+	 * 사용자 정의 Safelist 로 HTML 을 정제한다 — 표준 정책으로 부족할 때의 확장점.
+	 *
+	 * <p>커스텀 Safelist 를 쓰더라도 style 속성 재필터(width/height 만 허용)는
+	 * 동일하게 적용된다. Safelist 는 style 속성값(CSS) 자체의 위험성을 검증하지
+	 * 않기 때문이다.</p>
+	 *
+	 * @param safelist jsoup 허용 목록 (null 불가)
+	 * @param html     신뢰할 수 없는 원본 HTML — null/공백 허용
+	 * @return 위험 요소가 제거된 안전한 HTML (입력이 null 또는 공백이면 빈 문자열)
+	 * @throws IllegalArgumentException safelist 가 null 인 경우
+	 */
+	public static String sanitize(String html, Safelist safelist) {
+		if (safelist == null) {
+			throw new IllegalArgumentException("safelist must not be null");
+		}
+		if (html == null || html.trim().isEmpty()) {
+			return "";
+		}
+		String cleaned = Jsoup.clean(html, DUMMY_BASE_URI, safelist);
+		return sanitizeStyleAttributes(cleaned);
+	}
+
+	/**
+	 * 태그를 전부 제거하고 텍스트만 남긴다 —
+	 * {@code sanitize(html, TEXT_ONLY)} 의 편의 메서드.
+	 * 댓글·제목·검색어처럼 HTML 서식이 필요 없는 값에 사용한다.
+	 *
+	 * @param html 신뢰할 수 없는 원본 HTML — null/공백 허용
+	 * @return 태그가 제거된 텍스트(HTML 조각으로 안전하도록 엔티티 이스케이프됨).
+	 *         입력이 null 또는 공백이면 빈 문자열
+	 */
+	public static String stripToText(String html) {
+		return sanitize(html, EgovHtmlSanitizePolicy.TEXT_ONLY);
+	}
+
+	/**
+	 * Safelist 는 style 속성값(CSS) 자체의 위험성은 검증하지 않으므로,
+	 * 1차 정제 결과물에서 style 속성을 width/height 선언만 남도록 다시 필터링한다.
+	 */
+	private static String sanitizeStyleAttributes(String cleanedHtml) {
+		// 정제 결과에 style 속성이 없으면 재파싱을 생략한다 (jsoup 출력은 style="..." 형태)
+		if (!cleanedHtml.contains("style=")) {
+			return cleanedHtml;
+		}
+
+		Document doc = Jsoup.parseBodyFragment(cleanedHtml);
+		doc.outputSettings().prettyPrint(false);
+
+		for (Element element : doc.select("[style]")) {
+			String safeStyle = filterStyle(element.attr("style"));
+			if (safeStyle == null) {
+				element.removeAttr("style");
+			} else {
+				element.attr("style", safeStyle);
+			}
+		}
+
+		return doc.body().html();
+	}
+
+	/**
+	 * style 속성값에서 허용 선언(width/height)만 남긴다.
+	 *
+	 * @return 허용 선언만 남긴 값, 남는 것이 없으면 null
+	 */
+	private static String filterStyle(String style) {
+		if (style == null || style.trim().isEmpty()) {
+			return null;
+		}
+
+		StringBuilder safeStyle = new StringBuilder();
+		for (String declaration : style.split(";")) {
+			String trimmed = declaration.trim();
+			if (SAFE_STYLE_DECLARATION.matcher(trimmed).matches()) {
+				if (safeStyle.length() > 0) {
+					safeStyle.append("; ");
+				}
+				safeStyle.append(trimmed);
+			}
+		}
+
+		return safeStyle.length() > 0 ? safeStyle.toString() : null;
+	}
+
+}

--- a/Presentation/org.egovframe.rte.ptl.mvc/src/test/java/org/egovframe/rte/ptl/mvc/filter/EgovHtmlSanitizerSecurityTest.java
+++ b/Presentation/org.egovframe.rte.ptl.mvc/src/test/java/org/egovframe/rte/ptl/mvc/filter/EgovHtmlSanitizerSecurityTest.java
@@ -1,0 +1,237 @@
+package org.egovframe.rte.ptl.mvc.filter;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.regex.Pattern;
+
+import org.jsoup.Jsoup;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * {@link EgovHtmlSanitizer} 의 <b>XSS 공격 벡터</b> 회귀 검증(CWE-79).
+ *
+ * <p>기능 테스트({@link EgovHtmlSanitizerTest})가 대표 사례를 다루고, 이 클래스는 우회에 실제로
+ * 쓰이는 입력 변형을 한 표로 모아 <b>하나라도 실행 가능한 구조가 남으면 실패</b>하게 한다.
+ * 새 우회 기법이 알려지면 이 목록에 한 줄을 더한다.</p>
+ *
+ * <p>판정은 정제 결과를 다시 파싱해 검사한다 — {@code <script>}·이벤트 핸들러 속성·위험 프로토콜
+ * URL·raw-text 실행 요소가 없어야 하고, 재파싱해도 같은 결과여야 한다(mutation XSS 신호 차단).</p>
+ */
+class EgovHtmlSanitizerSecurityTest {
+
+	/** 소스에 리터럴로 두지 않는 제어문자. */
+	private static final String NUL = String.valueOf((char) 0x00);
+	private static final String TAB = String.valueOf((char) 0x09);
+	private static final String LF = String.valueOf((char) 0x0A);
+	private static final String CR = String.valueOf((char) 0x0D);
+	private static final String SOH = String.valueOf((char) 0x01);
+
+	private static final Pattern CONTROL = Pattern.compile("[\\x00-\\x20]");
+
+	/**
+	 * 실행 가능한 구조가 남았으면 그 목록을, 없으면 빈 목록을 돌려준다. 정제 결과를 <b>다시 파싱해</b>
+	 * 실제 요소·속성 단위로 판정한다 — 이스케이프된 텍스트에 나타난 {@code onerror=} 문자열 같은
+	 * 무해한 표기를 위험으로 오인하지 않기 위해서다.
+	 */
+	private static List<String> executableRemains(String out) {
+		java.util.List<String> found = new java.util.ArrayList<>();
+		if (out.toLowerCase(Locale.ROOT).contains("<script")) {
+			found.add("raw<script");
+		}
+		java.util.Set<String> danger = java.util.Set.of("script", "iframe", "object", "embed", "base", "meta",
+				"form", "style", "link", "svg", "math", "applet", "frame", "frameset", "noscript", "template",
+				"noframes", "noembed", "xmp", "title", "textarea", "input", "button");
+		org.jsoup.nodes.Document doc = Jsoup.parseBodyFragment(out);
+		for (org.jsoup.nodes.Element el : doc.getAllElements()) {
+			String name = el.tagName().toLowerCase(Locale.ROOT);
+			if (danger.contains(name)) {
+				found.add("tag:" + name);
+			}
+			for (org.jsoup.nodes.Attribute a : el.attributes()) {
+				if (a.getKey().toLowerCase(Locale.ROOT).startsWith("on")) {
+					found.add("handler:" + a.getKey());
+				}
+				String v = CONTROL.matcher(a.getValue()).replaceAll("").toLowerCase(Locale.ROOT);
+				if (v.startsWith("javascript:") || v.startsWith("vbscript:") || v.startsWith("livescript:")
+						|| v.startsWith("data:text/html")) {
+					found.add("url:" + a.getKey() + "=" + a.getValue());
+				}
+			}
+		}
+		return found;
+	}
+
+	private static String reparse(String html) {
+		org.jsoup.nodes.Document d = Jsoup.parseBodyFragment(html);
+		d.outputSettings().prettyPrint(false);
+		return d.body().html();
+	}
+
+	@Test
+	@DisplayName("우회 변형 배터리 — 어떤 정책에서도 실행 가능한 구조가 남지 않는다")
+	void 우회_변형_전부_무력화() {
+		List<String> hostile = List.of(
+				// javascript: 스킴 — 대소문자·공백·제어문자·엔티티 인코딩
+				"<a href=\"javascript:alert(1)\">x</a>",
+				"<a href=\"JaVaScRiPt:alert(1)\">x</a>",
+				"<a href=\"java" + TAB + "script:alert(1)\">x</a>",
+				"<a href=\"java" + LF + "script:alert(1)\">x</a>",
+				"<a href=\"java" + CR + "script:alert(1)\">x</a>",
+				"<a href=\" javascript:alert(1)\">x</a>",
+				"<a href=\"&#106;avascript:alert(1)\">x</a>",
+				"<a href=\"&#x6A;avascript:alert(1)\">x</a>",
+				"<a href=\"java&#9;script:alert(1)\">x</a>",
+				"<a href=\"javascript&colon;alert(1)\">x</a>",
+				"<a href=\"vbscript:msgbox(1)\">x</a>",
+				"<a href=\"data:text/html;base64,PHNjcmlwdD5hbGVydCgxKTwvc2NyaXB0Pg==\">x</a>",
+				"<img src=\"javascript:alert(1)\">",
+				"<img src=\"java" + TAB + "script:alert(1)\">",
+				"<blockquote cite=\"javascript:alert(1)\">x</blockquote>",
+				// 이벤트 핸들러
+				"<img src=x onerror=alert(1)>",
+				"<img src=x ONERROR=alert(1)>",
+				"<img src=x onerror =alert(1)>",
+				"<img src=x on" + NUL + "error=alert(1)>",
+				"<details open ontoggle=alert(1)>x</details>",
+				"<marquee onstart=alert(1)>x</marquee>",
+				"<input onfocus=alert(1) autofocus>",
+				"<body onload=alert(1)>",
+				// 허용 목록 밖 위험 태그
+				"<svg onload=alert(1)>",
+				"<svg><a xlink:href=\"javascript:alert(1)\"><text>x</text></a></svg>",
+				"<math href=\"javascript:alert(1)\">x</math>",
+				"<iframe srcdoc=\"&lt;script&gt;alert(1)&lt;/script&gt;\"></iframe>",
+				"<object data=\"javascript:alert(1)\"></object>",
+				"<embed src=\"javascript:alert(1)\">",
+				"<base href=\"javascript://evil/\">",
+				"<meta http-equiv=\"refresh\" content=\"0;url=javascript:alert(1)\">",
+				"<form action=\"javascript:alert(1)\"><input type=submit></form>",
+				"<link rel=\"import\" href=\"http://evil/x.html\">",
+				// style 로 흘리는 스크립트/클릭재킹
+				"<style>body{background:url(javascript:alert(1))}</style>",
+				"<img src=\"/a.png\" style=\"background:url(javascript:alert(1))\">",
+				"<img src=\"/a.png\" style=\"width:expression(alert(1))\">",
+				"<img src=\"/a.png\" style=\"-moz-binding:url(http://evil/x.xml#xss)\">",
+				"<img src=\"/a.png\" style=\"position:fixed;top:0;left:0;width:100%;height:100%\">",
+				// mutation XSS 고전
+				"<scr<script>ipt>alert('xss')</scr</script>ipt>",
+				"<svg><style><img src=x onerror=alert(1)></style></svg>",
+				"<noscript><p title=\"</noscript><img src=x onerror=alert(1)>\"></noscript>",
+				"<template><img src=x onerror=alert(1)></template>",
+				"<select><iframe></select><img src=x onerror=alert(1)>",
+				"<math><mtext><table><mglyph><style><img src=x onerror=alert(1)>",
+				"<p><a href=\"/x\" title=\"<img src=x onerror=alert(1)>\">x</a></p>",
+				// 형식 파괴
+				"<<script>alert(1)//<</script>",
+				"<script>alert(1)</script/>",
+				"<scr" + NUL + "ipt>alert(1)</scr" + NUL + "ipt>",
+				"<IMG SRC=x ONERROR=alert(1)><SCRIPT>alert(1)</SCRIPT>",
+				"<img src=x/onerror=alert(1)>",
+				// 선인코딩 입력은 그대로(이중 디코딩 금지)
+				"&lt;script&gt;alert(1)&lt;/script&gt;");
+
+		for (EgovHtmlSanitizePolicy policy : EgovHtmlSanitizePolicy.values()) {
+			for (String attack : hostile) {
+				String out = EgovHtmlSanitizer.sanitize(attack, policy);
+				List<String> remains = executableRemains(out);
+				assertTrue(remains.isEmpty(),
+						policy + " 정책에서 실행 가능한 구조 잔존 " + remains + " — 입력=" + visible(attack) + " 출력=" + visible(out));
+				assertEquals(reparse(out), reparse(reparse(out)),
+						policy + " 정책 결과가 재파싱에 안정적이지 않음(mutation XSS 신호): " + visible(out));
+			}
+		}
+	}
+
+	@Test
+	@DisplayName("제어문자로 끝나는 raw-text 태그를 넣어도 내장 정책은 스크립트를 실행 형태로 남기지 않는다")
+	void 제어문자_꼬리_raw_text_태그도_내장정책에서_무력화() {
+		// 파서 불일치 계열 공격(태그 이름 뒤 제어문자) — 내장 Safelist 는 raw-text 태그를 허용하지 않으므로
+		// style/title/iframe/textarea/script 를 어떤 제어문자로 감싸도 실행 형태가 남지 않아야 한다
+		String[] rawTags = { "style", "title", "iframe", "textarea", "noframes", "noembed", "xmp", "script" };
+		String[] tails = { SOH, TAB, LF, CR, NUL, "" };
+		for (EgovHtmlSanitizePolicy policy : EgovHtmlSanitizePolicy.values()) {
+			for (String tag : rawTags) {
+				for (String tail : tails) {
+					String attack = "<" + tag + tail + "><img src=x onerror=alert(1)></" + tag + ">";
+					String out = EgovHtmlSanitizer.sanitize(attack, policy);
+					assertTrue(executableRemains(out).isEmpty(),
+							policy + "/" + tag + " 제어문자 꼬리에서 실행 구조 잔존: " + visible(out));
+				}
+			}
+		}
+	}
+
+	@Test
+	@DisplayName("style 속성은 어떤 위험 CSS 를 넣어도 width/height 선언만 남는다")
+	void style_속성_재필터_우회_불가() {
+		String[] attacks = {
+				"<img src=\"/a.png\" style=\"width:1px;background:url(javascript:alert(1))\">",
+				"<img src=\"/a.png\" style=\"width:1px/**/;x:expression(alert(1))\">",
+				"<img src=\"/a.png\" style=\"wid\\74h:1px;background:url(javascript:alert(1))\">",
+				"<img src=\"/a.png\" style=\"behavior:url(x.htc)\">",
+				"<img src=\"/a.png\" style=\"position:absolute;z-index:9999\">" };
+		for (String attack : attacks) {
+			String out = EgovHtmlSanitizer.sanitize(attack);
+			String style = extractStyle(out);
+			assertFalse(style.toLowerCase(Locale.ROOT).contains("url("), "url() 잔존: " + visible(out));
+			assertFalse(style.toLowerCase(Locale.ROOT).contains("expression"), "expression 잔존: " + visible(out));
+			assertFalse(style.toLowerCase(Locale.ROOT).contains("position"), "position 잔존: " + visible(out));
+			assertFalse(style.toLowerCase(Locale.ROOT).contains("behavior"), "behavior 잔존: " + visible(out));
+			assertTrue(style.isEmpty() || style.matches("(?i)\\s*(width|height)\\s*:\\s*\\d{1,4}(px|%)?\\s*;?\\s*"
+					+ "((width|height)\\s*:\\s*\\d{1,4}(px|%)?\\s*;?\\s*)*"), "허용 밖 선언 잔존: " + visible(out));
+		}
+	}
+
+	@Test
+	@DisplayName("컨텍스트 상대경로는 보존하되 더미 baseUri 나 프로토콜 상대경로 스킴은 새지 않는다")
+	void 상대경로_보존과_baseUri_비노출() {
+		String out = EgovHtmlSanitizer.sanitize(
+				"<a href=\"/cop/bbs/select.do?id=1\">x</a><img src=\"/utl/web/imageSrc.do?p=a.png\">");
+		assertTrue(out.contains("href=\"/cop/bbs/select.do?id=1\""), "상대경로 링크 변형: " + out);
+		assertTrue(out.contains("src=\"/utl/web/imageSrc.do?p=a.png\""), "상대경로 이미지 변형: " + out);
+		assertFalse(out.contains("localhost"), "더미 baseUri 노출: " + out);
+	}
+
+	@Test
+	@DisplayName("대용량·깊은 입력에도 실행 구조를 남기지 않는다")
+	void 대용량_입력_견고성() {
+		StringBuilder deep = new StringBuilder();
+		for (int i = 0; i < 3000; i++) {
+			deep.append("<div>");
+		}
+		deep.append("<img src=x onerror=alert(1)>");
+		String outDeep = EgovHtmlSanitizer.sanitize(deep.toString());
+		assertTrue(executableRemains(outDeep).isEmpty(), "깊은 입력에서 실행 구조 잔존");
+
+		StringBuilder big = new StringBuilder();
+		while (big.length() < 200_000) {
+			big.append("<p>가나다 <b>x</b> <img src=x onerror=alert(1)> </p>");
+		}
+		String outBig = EgovHtmlSanitizer.sanitize(big.toString());
+		assertTrue(executableRemains(outBig).isEmpty(), "대용량 입력에서 실행 구조 잔존");
+	}
+
+	private static String extractStyle(String html) {
+		org.jsoup.nodes.Document doc = Jsoup.parseBodyFragment(html);
+		org.jsoup.nodes.Element el = doc.selectFirst("[style]");
+		return (el == null) ? "" : el.attr("style");
+	}
+
+	private static String visible(String s) {
+		StringBuilder b = new StringBuilder();
+		for (char c : s.toCharArray()) {
+			if (c < 0x20) {
+				b.append("<").append((int) c).append(">");
+			} else {
+				b.append(c);
+			}
+		}
+		return b.length() > 160 ? b.substring(0, 160) + "…" : b.toString();
+	}
+
+}

--- a/Presentation/org.egovframe.rte.ptl.mvc/src/test/java/org/egovframe/rte/ptl/mvc/filter/EgovHtmlSanitizerTest.java
+++ b/Presentation/org.egovframe.rte.ptl.mvc/src/test/java/org/egovframe/rte/ptl/mvc/filter/EgovHtmlSanitizerTest.java
@@ -1,0 +1,198 @@
+package org.egovframe.rte.ptl.mvc.filter;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.jsoup.safety.Safelist;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * {@link EgovHtmlSanitizer} 단위 테스트 — A-01 HTML 출력 정제.
+ *
+ * <p>공격 벡터 제거(스크립트·이벤트 핸들러·위험 프로토콜·변형 공격)와
+ * 정상 서식 보존(정책별 허용 범위·상대경로·style 재필터)을 함께 검증한다.</p>
+ */
+class EgovHtmlSanitizerTest {
+
+	// ─────────────────────────────── 공격 벡터 제거 ───────────────────────────────
+
+	@Test
+	@DisplayName("script 태그는 어떤 정책에서도 제거된다")
+	void script_태그_제거() {
+		String attack = "<p>본문</p><script>alert('xss')</script>";
+		for (EgovHtmlSanitizePolicy policy : EgovHtmlSanitizePolicy.values()) {
+			String result = EgovHtmlSanitizer.sanitize(attack, policy);
+			assertFalse(result.contains("<script"), policy + " 정책에서 script 잔존: " + result);
+			assertFalse(result.contains("alert"), policy + " 정책에서 script 본문 잔존: " + result);
+		}
+	}
+
+	@Test
+	@DisplayName("이벤트 핸들러 속성(onclick·onerror)은 제거된다")
+	void 이벤트_핸들러_제거() {
+		String result = EgovHtmlSanitizer.sanitize(
+				"<p onclick=\"steal()\">글</p><img src=\"/img/a.png\" onerror=\"steal()\">");
+		assertFalse(result.contains("onclick"));
+		assertFalse(result.contains("onerror"));
+		assertTrue(result.contains("<p>글</p>"), "정상 태그는 남아야 한다: " + result);
+		assertTrue(result.contains("<img"), "정상 이미지는 남아야 한다: " + result);
+	}
+
+	@Test
+	@DisplayName("javascript: 프로토콜 링크는 href 자체가 제거된다")
+	void 위험_프로토콜_제거() {
+		String result = EgovHtmlSanitizer.sanitize("<a href=\"javascript:alert(1)\">클릭</a>");
+		assertFalse(result.contains("javascript"), "javascript: URL 잔존: " + result);
+		assertTrue(result.contains("클릭"), "링크 텍스트는 남아야 한다");
+	}
+
+	@Test
+	@DisplayName("변형 공격(<scr<script>ipt>)도 파서 기반 정제라 무력화된다")
+	void 변형_공격_무력화() {
+		// 문자열 치환식 필터가 뚫리는 고전 우회 — 파서 기반 화이트리스트는 뚫리지 않는다
+		String result = EgovHtmlSanitizer.sanitize("<scr<script>ipt>alert('xss')</scr</script>ipt>");
+		assertFalse(result.contains("<script"), "변형 공격 잔존: " + result);
+	}
+
+	@Test
+	@DisplayName("svg/iframe 등 허용 목록 밖 태그는 제거된다")
+	void 허용목록_밖_태그_제거() {
+		String result = EgovHtmlSanitizer.sanitize(
+				"<svg onload=\"alert(1)\"></svg><iframe src=\"https://evil.example\"></iframe><p>본문</p>");
+		assertFalse(result.contains("<svg"));
+		assertFalse(result.contains("<iframe"));
+		assertTrue(result.contains("<p>본문</p>"));
+	}
+
+	// ─────────────────────────────── 정상 서식 보존 ───────────────────────────────
+
+	@Test
+	@DisplayName("기본 정책(RICH_TEXT)은 에디터 서식(표·제목·이미지·링크)을 보존한다")
+	void 기본정책_서식_보존() {
+		String richText = "<h2>제목</h2><table><tbody><tr><td>셀</td></tr></tbody></table>"
+				+ "<p><strong>강조</strong>와 <a href=\"https://www.egovframe.go.kr\">링크</a></p>"
+				+ "<img src=\"https://cdn.example/a.png\">";
+		String result = EgovHtmlSanitizer.sanitize(richText);
+		assertTrue(result.contains("<h2>제목</h2>"));
+		assertTrue(result.contains("<td>셀</td>"));
+		assertTrue(result.contains("<strong>강조</strong>"));
+		assertTrue(result.contains("href=\"https://www.egovframe.go.kr\""));
+		assertTrue(result.contains("<img src=\"https://cdn.example/a.png\""));
+	}
+
+	@Test
+	@DisplayName("컨텍스트 상대경로 URL 은 절대경로로 바뀌지 않고 유지된다")
+	void 상대경로_보존() {
+		String result = EgovHtmlSanitizer.sanitize(
+				"<img src=\"/utl/web/imageSrc.do?path=2026/a.png\">"
+						+ "<a href=\"/cop/bbs/select.do?bbsId=1\">글</a>");
+		assertTrue(result.contains("src=\"/utl/web/imageSrc.do?path=2026/a.png\""),
+				"이미지 상대경로가 변형됨: " + result);
+		assertTrue(result.contains("href=\"/cop/bbs/select.do?bbsId=1\""),
+				"링크 상대경로가 변형됨: " + result);
+		assertFalse(result.contains("http://localhost"), "더미 baseUri 가 출력에 노출됨: " + result);
+	}
+
+	@Test
+	@DisplayName("한글 본문은 훼손 없이 그대로 보존된다")
+	void 한글_본문_보존() {
+		String html = "<p>안녕하세요. 표준프레임워크 실행환경입니다, 마침표와 쉼표.</p>";
+		assertEquals(html, EgovHtmlSanitizer.sanitize(html));
+	}
+
+	// ─────────────────────────────── style 재필터 ───────────────────────────────
+
+	@Test
+	@DisplayName("img style 은 width/height 선언만 남고 그 외 CSS 는 제거된다")
+	void style_재필터() {
+		String result = EgovHtmlSanitizer.sanitize(
+				"<img src=\"/a.png\" style=\"width:640px; position:fixed; height:50%; "
+						+ "background:url(javascript:alert(1))\">");
+		assertTrue(result.contains("width:640px"), "허용 선언 소실: " + result);
+		assertTrue(result.contains("height:50%"), "허용 선언 소실: " + result);
+		assertFalse(result.contains("position"), "위험 선언 잔존: " + result);
+		assertFalse(result.contains("background"), "위험 선언 잔존: " + result);
+	}
+
+	@Test
+	@DisplayName("허용 선언이 하나도 없는 style 속성은 통째로 제거된다")
+	void style_전부_위험시_속성_제거() {
+		String result = EgovHtmlSanitizer.sanitize(
+				"<img src=\"/a.png\" style=\"position:absolute; z-index:9999\">");
+		assertFalse(result.contains("style="), "빈 style 속성이 남음: " + result);
+		assertTrue(result.contains("<img"), "이미지 자체는 남아야 한다");
+	}
+
+	// ─────────────────────────────── 정책별 허용 범위 ───────────────────────────────
+
+	@Test
+	@DisplayName("TEXT_ONLY/stripToText 는 태그를 전부 제거하고 텍스트만 남긴다")
+	void 텍스트_전용_정책() {
+		String result = EgovHtmlSanitizer.stripToText("<b>공지</b>: <a href=\"/a.do\">이동</a>");
+		assertFalse(result.contains("<"), "태그 잔존: " + result);
+		assertTrue(result.contains("공지"));
+		assertTrue(result.contains("이동"));
+	}
+
+	@Test
+	@DisplayName("SIMPLE_TEXT 는 강조 태그만 남기고 링크는 제거한다")
+	void 단순_강조_정책() {
+		String result = EgovHtmlSanitizer.sanitize(
+				"<b>강조</b> <a href=\"/a.do\">링크</a>", EgovHtmlSanitizePolicy.SIMPLE_TEXT);
+		assertTrue(result.contains("<b>강조</b>"));
+		assertFalse(result.contains("<a "), "링크 태그 잔존: " + result);
+		assertTrue(result.contains("링크"), "링크 텍스트는 남아야 한다");
+	}
+
+	@Test
+	@DisplayName("BASIC 은 이미지를 제거하고 BASIC_WITH_IMAGES 는 남긴다")
+	void 이미지_허용_정책_차이() {
+		String html = "<p>본문</p><img src=\"https://cdn.example/a.png\">";
+		String basic = EgovHtmlSanitizer.sanitize(html, EgovHtmlSanitizePolicy.BASIC);
+		String withImages = EgovHtmlSanitizer.sanitize(html, EgovHtmlSanitizePolicy.BASIC_WITH_IMAGES);
+		assertFalse(basic.contains("<img"), "BASIC 에서 이미지 잔존: " + basic);
+		assertTrue(withImages.contains("<img"), "BASIC_WITH_IMAGES 에서 이미지 소실: " + withImages);
+	}
+
+	// ─────────────────────────────── 계약(경계값·확장점) ───────────────────────────────
+
+	@Test
+	@DisplayName("null·공백 입력은 빈 문자열을 반환한다(뷰에서 null 분기 불필요)")
+	void null_공백_계약() {
+		assertEquals("", EgovHtmlSanitizer.sanitize(null));
+		assertEquals("", EgovHtmlSanitizer.sanitize("   "));
+		assertEquals("", EgovHtmlSanitizer.stripToText(null));
+		assertEquals("", EgovHtmlSanitizer.sanitize(null, EgovHtmlSanitizePolicy.BASIC));
+	}
+
+	@Test
+	@DisplayName("정책 null 은 기본 정책(RICH_TEXT)으로 동작한다")
+	void 정책_null_기본값() {
+		String html = "<h2>제목</h2>";
+		assertEquals(EgovHtmlSanitizer.sanitize(html),
+				EgovHtmlSanitizer.sanitize(html, (EgovHtmlSanitizePolicy) null));
+	}
+
+	@Test
+	@DisplayName("커스텀 Safelist 확장점 — 허용 목록을 직접 구성할 수 있고 style 재필터는 유지된다")
+	void 커스텀_Safelist() {
+		Safelist custom = Safelist.none().addTags("mark").addAttributes("mark", "style");
+		String result = EgovHtmlSanitizer.sanitize(
+				"<mark style=\"width:10px; color:red\">형광펜</mark><b>제거대상</b>", custom);
+		assertTrue(result.contains("<mark"), "커스텀 허용 태그 소실: " + result);
+		assertFalse(result.contains("<b>"), "커스텀 목록 밖 태그 잔존: " + result);
+		assertTrue(result.contains("width:10px"), "허용 style 선언 소실: " + result);
+		assertFalse(result.contains("color"), "커스텀 경로에서도 style 재필터가 적용돼야 한다: " + result);
+	}
+
+	@Test
+	@DisplayName("커스텀 Safelist null 은 명시 예외")
+	void 커스텀_Safelist_null_예외() {
+		assertThrows(IllegalArgumentException.class,
+				() -> EgovHtmlSanitizer.sanitize("<p>x</p>", (Safelist) null));
+	}
+
+}


### PR DESCRIPTION
> **[공통컴포넌트 공통 기능 개선 → 실행환경 이관]**
>
> 공통컴포넌트에 있던 공통 기능을 개선해 실행환경으로 올리는 항목입니다.
> 실행환경에 올라가면 공통컴포넌트를 포함한 모든 사업에서 같은 구현을 쓸 수 있습니다.
>
> 공통컴포넌트 원본
> - `egovframework.com.cmm.EgovHtmlSanitizer`

## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [ ] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [X] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

### 배경

`ptl.mvc` 의 기존 XSS 방어는 입력 필터 `HTMLTagFilter` 하나이며, 요청 파라미터의 `<` 를
`&lt;` 로 전량 인코딩합니다. 안전하지만 **HTML 서식 자체를 쓸 수 없어** 리치 텍스트
에디터(CKEditor 등)로 작성한 게시물 본문과는 양립하지 않습니다.

그래서 실무에서는 해당 경로에서 필터를 끄거나 우회하게 되고, **그 지점의 방어가 사라집니다.**
실행환경에는 jsoup·OWASP Encoder·ESAPI·AntiSamy 계열 의존이 없어 "HTML 을 허용하면서 위험
요소만 거르는" 수단이 존재하지 않았습니다.

### 추가한 것

- **`filter/EgovHtmlSanitizer`** — jsoup `Safelist` 화이트리스트 기반 출력 정제
  - `sanitize(html)` / `sanitize(html, 정책)` / `sanitize(html, Safelist)` / `stripToText(html)`
- **`filter/EgovHtmlSanitizePolicy`** — 용도별 정책 5종
  - `TEXT_ONLY` → `SIMPLE_TEXT` → `BASIC` → `BASIC_WITH_IMAGES` → `RICH_TEXT`

입력 필터(`HTMLTagFilter`)와 **상호 보완** 관계이며 **기존 클래스는 수정하지 않았습니다.**
서식이 필요 없는 필드는 기존 필터, 서식이 필요한 본문은 정제기를 쓰는 구성입니다.

### 설계 메모

- **화이트리스트 방식** — 허용 목록에 없는 태그·속성·프로토콜은 전부 제거되므로, 문자열
  치환식 필터를 뚫는 우회(`<scr<script>ipt>`)가 통하지 않습니다
- **컨텍스트 상대경로 보존** — `/utl/web/imageSrc.do?...` 같은 URL 이 절대경로로 변형되지 않습니다
- **`style` 재필터** — `Safelist` 는 CSS 값 자체를 검증하지 않으므로, 정제 후 `style` 속성을
  `width`/`height` 선언만 남도록 한 번 더 거릅니다(`position:fixed` 클릭재킹 등 차단)
- **의존성 격리** — `jsoup` 은 `ptl.mvc` 한정 **`optional`** 입니다. 정제 기능을 쓰는
  애플리케이션만 직접 선언하면 되고, **기존 사용자의 클래스패스에는 아무 영향이 없습니다**
- 설계는 공통컴포넌트 `cmm/EgovHtmlSanitizer`(Apache 2.0)에서 차용했고, 단일 고정 정책을
  용도별 선택형으로 재구성했습니다. **기본 정책이 원본과 동일**해 공통컴포넌트를 쓰던 코드는
  import 교체만으로 이전할 수 있습니다

### 추가되는 의존성

| 좌표 | 버전 | 라이선스 | 크기 | 스코프 |
|---|---|---|---:|---|
| `org.jsoup:jsoup` | 1.21.1 | **MIT** | 487 KB | **`optional`** |

`mvn dependency:tree` 실측 결과 **전이 의존이 0건**이며 `(optional)` 로 표시됩니다.

```
[INFO] +- org.jsoup:jsoup:jar:1.21.1:compile (optional)
```

## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [X] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

`EgovHtmlSanitizerTest` **17건** + 보안 회귀 `EgovHtmlSanitizerSecurityTest` **5건**, 합계 **22건 신규**. `ptl.mvc` 모듈 **전건 통과**.

```
mvn -B -Dfile.encoding=UTF-8 -Duser.timezone=Asia/Seoul -pl :egovframe-rte-ptl-mvc -am clean test
```

| 환경 | 기본 로케일(Locale) | ptl.mvc 실행 건수 | 결과 |
|---|---|---:|---|
| 이관 전 | — | 42 | — |
| **Windows** | ko_KR | **64** | `Tests run: 64, Failures: 0, Errors: 0, Skipped: 0` |
| **Linux** (Ubuntu 22.04 / OpenJDK 17 / ext4) | C.UTF-8 | **64** | `Tests run: 64, Failures: 0, Errors: 0, Skipped: 0` |

| 구분 | 건수 | 내용 |
|---|---:|---|
| 공격 벡터 제거 | 5 | script 태그(전 정책 순회) · 이벤트 핸들러 · `javascript:` · **변형 공격 무력화** · svg/iframe |
| 정상 서식 보존 | 3 | 표·제목·이미지·링크 · **컨텍스트 상대경로 무변형** · **한글 본문 무훼손** |
| style 재필터 | 2 | `width`/`height` 만 잔존 · 전부 위험하면 속성 제거 |
| 정책별 허용 범위 | 3 | `TEXT_ONLY` · `SIMPLE_TEXT` 링크 제거 · 이미지 허용 차이 |
| 계약 | 4 | `null`/공백 → 빈 문자열 · 정책 `null` 기본값 · 커스텀 `Safelist` · `null` 예외 |

`EgovHtmlSanitizerSecurityTest` 5건 — 5개 정책 × 51개 우회 변형(`javascript:`/`vbscript:`/`data:` 스킴 변형·이벤트 핸들러·svg/iframe/object/embed/base/meta/form·mXSS 고전)에서 **실행 가능한 구조가 하나도 남지 않고 재파싱 결과가 같음** · 제어 문자로 끝나는 raw-text 태그도 내장 정책에서 무력화 · `style` 속성 재필터 우회 불가 · 상대경로 보존과 baseUri 비노출 · 대용량·깊은 입력 견고성.

**수동 확인**: 한글 본문 처리와 인코딩이 얽혀 있어, 기본 로케일이 다른 Linux(`C.UTF-8`) 환경에서
별도로 교차 검증했습니다.

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

해당 없음 — 뷰나 화면이 아닌 **라이브러리 클래스 추가**이며, 검증은 위 JUnit 으로 수행했습니다.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

해당 없음 — 위 JUnit 테스트 결과로 갈음합니다.

---

<sub>base: `eGovFramework:main` @ `cd9fd9c` (2026-09-08 fetch 기준) · 단일 커밋</sub>
