### PR TITLE
fix: 빈 행이 섞인 엑셀을 업로드하면 데이터 행이 누락되거나 업로드가 중단되는 문제 수정

### DIFF
--- a/Foundation/org.egovframe.rte.fdl.excel/src/main/java/org/egovframe/rte/fdl/excel/impl/EgovExcelServiceImpl.java
+++ b/Foundation/org.egovframe.rte.fdl.excel/src/main/java/org/egovframe/rte/fdl/excel/impl/EgovExcelServiceImpl.java
@@ -282,7 +282,7 @@ public class EgovExcelServiceImpl implements EgovExcelService, ApplicationContex
         LOGGER.debug("sheet.getPhysicalNumberOfRows() : {}", sheet.getPhysicalNumberOfRows());
 
         Integer rowsAffected = 0;
-        long rowCnt = sheet.getPhysicalNumberOfRows();
+        long rowCnt = sheet.getLastRowNum() + 1L;
         long cnt = (commitCnt == 0) ? rowCnt : commitCnt;
 
         LOGGER.debug("Runtime.getRuntime().totalMemory() : {}", Runtime.getRuntime().totalMemory());
@@ -303,14 +303,21 @@ public class EgovExcelServiceImpl implements EgovExcelService, ApplicationContex
 
             for (i = idx; i < rowCnt && i < (cnt + idx); i++) {
                 Row row = sheet.getRow(i);
+                if (row == null) {
+                    LOGGER.debug("row {} is blank, skipped", i);
+                    continue;
+                }
                 list.add(mapping.mappingColumn(row));
             }
