### PR TITLE
feat: HTTP 요청 컨텍스트 파사드 EgovRequestContext 추가

### DIFF
--- a/Presentation/org.egovframe.rte.ptl.mvc/src/main/java/org/egovframe/rte/ptl/mvc/context/EgovRequestContext.java
+++ b/Presentation/org.egovframe.rte.ptl.mvc/src/main/java/org/egovframe/rte/ptl/mvc/context/EgovRequestContext.java
@@ -1,0 +1,219 @@
+/*
+ * Copyright 2009-2026 MOIS(Ministry of the Interior and Safety).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.egovframe.rte.ptl.mvc.context;
+
+import java.util.Optional;
+
+import org.springframework.web.context.request.RequestAttributes;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
+
+/**
+ * 현재 HTTP 요청 정보를 어디서나 꺼낼 수 있게 하는 <b>요청 컨텍스트 파사드</b>.
+ *
+ * <p>서비스 계층처럼 {@code HttpServletRequest} 를 인자로 받지 않는 자리에서 요청 정보가
+ * 필요할 때, {@code RequestContextHolder} 를 직접 다루는 보일러플레이트를 대신한다.</p>
+ *
+ * <pre>
+ * // 직접 다루면 — 매번 반복되고, 컨텍스트가 없을 때의 처리가 제각각이 된다
+ * RequestAttributes attrs = RequestContextHolder.getRequestAttributes();
+ * if (attrs instanceof ServletRequestAttributes) {
+ *     HttpServletRequest request = ((ServletRequestAttributes) attrs).getRequest();
+ *     ...
+ * }
+ *
+ * // 파사드
+ * EgovRequestContext.getRequestUri().ifPresent(uri -&gt; log.info("요청 {}", uri));
+ * </pre>
+ *
+ * <p><b>요청 컨텍스트가 없을 수 있다.</b> 배치·스케줄러·비동기 스레드에서는 당연히 없고,
+ * 웹 요청이라도 별도 스레드로 넘어가면 사라진다. 그래서 조회 메서드는 모두
+ * {@link Optional} 을 돌려주며, <b>없는 것은 예외 상황이 아니다</b>.
+ * 반드시 있어야 하는 자리라면 {@link #getRequiredRequest()} 를 쓴다.</p>
+ *
+ * <p><b>가능하면 요청을 인자로 받는 편이 낫다.</b> 이 파사드는 스레드로컬에 의존하므로
+ * 비동기 처리에서 값이 사라지고, 테스트에서도 별도 준비가 필요하다.
+ * 컨트롤러·필터처럼 요청을 손에 쥘 수 있는 자리에서는 그대로 넘겨 쓰는 것이 명확하다.</p>
+ *
+ * <p><b>전제</b> — 서블릿 컨테이너에서 {@code RequestContextHolder} 가 채워져 있어야 한다.
+ * Spring MVC 의 {@code DispatcherServlet} 이 처리하는 요청은 자동으로 채워지지만,
+ * 그 밖의 경로(필터 단계 등)에서도 쓰려면 {@code RequestContextListener} 등록이 필요하다.</p>
+ *
+ * <pre>
+ * &lt;&lt; 개정이력(Modification Information) &gt;&gt;
+ *
+ *  수정일        수정자        수정내용
+ *  ----------  --------    ---------------------------
+ *  2026.09.01  실행환경팀     최초 생성 (A-05: 공통컴포넌트 EgovHttpRequestHelper 의 설계를
+ *                            차용하되 예외 기반 판정·세션 강제 생성·프록시 미대응 IP 이름을
+ *                            Optional 계약과 정직한 명명으로 재구성 — 코드 이식 아님)
+ * </pre>
+ *
+ * @author 실행환경 개발팀
+ * @since 5.1
+ */
+public final class EgovRequestContext {
+
+	private EgovRequestContext() {
+	}
+
+	/**
+	 * 현재 스레드에 HTTP 요청 컨텍스트가 있는지 확인한다.
+	 *
+	 * <p>예외를 던지거나 잡지 않고 판정한다 — 배치·비동기 스레드에서 이 메서드를 호출하는 것은
+	 * 정상적인 사용이므로 예외를 흐름 제어에 쓰지 않는다.</p>
+	 *
+	 * @return 요청 컨텍스트가 있으면 true
+	 */
+	public static boolean isPresent() {
+		return servletRequestAttributes().isPresent();
+	}
+
+	/**
+	 * 현재 요청을 반환한다.
+	 *
+	 * @return 현재 요청. 요청 컨텍스트가 없으면 빈 Optional
+	 */
+	public static Optional<HttpServletRequest> getRequest() {
+		return servletRequestAttributes().map(ServletRequestAttributes::getRequest);
+	}
+
+	/**
+	 * 현재 요청을 반환하되, 없으면 예외를 던진다.
+	 *
+	 * <p>요청이 반드시 있어야 하는 자리(웹 전용 컴포넌트)에서만 쓴다.</p>
+	 *
+	 * @return 현재 요청
+	 * @throws IllegalStateException 요청 컨텍스트가 없는 경우
+	 */
+	public static HttpServletRequest getRequiredRequest() {
+		return getRequest().orElseThrow(() -> new IllegalStateException(
+				"현재 스레드에 HTTP 요청 컨텍스트가 없습니다. "
+						+ "배치·비동기 스레드이거나 RequestContextListener 가 등록되지 않았을 수 있습니다."));
+	}
+
+	/**
+	 * 현재 응답을 반환한다.
+	 *
+	 * @return 현재 응답. 컨텍스트가 없거나 응답이 노출되지 않는 경우 빈 Optional
+	 */
+	public static Optional<HttpServletResponse> getResponse() {
+		return servletRequestAttributes().map(ServletRequestAttributes::getResponse);
+	}
+
+	/**
+	 * 현재 세션을 반환한다 — <b>없으면 만들지 않는다.</b>
+	 *
+	 * <p>단순 조회 때문에 세션이 생기면 비로그인 방문자에게도 세션이 할당되어 자원이 낭비된다.
+	 * 세션이 필요해서 만들어야 한다면 {@link #getOrCreateSession()} 을 명시적으로 쓴다.</p>
+	 *
+	 * @return 현재 세션. 요청 컨텍스트나 세션이 없으면 빈 Optional
+	 */
+	public static Optional<HttpSession> getSession() {
+		return getRequest().map(request -> request.getSession(false));
+	}
+
+	/**
+	 * 현재 세션을 반환하되, 없으면 새로 만든다.
+	 *
+	 * @return 현재 세션(필요하면 신규 생성)
+	 * @throws IllegalStateException 요청 컨텍스트가 없는 경우
+	 */
+	public static HttpSession getOrCreateSession() {
+		return getRequiredRequest().getSession();
+	}
+
+	/**
+	 * 요청 URI 를 반환한다(컨텍스트 경로 포함).
+	 *
+	 * @return 요청 URI. 요청 컨텍스트가 없으면 빈 Optional
+	 */
+	public static Optional<String> getRequestUri() {
+		return getRequest().map(HttpServletRequest::getRequestURI);
+	}
+
+	/**
+	 * HTTP 메서드를 반환한다.
+	 *
+	 * @return GET·POST 등. 요청 컨텍스트가 없으면 빈 Optional
+	 */
+	public static Optional<String> getMethod() {
+		return getRequest().map(HttpServletRequest::getMethod);
+	}
+
+	/**
+	 * <b>TCP 연결 상대의 주소</b>를 반환한다({@code getRemoteAddr()}).
+	 *
+	 * <p><b>이것은 "클라이언트 IP" 가 아닐 수 있다.</b> L4·리버스 프록시·CDN 뒤에 배포하면
+	 * 이 값은 전부 <b>프록시의 IP</b> 로 고정된다. 접속 기록·감사 로그에 실제 사용자 IP 가
+	 * 필요하다면 {@code X-Forwarded-For} 같은 헤더를 봐야 하는데, 그 헤더는 클라이언트가
+	 * 임의로 넣을 수 있으므로 <b>신뢰할 프록시를 정해 두고 그 경우에만 받아들이는</b>
+	 * 신뢰 경계 설계가 함께 필요하다.</p>
+	 *
+	 * <p>메서드 이름을 {@code getClientIp} 로 두지 않은 이유가 그것이다 — 프록시 뒤에서는
+	 * 이름이 사실과 달라진다. 신뢰 경계를 갖춘 클라이언트 IP 해석은 별도 과제(C-04)에서 다룬다.</p>
+	 *
+	 * @return 원격 주소. 요청 컨텍스트가 없으면 빈 Optional
+	 */
+	public static Optional<String> getRemoteAddress() {
+		return getRequest().map(HttpServletRequest::getRemoteAddr);
+	}
+
+	/**
+	 * 요청 헤더 값을 반환한다.
+	 *
+	 * @param name 헤더 이름 (null 이면 빈 Optional)
+	 * @return 헤더 값. 요청 컨텍스트가 없거나 해당 헤더가 없으면 빈 Optional
+	 */
+	public static Optional<String> getHeader(String name) {
+		if (name == null) {
+			return Optional.empty();
+		}
+		return getRequest().map(request -> request.getHeader(name));
+	}
+
+	/**
+	 * 요청 파라미터 값을 반환한다.
+	 *
+	 * @param name 파라미터 이름 (null 이면 빈 Optional)
+	 * @return 파라미터 값. 요청 컨텍스트가 없거나 해당 파라미터가 없으면 빈 Optional
+	 */
+	public static Optional<String> getParameter(String name) {
+		if (name == null) {
+			return Optional.empty();
+		}
+		return getRequest().map(request -> request.getParameter(name));
+	}
+
+	/**
+	 * 현재 스레드의 {@link ServletRequestAttributes} 를 찾는다.
+	 *
+	 * <p>{@code RequestContextHolder.currentRequestAttributes()} 는 없을 때 예외를 던지므로,
+	 * 예외 없이 판정 가능한 {@code getRequestAttributes()} 를 쓴다. 서블릿 환경이 아닌
+	 * {@link RequestAttributes} 구현이 올 수도 있어 타입도 함께 확인한다.</p>
+	 */
+	private static Optional<ServletRequestAttributes> servletRequestAttributes() {
+		RequestAttributes attributes = RequestContextHolder.getRequestAttributes();
+		return (attributes instanceof ServletRequestAttributes)
+				? Optional.of((ServletRequestAttributes) attributes)
+				: Optional.empty();
+	}
+
+}

