### PR TITLE
fix: 수식 셀을 읽으면 값을 돌려주지 못하고 예외가 새어 나가는 문제 수정

### DIFF
--- a/Foundation/org.egovframe.rte.fdl.excel/src/main/java/org/egovframe/rte/fdl/excel/util/EgovExcelUtil.java
+++ b/Foundation/org.egovframe.rte.fdl.excel/src/main/java/org/egovframe/rte/fdl/excel/util/EgovExcelUtil.java
@@ -61,10 +61,14 @@ public final class EgovExcelUtil {
             String stringValue = null;
             String longValue = null;
             try {
-                stringValue = cell.getRichStringCellValue().getString();
-                longValue = doubleToString(cell.getNumericCellValue());
+                CellType cachedType = cell.getCachedFormulaResultType();
+                if (cachedType == CellType.STRING) {
+                    stringValue = cell.getRichStringCellValue().getString();
+                } else if (cachedType == CellType.NUMERIC) {
+                    longValue = doubleToString(cell.getNumericCellValue());
+                }
                 //2017.02.15 장동한 시큐어코딩(ES)-부적절한 예외 처리[CWE-253, CWE-440, CWE-754]
-            } catch (IllegalArgumentException e) {
+            } catch (IllegalArgumentException | IllegalStateException e) {
                 LOGGER.debug("[{}] EgovExcelUtil getValue() : {}", e.getClass().getName(), e.getMessage());
             }
             if (stringValue != null) {

--- a/Foundation/org.egovframe.rte.fdl.excel/src/test/java/org/egovframe/rte/fdl/excel/EgovExcelUtilFormulaCellTest.java
+++ b/Foundation/org.egovframe.rte.fdl.excel/src/test/java/org/egovframe/rte/fdl/excel/EgovExcelUtilFormulaCellTest.java
@@ -1,0 +1,96 @@
+package org.egovframe.rte.fdl.excel;
+
+import org.apache.poi.hssf.usermodel.HSSFWorkbook;
+import org.apache.poi.ss.usermodel.Cell;
+import org.apache.poi.ss.usermodel.CellType;
+import org.apache.poi.ss.usermodel.Row;
+import org.apache.poi.ss.usermodel.Sheet;
+import org.apache.poi.ss.usermodel.Workbook;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import org.egovframe.rte.fdl.excel.upload.EgovExcelTestMapping;
+import org.egovframe.rte.fdl.excel.util.EgovExcelUtil;
+import org.egovframe.rte.fdl.excel.vo.EmpVO;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.function.Supplier;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * 수식 셀에서 EgovExcelUtil.getValue 가 값을 돌려주는지 검증한다.
+ * <p>
+ * getValue 는 수식 셀의 캐시 결과 타입을 보지 않고 getRichStringCellValue 와
+ * getNumericCellValue 를 연달아 호출했다. POI 는 캐시 결과 타입과 다른 접근자를 부르면
+ * IllegalStateException 을 던지는데 catch 절은 IllegalArgumentException 만 잡았고
+ * 둘은 상속 관계가 아니다. 그래서 캐시 결과가 숫자면 첫 번째 호출에서, 문자열이면 두 번째
+ * 호출에서 예외가 그대로 새어 나갔고, 그 아래 폴백 분기는 도달할 수 없었다.
+ */
+public class EgovExcelUtilFormulaCellTest {
+
+    @Test
+    public void testNumericFormulaOnHssf() throws IOException {
+        assertEquals("3", valueOfFormula(HSSFWorkbook::new, "1+2"));
+    }
+
+    @Test
+    public void testNumericFormulaOnXssf() throws IOException {
+        assertEquals("3", valueOfFormula(XSSFWorkbook::new, "1+2"));
+    }
+
+    @Test
+    public void testStringFormulaOnHssf() throws IOException {
+        assertEquals("ABCD", valueOfFormula(HSSFWorkbook::new, "\"AB\"&\"CD\""));
+    }
+
+    @Test
+    public void testStringFormulaOnXssf() throws IOException {
+        assertEquals("ABCD", valueOfFormula(XSSFWorkbook::new, "CONCATENATE(\"AB\",\"CD\")"));
+    }
+
+    /**
+     * 캐시 결과가 문자열도 숫자도 아니면 수식 문자열을 돌려주는 폴백 분기를 탄다.
+     */
+    @Test
+    public void testBooleanFormulaFallsBackToFormulaText() throws IOException {
+        try (Workbook wb = new XSSFWorkbook()) {
+            Cell cell = evaluatedFormulaCell(wb, "TRUE()");
+            assertEquals(CellType.BOOLEAN, cell.getCachedFormulaResultType());
+            assertEquals("TRUE()", EgovExcelUtil.getValue(cell));
+        }
+    }
+
+    /**
+     * 프레임워크가 배포한 매핑 예제가 수식 셀이 든 행을 매핑할 수 있어야 한다.
+     */
+    @Test
+    public void testShippedMappingHandlesFormulaCell() throws IOException {
+        try (Workbook wb = new XSSFWorkbook()) {
+            Sheet sheet = wb.createSheet("emp");
+            Row row = sheet.createRow(0);
+            row.createCell(0).setCellValue(1001);
+            row.createCell(1).setCellFormula("\"HONG\"&\"GILDONG\"");
+            row.createCell(2).setCellFormula("1+2");
+            wb.getCreationHelper().createFormulaEvaluator().evaluateAll();
+
+            EmpVO vo = new EgovExcelTestMapping().mappingColumn(row);
+
+            assertEquals("HONGGILDONG", vo.getEmpName());
+            assertEquals("3", vo.getJob());
+        }
+    }
+
+    private String valueOfFormula(Supplier<Workbook> workbookSupplier, String formula) throws IOException {
+        try (Workbook wb = workbookSupplier.get()) {
+            return EgovExcelUtil.getValue(evaluatedFormulaCell(wb, formula));
+        }
+    }
+
+    private Cell evaluatedFormulaCell(Workbook wb, String formula) {
+        Cell cell = wb.createSheet().createRow(0).createCell(0);
+        cell.setCellFormula(formula);
+        wb.getCreationHelper().createFormulaEvaluator().evaluateFormulaCell(cell);
+        return cell;
+    }
+
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

`EgovExcelUtil.getValue(Cell)` 의 수식 셀 분기가 캐시 결과 타입을 확인하지 않고 `getRichStringCellValue()` 와 `getNumericCellValue()` 를 연달아 호출합니다. POI 는 캐시 결과 타입과 다른 접근자를 호출하면 `IllegalStateException` 을 던지는데, `catch` 절이 잡는 것은 `IllegalArgumentException` 이고 둘은 상속 관계가 아닌 형제입니다.

그래서 캐시 결과가 숫자면 첫 번째 호출에서, 문자열이면 두 번째 호출에서 예외가 그대로 호출자에게 전달됩니다. 이 둘이 대부분의 경우라서 아래 폴백 분기는 사실상 도달하지 못했고, 개정이력 `2014.09.03` 항목이 의도한 동작이 성립하지 않습니다.

`getCachedFormulaResultType()` 으로 분기해 캐시 결과 타입에 맞는 접근자만 호출하도록 했습니다. 문자열도 숫자도 아닌 경우(`BOOLEAN`, `ERROR`)에는 두 지역변수가 `null` 로 남아 기존 폴백 분기가 수식 문자열을 반환합니다. 반환 우선순위와 나머지 셀 타입 경로는 그대로입니다.

수식 셀에서 값이 반환된 적이 없으므로 기존 반환값에 의존하던 코드는 없습니다. 합계나 문자열 결합 수식이 든 시트를 올리면 매핑 단계에서 중단되어 한 건도 저장되지 않는 것이 이 결함의 영향입니다.

범위를 좁힌 부분이 하나 있습니다. 날짜 서식인 숫자 수식(`=TODAY()`)은 이번 수정 후에도 날짜가 아니라 숫자 문자열로 반환됩니다. 수식이 아닌 `NUMERIC` 분기는 날짜를 서식화하고 있어 비대칭이 남지만, 결함 수정 범위를 넘는다고 보아 포함하지 않았습니다. 함께 맞추는 편이 낫다면 반영하겠습니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

`EgovExcelUtilFormulaCellTest` 6건을 추가했습니다. HSSF 와 XSSF 각각의 숫자 수식과 문자열 수식, `BOOLEAN` 캐시 결과의 폴백, 그리고 저장소에 포함된 매핑 예제로 수식 셀이 든 행을 매핑하는 경우입니다. 소스 수정만 되돌리면 6건이 전부 `IllegalStateException` 으로 실패합니다.

JDK 17, Maven 3.9.9 에서 `fdl.excel` 39건과 저장소 전체 20개 모듈 726건이 통과합니다.

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

셀 값 변환 유틸리티라 브라우저 테스트는 해당하지 않습니다.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

화면 변경이 없어 첨부하지 않았습니다.