-            if (sqlSessionTemplate != null) {
-                rowsAffected += excelBatchMapper.batchInsert(queryId, list);
-            } else if (sqlMapClient != null) {
-                rowsAffected += dao.batchInsert(queryId, list);
-            } else {
+            if (sqlSessionTemplate == null && sqlMapClient == null) {
                 throw new RuntimeException(getMessageSource().getMessage("error.excel.persistence.error", null, Locale.getDefault()));
+            }
+            if (!list.isEmpty()) {
+                if (sqlSessionTemplate != null) {
+                    rowsAffected += excelBatchMapper.batchInsert(queryId, list);
+                } else {
+                    rowsAffected += dao.batchInsert(queryId, list);
+                }
             }
 
             LOGGER.debug("after Runtime.getRuntime().freeMemory() : {}", Runtime.getRuntime().freeMemory());

--- a/Foundation/org.egovframe.rte.fdl.excel/src/test/java/org/egovframe/rte/fdl/excel/EgovExcelUploadBlankRowTest.java
+++ b/Foundation/org.egovframe.rte.fdl.excel/src/test/java/org/egovframe/rte/fdl/excel/EgovExcelUploadBlankRowTest.java
@@ -1,0 +1,146 @@
+package org.egovframe.rte.fdl.excel;
+
+import jakarta.annotation.Resource;
+import org.apache.poi.ss.usermodel.Row;
+import org.apache.poi.ss.usermodel.Sheet;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import org.egovframe.rte.fdl.excel.config.ExcelTestConfig;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.datasource.init.ScriptUtils;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import javax.sql.DataSource;
+import java.io.IOException;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+/**
+ * 빈 행이 섞인 시트를 업로드할 때 데이터 행이 누락되거나 업로드가 중단되지 않는지 검증한다.
+ * <p>
+ * uploadExcel 은 sheet.getPhysicalNumberOfRows() 로 얻은 "행 개수"를 "행 인덱스" 상한으로 사용했다.
+ * 빈 행이 있으면 두 값이 어긋나므로 시작 위치 앞에 빈 행이 있으면 마지막 데이터 행이 누락되고,
+ * 데이터 중간에 빈 행이 있으면 sheet.getRow(i) 가 null 을 돌려줘 매핑에서 NullPointerException 이 난다.
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = ExcelTestConfig.class)
+public class EgovExcelUploadBlankRowTest {
+
+    private static final String QUERY_ID = "insertEmpUsingBatch";
+
+    @Resource(name = "dataSource")
+    private DataSource dataSource;
+
+    @Resource(name = "excelService")
+    private EgovExcelService excelService;
+
+    private JdbcTemplate jdbcTemplate;
+
+    @BeforeEach
+    public void onSetUp() throws SQLException {
+        try (Connection conn = dataSource.getConnection()) {
+            ScriptUtils.executeSqlScript(conn, new ClassPathResource("/META-INF/testdata/testdb.sql"));
+        }
+        jdbcTemplate = new JdbcTemplate(dataSource);
+    }
+
+    /**
+     * 시작 위치 앞에 빈 행이 있으면 마지막 데이터 행이 예외 없이 누락된다.
+     */
+    @Test
+    public void testBlankRowBeforeStartKeepsEveryDataRow() throws IOException {
+        try (XSSFWorkbook wb = new XSSFWorkbook()) {
+            Sheet sheet = wb.createSheet("emp");
+            createHeaderRow(sheet, 0);
+            // 1행은 만들지 않아 빈 행으로 둔다
+            createDataRows(sheet, 2, 5);
+
+            excelService.uploadExcel(QUERY_ID, sheet, 2, 0);
+
+            assertEquals(List.of(1001, 1002, 1003, 1004, 1005), selectEmpNos());
+        }
+    }
+
+    /**
+     * 데이터 중간의 빈 행에서 업로드가 중단되지 않는다.
+     */
+    @Test
+    public void testBlankRowBetweenDataRowsDoesNotAbortUpload() throws IOException {
+        try (XSSFWorkbook wb = new XSSFWorkbook()) {
+            Sheet sheet = wb.createSheet("emp");
+            createDataRows(sheet, 0, 2);
+            // 2행은 만들지 않아 빈 행으로 둔다
+            createDataRows(sheet, 3, 2, 1003);
+
+            assertDoesNotThrow(() -> excelService.uploadExcel(QUERY_ID, sheet, 0, 0));
+
+            assertEquals(List.of(1001, 1002, 1003, 1004), selectEmpNos());
+        }
+    }
+
+    /**
+     * commitCnt 로 청크 커밋할 때도 빈 행 때문에 청크가 잘리지 않는다.
+     */
+    @Test
+    public void testBlankRowWithCommitCountKeepsEveryDataRow() throws IOException {
+        try (XSSFWorkbook wb = new XSSFWorkbook()) {
+            Sheet sheet = wb.createSheet("emp");
+            createHeaderRow(sheet, 0);
+            // 1행은 만들지 않아 빈 행으로 둔다
+            createDataRows(sheet, 2, 5);
+
+            excelService.uploadExcel(QUERY_ID, sheet, 2, 2);
+
+            assertEquals(List.of(1001, 1002, 1003, 1004, 1005), selectEmpNos());
+        }
+    }
+
+    /**
+     * 빈 행이 없는 시트의 결과는 그대로다.
+     */
+    @Test
+    public void testSheetWithoutBlankRowIsUnaffected() throws IOException {
+        try (XSSFWorkbook wb = new XSSFWorkbook()) {
+            Sheet sheet = wb.createSheet("emp");
+            createHeaderRow(sheet, 0);
+            createDataRows(sheet, 1, 5);
+
+            excelService.uploadExcel(QUERY_ID, sheet, 1, 0);
+
+            assertEquals(List.of(1001, 1002, 1003, 1004, 1005), selectEmpNos());
+        }
+    }
+
+    private void createHeaderRow(Sheet sheet, int rowIndex) {
+        Row row = sheet.createRow(rowIndex);
+        row.createCell(0).setCellValue("EMP_NO");
+        row.createCell(1).setCellValue("EMP_NAME");
+        row.createCell(2).setCellValue("JOB");
+    }
+
+    private void createDataRows(Sheet sheet, int firstRowIndex, int count) {
+        createDataRows(sheet, firstRowIndex, count, 1001);
+    }
+
+    private void createDataRows(Sheet sheet, int firstRowIndex, int count, int firstEmpNo) {
+        for (int i = 0; i < count; i++) {
+            Row row = sheet.createRow(firstRowIndex + i);
+            row.createCell(0).setCellValue(firstEmpNo + i);
+            row.createCell(1).setCellValue("NAME" + (firstEmpNo + i));
+            row.createCell(2).setCellValue("CLERK");
+        }
+    }
+
+    private List<Integer> selectEmpNos() {
+        return jdbcTemplate.queryForList("select emp_no from emp order by emp_no", Integer.class);
+    }
+
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

`uploadExcel(String, Sheet, int, long)` 이 `sheet.getPhysicalNumberOfRows()` 의 반환값을 행 인덱스 상한으로 사용합니다. 이 값은 존재하는 행의 개수이지 마지막 행의 인덱스가 아니라서, 빈 행이 있으면 두 값이 어긋납니다.

그 결과 빈 행이 `start` 앞에 있으면 마지막 데이터 행이 예외 없이 누락되고, 데이터 중간에 있으면 `sheet.getRow(i)` 가 반환한 `null` 이 걸러지지 않아 매핑에서 `NullPointerException` 으로 업로드가 중단됩니다. `commitCnt` 청크 커밋 중이면 앞쪽 청크만 커밋된 채 끝납니다.

상한을 `sheet.getLastRowNum() + 1` 로 바꾸고 빈 행은 건너뛰도록 했습니다. 건너뛴 결과 청크가 비면 `batchInsert` 를 호출하지 않으며, 영속성 설정 누락 예외는 그와 무관하게 발생하도록 검사를 앞으로 옮겼습니다. 빈 행이 없으면 두 값이 같으므로 기존 동작은 그대로입니다.

공통컴포넌트의 우편번호 일괄 등록(`EgovCcmZipManageServiceImpl.insertExcelZip`)이 `uploadExcel(queryId, file, 1, 5000)` 으로 이 경로를 사용합니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

`EgovExcelUploadBlankRowTest` 4건을 추가했습니다. 빈 행 위치 두 가지와 `commitCnt` 청크 커밋, 그리고 빈 행 없는 대조군입니다. 소스 수정만 되돌리면 대조군을 제외한 3건이 실패합니다.

JDK 17, Maven 3.9.9 에서 `fdl.excel` 37건과 저장소 전체 20개 모듈 724건이 통과합니다.

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

서버 측 업로드 로직이라 브라우저 테스트는 해당하지 않습니다.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

화면 변경이 없어 첨부하지 않았습니다.