--- a/Presentation/org.egovframe.rte.ptl.mvc/src/test/java/org/egovframe/rte/ptl/mvc/context/EgovRequestContextSecurityTest.java
+++ b/Presentation/org.egovframe.rte.ptl.mvc/src/test/java/org/egovframe/rte/ptl/mvc/context/EgovRequestContextSecurityTest.java
@@ -1,0 +1,125 @@
+package org.egovframe.rte.ptl.mvc.context;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.web.context.request.AbstractRequestAttributes;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+/**
+ * {@link EgovRequestContext} 의 <b>신뢰 경계</b> 회귀 검증.
+ *
+ * <p>이 파사드는 요청 정보를 <b>해석하지 않고 그대로 전달</b>한다. 그래서 고정할 성질은 두 가지다 —
+ * 원격 주소가 클라이언트가 위조할 수 있는 전달 헤더에 영향받지 않을 것, 어떤 적대적 헤더 값에도
+ * 예외 없이 값을 그대로 돌려줄 것(해석은 호출자의 신뢰 경계 설계에 맡긴다).</p>
+ */
+class EgovRequestContextSecurityTest {
+
+	@AfterEach
+	void clearContext() {
+		RequestContextHolder.resetRequestAttributes();
+	}
+
+	private static MockHttpServletRequest bind() {
+		MockHttpServletRequest request = new MockHttpServletRequest("GET", "/app/page");
+		request.setRemoteAddr("10.0.0.1");
+		RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request, new MockHttpServletResponse()));
+		return request;
+	}
+
+	@Test
+	@DisplayName("원격 주소는 TCP 상대 주소이며, 클라이언트가 위조할 수 있는 전달 헤더에 영향받지 않는다")
+	void 원격_주소는_전달_헤더에_영향받지_않음() {
+		MockHttpServletRequest request = bind();
+		request.addHeader("X-Forwarded-For", "203.0.113.5, 198.51.100.7");
+		request.addHeader("X-Real-IP", "203.0.113.5");
+		request.addHeader("Proxy-Client-IP", "203.0.113.5");
+		request.addHeader("WL-Proxy-Client-IP", "203.0.113.5");
+		request.addHeader("Forwarded", "for=203.0.113.5");
+
+		assertEquals(Optional.of("10.0.0.1"), EgovRequestContext.getRemoteAddress());
+	}
+
+	@Test
+	@DisplayName("적대적 헤더 값(CR/LF·10KB·스크립트·비정상 언어 태그)은 해석 없이 그대로 돌아오고 예외를 내지 않는다")
+	void 적대_헤더는_해석_없이_그대로() {
+		MockHttpServletRequest request = bind();
+		String crlf = "https\r\nX-Injected: 1";
+		String huge = "x".repeat(10240);
+		request.addHeader("X-Forwarded-Proto", crlf);
+		request.addHeader("User-Agent", huge);
+		request.addHeader("Referer", "javascript:alert(1)");
+		request.addHeader("Accept-Language", "xx-YY-ZZ-" + "a".repeat(500));
+		request.addHeader("X-Forwarded-Host", "evil.example:80@good.example");
+
+		assertEquals(Optional.of(crlf), EgovRequestContext.getHeader("X-Forwarded-Proto"));
+		assertEquals(Optional.of(huge), EgovRequestContext.getHeader("User-Agent"));
+		assertEquals(Optional.of("javascript:alert(1)"), EgovRequestContext.getHeader("Referer"));
+		assertTrue(EgovRequestContext.getHeader("Accept-Language").isPresent());
+		assertEquals(Optional.of("evil.example:80@good.example"), EgovRequestContext.getHeader("X-Forwarded-Host"));
+		assertEquals(Optional.empty(), EgovRequestContext.getHeader("X-Not-Sent"));
+		assertEquals(Optional.of("/app/page"), EgovRequestContext.getRequestUri());
+	}
+
+	@Test
+	@DisplayName("서블릿이 아닌 요청 속성 구현이 바인딩돼 있으면 '없음'으로 판정한다 — 형 변환 예외가 나지 않는다")
+	void 비서블릿_요청_속성은_없음으로_판정() {
+		RequestContextHolder.setRequestAttributes(new AbstractRequestAttributes() {
+			@Override
+			public Object getAttribute(String name, int scope) {
+				return null;
+			}
+
+			@Override
+			public void setAttribute(String name, Object value, int scope) {
+			}
+
+			@Override
+			public void removeAttribute(String name, int scope) {
+			}
+
+			@Override
+			public String[] getAttributeNames(int scope) {
+				return new String[0];
+			}
+
+			@Override
+			public void registerDestructionCallback(String name, Runnable callback, int scope) {
+			}
+
+			@Override
+			public Object resolveReference(String key) {
+				return null;
+			}
+
+			@Override
+			public String getSessionId() {
+				return "none";
+			}
+
+			@Override
+			public Object getSessionMutex() {
+				return this;
+			}
+
+			@Override
+			protected void updateAccessedSessionAttributes() {
+			}
+		});
+
+		assertFalse(EgovRequestContext.isPresent());
+		assertEquals(Optional.empty(), EgovRequestContext.getRequest());
+		assertEquals(Optional.empty(), EgovRequestContext.getRemoteAddress());
+		assertEquals(Optional.empty(), EgovRequestContext.getSession());
+	}
+
+}

--- a/Presentation/org.egovframe.rte.ptl.mvc/src/test/java/org/egovframe/rte/ptl/mvc/context/EgovRequestContextTest.java
+++ b/Presentation/org.egovframe.rte.ptl.mvc/src/test/java/org/egovframe/rte/ptl/mvc/context/EgovRequestContextTest.java
@@ -1,0 +1,195 @@
+package org.egovframe.rte.ptl.mvc.context;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.mock.web.MockHttpSession;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+import jakarta.servlet.http.HttpSession;
+
+/**
+ * {@link EgovRequestContext} 단위 테스트 — A-05 요청 컨텍스트 파사드.
+ *
+ * <p>기본 조회 계약과 함께, 원본(공통컴포넌트 EgovHttpRequestHelper)의
+ * <b>예외 기반 존재 판정</b>·<b>세션 강제 생성</b>을 회귀 검증한다.</p>
+ */
+class EgovRequestContextTest {
+
+	@AfterEach
+	void clearContext() {
+		RequestContextHolder.resetRequestAttributes();
+	}
+
+	private MockHttpServletRequest bind() {
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
+		return request;
+	}
+
+	private MockHttpServletRequest bind(MockHttpServletResponse response) {
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request, response));
+		return request;
+	}
+
+	// ─────────────── 원본 결함 ① 예외 기반 존재 판정 ───────────────
+
+	@Test
+	@DisplayName("요청 컨텍스트가 없으면 isPresent 는 예외 없이 false 를 반환한다")
+	void 컨텍스트_없음_예외_없이_판정() {
+		assertFalse(EgovRequestContext.isPresent(),
+				"배치·비동기 스레드에서의 호출은 정상 사용이므로 예외가 나면 안 된다");
+	}
+
+	@Test
+	@DisplayName("컨텍스트가 없으면 조회 메서드는 모두 빈 Optional 이다")
+	void 컨텍스트_없음_조회() {
+		assertTrue(EgovRequestContext.getRequest().isEmpty());
+		assertTrue(EgovRequestContext.getResponse().isEmpty());
+		assertTrue(EgovRequestContext.getSession().isEmpty());
+		assertTrue(EgovRequestContext.getRequestUri().isEmpty());
+		assertTrue(EgovRequestContext.getMethod().isEmpty());
+		assertTrue(EgovRequestContext.getRemoteAddress().isEmpty());
+		assertTrue(EgovRequestContext.getHeader("X-Test").isEmpty());
+		assertTrue(EgovRequestContext.getParameter("q").isEmpty());
+	}
+
+	@Test
+	@DisplayName("반드시 필요한 자리에서는 getRequiredRequest 가 사유를 담아 예외를 던진다")
+	void 필수_요청_예외() {
+		IllegalStateException e = assertThrows(IllegalStateException.class,
+				EgovRequestContext::getRequiredRequest);
+
+		assertTrue(e.getMessage().contains("요청 컨텍스트"), "원인을 알 수 있는 메시지여야 한다");
+	}
+
+	// ─────────────── 원본 결함 ② 세션 강제 생성 ───────────────
+
+	@Test
+	@DisplayName("getSession 은 세션이 없으면 만들지 않는다")
+	void 세션_생성하지_않음() {
+		MockHttpServletRequest request = bind();
+
+		assertTrue(EgovRequestContext.getSession().isEmpty());
+		assertNull(request.getSession(false),
+				"단순 조회로 세션이 생기면 비로그인 방문자에게도 세션이 할당된다");
+	}
+
+	@Test
+	@DisplayName("세션이 이미 있으면 그 세션을 그대로 반환한다")
+	void 기존_세션_반환() {
+		MockHttpServletRequest request = bind();
+		MockHttpSession session = new MockHttpSession();
+		request.setSession(session);
+
+		assertSame(session, EgovRequestContext.getSession().orElseThrow());
+	}
+
+	@Test
+	@DisplayName("getOrCreateSession 은 명시적으로 세션을 만든다")
+	void 세션_명시_생성() {
+		MockHttpServletRequest request = bind();
+
+		HttpSession created = EgovRequestContext.getOrCreateSession();
+
+		assertNotNull(created);
+		assertNotNull(request.getSession(false), "명시 호출에서는 생성돼야 한다");
+	}
+
+	@Test
+	@DisplayName("컨텍스트가 없으면 getOrCreateSession 은 예외")
+	void 세션_생성_컨텍스트_없음() {
+		assertThrows(IllegalStateException.class, EgovRequestContext::getOrCreateSession);
+	}
+
+	// ─────────────────────────── 기본 조회 ───────────────────────────
+
+	@Test
+	@DisplayName("바인딩된 요청을 그대로 반환한다")
+	void 요청_반환() {
+		MockHttpServletRequest request = bind();
+
+		assertTrue(EgovRequestContext.isPresent());
+		assertSame(request, EgovRequestContext.getRequest().orElseThrow());
+		assertSame(request, EgovRequestContext.getRequiredRequest());
+	}
+
+	@Test
+	@DisplayName("요청 URI·메서드·원격 주소를 조회한다")
+	void 요청_정보() {
+		MockHttpServletRequest request = bind();
+		request.setRequestURI("/board/list.do");
+		request.setMethod("POST");
+		request.setRemoteAddr("10.1.2.3");
+
+		assertEquals("/board/list.do", EgovRequestContext.getRequestUri().orElseThrow());
+		assertEquals("POST", EgovRequestContext.getMethod().orElseThrow());
+		assertEquals("10.1.2.3", EgovRequestContext.getRemoteAddress().orElseThrow());
+	}
+
+	@Test
+	@DisplayName("헤더·파라미터를 조회하고, 없으면 빈 Optional 이다")
+	void 헤더_파라미터() {
+		MockHttpServletRequest request = bind();
+		request.addHeader("X-Request-Id", "abc-123");
+		request.setParameter("pageIndex", "2");
+
+		assertEquals("abc-123", EgovRequestContext.getHeader("X-Request-Id").orElseThrow());
+		assertEquals("2", EgovRequestContext.getParameter("pageIndex").orElseThrow());
+		assertTrue(EgovRequestContext.getHeader("X-Absent").isEmpty());
+		assertTrue(EgovRequestContext.getParameter("absent").isEmpty());
+	}
+
+	@Test
+	@DisplayName("헤더·파라미터 이름이 null 이면 빈 Optional (예외 아님)")
+	void 이름_null() {
+		bind();
+
+		assertTrue(EgovRequestContext.getHeader(null).isEmpty());
+		assertTrue(EgovRequestContext.getParameter(null).isEmpty());
+	}
+
+	@Test
+	@DisplayName("응답이 함께 바인딩되면 응답도 반환한다")
+	void 응답_반환() {
+		MockHttpServletResponse response = new MockHttpServletResponse();
+		bind(response);
+
+		assertSame(response, EgovRequestContext.getResponse().orElseThrow());
+	}
+
+	@Test
+	@DisplayName("응답이 바인딩되지 않았으면 응답은 빈 Optional")
+	void 응답_없음() {
+		bind();
+
+		assertTrue(EgovRequestContext.getResponse().isEmpty());
+	}
+
+	// ─────────────────────────── 정리 계약 ───────────────────────────
+
+	@Test
+	@DisplayName("컨텍스트를 비우면 다시 없음으로 돌아간다(스레드 재사용 대비)")
+	void 컨텍스트_정리() {
+		bind();
+		assertTrue(EgovRequestContext.isPresent());
+
+		RequestContextHolder.resetRequestAttributes();
+
+		assertFalse(EgovRequestContext.isPresent(),
+				"스레드풀 재사용 시 이전 요청 정보가 남으면 안 된다");
+	}
+
+}


### PR DESCRIPTION
> **[공통컴포넌트 공통 기능 개선 → 실행환경 이관]**
>
> 공통컴포넌트에 있던 공통 기능을 개선해 실행환경으로 올리는 항목입니다.
> 실행환경에 올라가면 공통컴포넌트를 포함한 모든 사업에서 같은 구현을 쓸 수 있습니다.
>
> 공통컴포넌트 원본
> - `egovframework.com.cmm.util.EgovHttpRequestHelper`

## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [ ] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [X] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

### 배경

컨트롤러 밖(서비스 계층·AOP·유틸)에서 현재 요청 정보가 필요하면 매번 다음을 반복해야 합니다.

```java
RequestAttributes attrs = RequestContextHolder.getRequestAttributes();
if (attrs instanceof ServletRequestAttributes) {
    HttpServletRequest request = ((ServletRequestAttributes) attrs).getRequest();
    // ...
}
```

캐스팅과 널 확인이 매번 붙고, **널 확인을 빠뜨리면 요청 스코프 밖(배치·비동기 스레드·스케줄러)
에서 `NullPointerException` 이 납니다.** 그런데 예외가 나는 지점이 요청과 무관한 곳이라
원인이 호출 지점에서 드러나지 않아 추적이 어렵습니다.

### 추가한 것

- **`context/EgovRequestContext`** — `RequestContextHolder` 접근을 감싼 정적 파사드

```java
// 있으면 쓰고 없으면 넘어가는 자리
EgovRequestContext.getRemoteAddress().ifPresent(ip -> log.info("from {}", ip));

// 요청이 반드시 있어야 하는 자리
HttpServletRequest request = EgovRequestContext.getRequiredRequest();

// 요청 스코프 여부만 확인
if (EgovRequestContext.isPresent()) { ... }
```

| 메서드 | 반환 | 용도 |
|---|---|---|
| `getRequest` · `getResponse` · `getSession` | `Optional<…>` | 원본 객체 |
| `getRequestUri` · `getMethod` · `getRemoteAddress` | `Optional<String>` | 자주 쓰는 속성 |
| `getHeader(name)` · `getParameter(name)` | `Optional<String>` | 이름 지정 조회 |
| `getRequiredRequest()` | `HttpServletRequest` | 부재 시 **사유를 담은 명시적 예외** |
| `getOrCreateSession()` | `HttpSession` | 세션 생성 의도를 이름에 드러냄 |
| `isPresent()` | `boolean` | 요청 스코프 여부 |

### 설계 메모

- **부재를 `null` 이 아니라 `Optional` 로 표현**합니다. 호출부가 널 확인을 잊을 수 없고,
  요청 스코프 밖에서도 예외 없이 동작합니다
- **필수 접근은 따로 둡니다.** `getRequiredRequest()` 는 부재 시 조용히 넘어가지 않고
  사유를 담은 예외를 던집니다 — 널 반환보다 원인 파악이 빠릅니다
- **세션 생성 여부를 이름으로 구분**합니다. `getSession()` 은 세션을 만들지 않고,
  `getOrCreateSession()` 만 만듭니다. `HttpServletRequest.getSession()` 이 기본값 `true` 로
  세션을 만들어 버리는 것과 달리 의도가 코드에 드러납니다
- **이름이 `null` 이면 예외가 아니라 빈 `Optional`** 입니다(`getHeader(null)` 등) —
  조회 계열의 계약을 일관되게 유지합니다
- **기존 클래스 수정 0 · pom 변경 0 · 신규 의존 0.** 쓰지 않으면 아무 영향이 없습니다

## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [X] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

`EgovRequestContextTest` **14건** + 보안 회귀 `EgovRequestContextSecurityTest` **3건**, 합계 **17건 신규**. `ptl.mvc` 모듈 **전건 통과**.

```
mvn -B -Dfile.encoding=UTF-8 -Duser.timezone=Asia/Seoul -pl :egovframe-rte-ptl-mvc -am clean test
```

| 환경 | 기본 로케일(Locale) | ptl.mvc 실행 건수 | 결과 |
|---|---|---:|---|
| 이관 전 | — | 42 | — |
| **Windows** | ko_KR | **59** | `Tests run: 59, Failures: 0, Errors: 0, Skipped: 0` |
| **Linux** (Ubuntu 22.04 / OpenJDK 17 / ext4) | C.UTF-8 | **59** | `Tests run: 59, Failures: 0, Errors: 0, Skipped: 0` |

| 구분 | 건수 | 내용 |
|---|---:|---|
| 요청 스코프 밖 계약 | 3 | `isPresent` 가 예외 없이 `false` · 조회 메서드 전부 빈 `Optional` · `getOrCreateSession` 은 예외 |
| 필수 접근 | 1 | `getRequiredRequest` 가 **사유를 담아** 예외 |
| 세션 | 3 | `getSession` 은 세션을 만들지 않음 · 기존 세션 그대로 반환 · `getOrCreateSession` 은 명시적 생성 |
| 요청 속성 조회 | 4 | 바인딩된 요청 반환 · URI/메서드/원격주소 · 헤더/파라미터(부재 시 빈 `Optional`) · **이름 `null` 은 예외가 아닌 빈 `Optional`** |
| 응답 바인딩 | 2 | 응답이 함께 바인딩된 경우 · 바인딩되지 않은 경우 |
| 스레드 정리 | 1 | 컨텍스트를 비우면 다시 부재 상태로 복귀(**스레드 재사용 대비**) |

`EgovRequestContextSecurityTest` 3건 — `X-Forwarded-For`·`X-Real-IP`·`Proxy-Client-IP` 를 심어도 **원격 주소는 `getRemoteAddr()` 그대로**(신뢰 경계는 배포자의 프록시 계층) · CRLF·10 KB·스크립트·장문 언어 태그 헤더를 **해석 없이 그대로 돌려주며 예외 없음** · 비서블릿 요청 속성에서는 '없음' 판정.

**수동 확인**: 기본 로케일이 다른 Linux(`C.UTF-8`) 환경에서 별도로 교차 검증했습니다.

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

해당 없음 — 뷰나 화면이 아닌 **라이브러리 클래스 추가**이며, 검증은 위 JUnit 으로 수행했습니다.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

해당 없음 — 위 JUnit 테스트 결과로 갈음합니다.

---

<sub>base: `eGovFramework:main` @ `cd9fd9c` (2026-09-08 fetch 기준) · 단일 커밋</sub>
