### PR TITLE
feat: 안전 경로 해석·헤더 생성 유틸 EgovFiles·EgovContentDispositions 추가

### DIFF
--- a/Foundation/org.egovframe.rte.fdl.filehandling/src/main/java/org/egovframe/rte/fdl/filehandling/EgovContentDispositions.java
+++ b/Foundation/org.egovframe.rte.fdl.filehandling/src/main/java/org/egovframe/rte/fdl/filehandling/EgovContentDispositions.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright 2009-2026 MOIS(Ministry of the Interior and Safety).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.egovframe.rte.fdl.filehandling;
+
+import java.nio.charset.StandardCharsets;
+
+/**
+ * 다운로드 응답의 {@code Content-Disposition} 헤더 값을 만든다 — RFC 6266/5987 준수.
+ *
+ * <p><b>NOTE:</b> 한글 파일명을 {@code filename="한글.hwp"} 로 그대로 실으면 브라우저·프록시의
+ * 헤더 해석 규칙(ISO-8859-1 기준)에 따라 파일명이 깨진다. 표준 해법은 RFC 5987
+ * {@code filename*=UTF-8''퍼센트인코딩} 확장 파라미터이며, 이를 해석하지 못하는 구형
+ * 에이전트를 위해 ASCII 폴백 {@code filename="..."} 을 <b>병기</b>하는 것이 RFC 6266 부록 D의
+ * 권고다. 이 클래스는 두 파라미터를 함께 만든다.</p>
+ *
+ * <pre>
+ * response.setHeader("Content-Disposition", EgovContentDispositions.attachment("연차보고서.hwp"));
+ * // → attachment; filename="_____.hwp"; filename*=UTF-8''%EC%97%B0%EC%B0%A8...%EC%84%9C.hwp
+ *
+ * response.setHeader("Content-Disposition", EgovContentDispositions.attachment("report.pdf"));
+ * // → attachment; filename="report.pdf"   (ASCII 는 기존 형식 유지)
+ * </pre>
+ *
+ * <p><b>헤더 인젝션 차단.</b> 파일명은 사용자 입력(원본 업로드명)에서 오는 값이므로,
+ * CR·LF 등 제어문자는 제거하고 경로 구분자 앞부분은 잘라 <b>파일명만</b> 싣는다.
+ * 인용부호·역슬래시는 quoted-string 규칙으로 이스케이프한다.</p>
+ *
+ * <p>Spring MVC 컨트롤러에서는 {@code org.springframework.http.ContentDisposition} 빌더를 써도
+ * 되지만, 그 빌더는 비ASCII 파일명에서 ASCII 폴백을 병기하지 않으며 spring-web 의존을 요구한다.
+ * 본 클래스는 서블릿·필터·뷰 등 <b>의존 없는 어느 계층에서나</b> 쓸 수 있다.</p>
+ *
+ * <pre>
+ * &lt;&lt; 개정이력(Modification Information) &gt;&gt;
+ *
+ *  수정일        수정자        수정내용
+ *  ----------  --------    ---------------------------
+ *  2026.09.01  실행환경팀     최초 생성 (RFC 5987 파일명 인코딩을 공용 API 로 제공 —
+ *                            구형 에이전트용 ASCII 폴백 병기·제어문자 제거)
+ * </pre>
+ *
+ * @author 실행환경 개발팀
+ * @since 5.1
+ */
+public final class EgovContentDispositions {
+
+	/** RFC 5987 attr-char 중 영숫자 외에 퍼센트 인코딩 없이 쓸 수 있는 문자. */
+	private static final String ATTR_CHARS = "!#$&+-.^_`|~";
+
+	private static final char[] HEX = "0123456789ABCDEF".toCharArray();
+
+	private EgovContentDispositions() {
+	}
+
+	/**
+	 * 첨부 다운로드({@code attachment})용 헤더 값을 만든다.
+	 *
+	 * @param filename 내려줄 파일명(원본 업로드명 등 신뢰할 수 없는 값 허용)
+	 * @return {@code Content-Disposition} 헤더에 실을 값
+	 * @throws IllegalArgumentException 파일명이 {@code null}·빈 값이거나 정리 후 남는 문자가 없는 경우
+	 */
+	public static String attachment(String filename) {
+		return build("attachment", filename);
+	}
+
+	/**
+	 * 브라우저 내 표시({@code inline})용 헤더 값을 만든다.
+	 *
+	 * @param filename 내려줄 파일명(원본 업로드명 등 신뢰할 수 없는 값 허용)
+	 * @return {@code Content-Disposition} 헤더에 실을 값
+	 * @throws IllegalArgumentException 파일명이 {@code null}·빈 값이거나 정리 후 남는 문자가 없는 경우
+	 */
+	public static String inline(String filename) {
+		return build("inline", filename);
+	}
+
+	private static String build(String disposition, String filename) {
+		String name = sanitize(filename);
+		StringBuilder header = new StringBuilder(disposition);
+		if (isAscii(name)) {
+			header.append("; filename=\"").append(escapeQuoted(name)).append('"');
+		} else {
+			header.append("; filename=\"").append(escapeQuoted(asciiFallback(name))).append('"');
+			header.append("; filename*=UTF-8''").append(rfc5987Encode(name));
+		}
+		return header.toString();
+	}
+
+	/**
+	 * 파일명만 남기고(경로 구분자 앞 제거) 제어문자를 걷어낸다 — 헤더 인젝션(CR/LF) 차단.
+	 */
+	private static String sanitize(String filename) {
+		if (filename == null || filename.isEmpty()) {
+			throw new IllegalArgumentException("filename must not be null or empty");
+		}
+		int sep = Math.max(filename.lastIndexOf('/'), filename.lastIndexOf('\\'));
+		String name = (sep < 0) ? filename : filename.substring(sep + 1);
+		StringBuilder cleaned = new StringBuilder(name.length());
+		for (int i = 0; i < name.length(); i++) {
+			char c = name.charAt(i);
+			if (c >= 0x20 && c != 0x7F) {
+				cleaned.append(c);
+			}
+		}
+		if (cleaned.length() == 0) {
+			throw new IllegalArgumentException("filename has no usable characters: " + filename);
+		}
+		return cleaned.toString();
+	}
+
+	private static boolean isAscii(String value) {
+		for (int i = 0; i < value.length(); i++) {
+			if (value.charAt(i) > 127) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	/** quoted-string 이스케이프 — 역슬래시·인용부호. */
+	private static String escapeQuoted(String value) {
+		StringBuilder escaped = new StringBuilder(value.length());
+		for (int i = 0; i < value.length(); i++) {
+			char c = value.charAt(i);
+			if (c == '\\' || c == '"') {
+				escaped.append('\\');
+			}
+			escaped.append(c);
+		}
+		return escaped.toString();
+	}
+
+	/** 구형 에이전트용 ASCII 폴백 — 비ASCII 문자를 {@code _} 로 치환한다(확장자는 통상 ASCII 라 보존된다). */
+	private static String asciiFallback(String value) {
+		StringBuilder fallback = new StringBuilder(value.length());
+		for (int i = 0; i < value.length(); i++) {
+			char c = value.charAt(i);
+			fallback.append(c > 127 ? '_' : c);
+		}
+		return fallback.toString();
+	}
+
+	/** RFC 5987 — UTF-8 바이트를 attr-char 외 전부 퍼센트 인코딩한다. */
+	private static String rfc5987Encode(String value) {
+		byte[] bytes = value.getBytes(StandardCharsets.UTF_8);
+		StringBuilder encoded = new StringBuilder(bytes.length * 3);
+		for (byte b : bytes) {
+			int c = b & 0xFF;
+			if ((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9')
+					|| ATTR_CHARS.indexOf(c) >= 0) {
+				encoded.append((char) c);
+			} else {
+				encoded.append('%').append(HEX[c >>> 4]).append(HEX[c & 0xF]);
+			}
+		}
+		return encoded.toString();
+	}
+
+}

--- a/Foundation/org.egovframe.rte.fdl.filehandling/src/main/java/org/egovframe/rte/fdl/filehandling/EgovFiles.java
+++ b/Foundation/org.egovframe.rte.fdl.filehandling/src/main/java/org/egovframe/rte/fdl/filehandling/EgovFiles.java
@@ -1,0 +1,537 @@
+/*
+ * Copyright 2009-2026 MOIS(Ministry of the Interior and Safety).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.egovframe.rte.fdl.filehandling;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.AtomicMoveNotSupportedException;
+import java.nio.file.FileSystems;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.InvalidPathException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.nio.file.attribute.FileTime;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * NIO.2({@code java.nio.file}) 기반 파일 유틸 — {@link EgovFileUtil}의 현대화 표준 구현.
+ *
+ * <p>기존 {@link EgovFileUtil}의 구조 결함을 해소한다:</p>
+ * <ul>
+ *   <li><b>전역 상태 없음</b>: {@code cd()}식 프로세스 전역 기준 디렉터리를 두지 않는다 —
+ *       모든 경로는 호출 인자로 완결(스레드 안전)</li>
+ *   <li><b>침묵 실패 없음</b>: 실패는 {@link UncheckedIOException}(JDK 표준 unchecked + cause 체인)으로
+ *       정직하게 전파한다 — debug 로그 후 정상 복귀하던 rm/cp/mv 유형 제거</li>
+ *   <li><b>문자셋 명시</b>: 텍스트 IO 기본값은 UTF-8(오버로드로 지정 가능) — 플랫폼 기본
+ *       문자셋(MS949/UTF-8) 의존 제거</li>
+ *   <li><b>올바른 시맨틱</b>: {@link #grepLines}는 패턴이 <b>매칭되는 라인</b>을 반환(기존
+ *       {@code grep()}의 split 오동작 대체), {@link #deleteRecursively}는 깊이 무제한 재귀 삭제
+ *       (기존 {@code rm()}의 1단계 한계 대체), {@link #list}는 실제 목록을 반환(기존 {@code ls()}
+ *       빈 리스트 대체)</li>
+ *   <li><b>경로 조작 방어</b>: {@link #resolveSecurely}로 신뢰할 수 없는 상대 경로를 기준 디렉터리
+ *       내부로 강제(traversal·절대 경로·널 바이트 차단). 예외를 던질 수 없는 자리(일괄 검증·필터)에는
+ *       판정형 {@link #tryResolveSecurely}·{@link #isContainedIn(Path, Path...)}를, 업로드 루트가
+ *       여러 개인 배치에는 다중 허용 루트 봉쇄 {@link #requireContainedIn(Path, Path...)}를 쓴다</li>
+ * </ul>
+ *
+ * <p>원격 파일시스템(SFTP 등)이 필요한 경우에만 Commons VFS 기반 {@link EgovFileUtil}을 계속
+ * 사용하고, 로컬 파일 처리는 본 클래스를 표준으로 한다.</p>
+ *
+ * @author 실행환경 개발팀
+ * @since 5.1
+ * @version 1.0
+ * <pre>
+ * 개정이력(Modification Information)
+ *
+ * 수정일        수정자           수정내용
+ * ----------  --------------  ---------------------------
+ * 2026.08.16  실행환경 개발팀    최초 생성
+ * 2026.09.01  실행환경 개발팀    판정형 경로 검증(tryResolveSecurely·isContainedIn)과
+ *                             다중 허용 루트 봉쇄(requireContainedIn) 추가 — 호출부에
+ *                             try-catch 를 강요해 {@code catch {}} 무시를 부르던 예외
+ *                             단일형의 한계 해소
+ * </pre>
+ */
+public final class EgovFiles {
+
+    /** Windows 예약 장치명 — 확장자가 붙어도({@code NUL.txt}) 장치로 해석되며 대소문자를 가리지 않는다. */
+    private static final Pattern WINDOWS_RESERVED_NAME =
+            Pattern.compile("(?i)^(CON|PRN|AUX|NUL|COM[1-9¹²³]|LPT[1-9¹²³])(\\..*)?$");
+
+    private static final boolean WINDOWS = "\\".equals(FileSystems.getDefault().getSeparator());
+
+
+    private EgovFiles() {
+    }
+
+    // ---------------------------------------------------------------- 텍스트 IO
+
+    /**
+     * 파일 전체를 UTF-8 문자열로 읽는다.
+     */
+    public static String readString(Path file) {
+        return readString(file, StandardCharsets.UTF_8);
+    }
+
+    /**
+     * 파일 전체를 지정한 문자셋의 문자열로 읽는다.
+     */
+    public static String readString(Path file, Charset charset) {
+        Objects.requireNonNull(file, "file must not be null");
+        try {
+            return new String(Files.readAllBytes(file), charset(charset));
+        } catch (IOException e) {
+            throw new UncheckedIOException("Failed to read file: " + file, e);
+        }
+    }
+
+    /**
+     * 파일을 라인 리스트로 읽는다(UTF-8).
+     */
+    public static List<String> readLines(Path file) {
+        return readLines(file, StandardCharsets.UTF_8);
+    }
+
+    /**
+     * 파일을 지정한 문자셋의 라인 리스트로 읽는다.
+     */
+    public static List<String> readLines(Path file, Charset charset) {
+        Objects.requireNonNull(file, "file must not be null");
+        try {
+            return Files.readAllLines(file, charset(charset));
+        } catch (IOException e) {
+            throw new UncheckedIOException("Failed to read lines: " + file, e);
+        }
+    }
+
+    /**
+     * 문자열을 UTF-8로 파일에 쓴다(기존 내용 대체). 부모 디렉터리가 없으면 생성한다.
+     */
+    public static void writeString(Path file, CharSequence content) {
+        writeString(file, content, StandardCharsets.UTF_8);
+    }
+
+    /**
+     * 문자열을 지정한 문자셋으로 파일에 쓴다(기존 내용 대체). 부모 디렉터리가 없으면 생성한다.
+     */
+    public static void writeString(Path file, CharSequence content, Charset charset) {
+        Objects.requireNonNull(file, "file must not be null");
+        Objects.requireNonNull(content, "content must not be null");
+        try {
+            createParentDirectories(file);
+            Files.write(file, content.toString().getBytes(charset(charset)));
+        } catch (IOException e) {
+            throw new UncheckedIOException("Failed to write file: " + file, e);
+        }
+    }
+
+    // ---------------------------------------------------------------- 복사/이동/삭제
+
+    /**
+     * 파일 또는 디렉터리(재귀)를 복사한다. 대상의 기존 파일은 대체한다.
+     */
+    public static void copy(Path source, Path target) {
+        Objects.requireNonNull(source, "source must not be null");
+        Objects.requireNonNull(target, "target must not be null");
+        try {
+            if (Files.isDirectory(source)) {
+                copyDirectory(source, target);
+            } else {
+                createParentDirectories(target);
+                Files.copy(source, target, StandardCopyOption.REPLACE_EXISTING);
+            }
+        } catch (IOException e) {
+            throw new UncheckedIOException("Failed to copy " + source + " -> " + target, e);
+        }
+    }
+
+    private static void copyDirectory(Path sourceDir, Path targetDir) throws IOException {
+        Files.walkFileTree(sourceDir, new SimpleFileVisitor<Path>() {
+            @Override
+            public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) throws IOException {
+                Files.createDirectories(targetDir.resolve(sourceDir.relativize(dir).toString()));
+                return FileVisitResult.CONTINUE;
+            }
+
+            @Override
+            public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+                Files.copy(file, targetDir.resolve(sourceDir.relativize(file).toString()),
+                        StandardCopyOption.REPLACE_EXISTING);
+                return FileVisitResult.CONTINUE;
+            }
+        });
+    }
+
+    /**
+     * 파일 또는 디렉터리를 이동한다. 가능하면 원자적 이동을 시도하고,
+     * 파일시스템이 지원하지 않으면 일반 이동(대체 허용)으로 폴백한다.
+     */
+    public static void move(Path source, Path target) {
+        Objects.requireNonNull(source, "source must not be null");
+        Objects.requireNonNull(target, "target must not be null");
+        try {
+            createParentDirectories(target);
+            try {
+                Files.move(source, target, StandardCopyOption.ATOMIC_MOVE);
+            } catch (AtomicMoveNotSupportedException e) {
+                Files.move(source, target, StandardCopyOption.REPLACE_EXISTING);
+            }
+        } catch (IOException e) {
+            throw new UncheckedIOException("Failed to move " + source + " -> " + target, e);
+        }
+    }
+
+    /**
+     * 파일 또는 디렉터리 트리를 <b>깊이 무제한</b>으로 삭제한다(기존 {@code EgovFileUtil.rm()}의
+     * 1단계 깊이 한계 대체). 대상이 없으면 0을 반환한다.
+     *
+     * @return 삭제된 파일·디렉터리 수
+     */
+    public static long deleteRecursively(Path path) {
+        Objects.requireNonNull(path, "path must not be null");
+        if (!Files.exists(path)) {
+            return 0;
+        }
+        try (Stream<Path> walk = Files.walk(path)) {
+            List<Path> targets = walk.sorted(Comparator.reverseOrder()).collect(Collectors.toList());
+            for (Path target : targets) {
+                Files.delete(target);
+            }
+            return targets.size();
+        } catch (IOException e) {
+            throw new UncheckedIOException("Failed to delete recursively: " + path, e);
+        }
+    }
+
+    // ---------------------------------------------------------------- 조회
+
+    /**
+     * 디렉터리 직속 항목 목록을 이름순으로 반환한다(기존 {@code ls()}의 빈 리스트 반환 대체).
+     */
+    public static List<Path> list(Path dir) {
+        Objects.requireNonNull(dir, "dir must not be null");
+        try (Stream<Path> stream = Files.list(dir)) {
+            return stream.sorted().collect(Collectors.toList());
+        } catch (IOException e) {
+            throw new UncheckedIOException("Failed to list directory: " + dir, e);
+        }
+    }
+
+    /**
+     * 디렉터리 하위 전체(파일만)를 재귀로 반환한다.
+     */
+    public static List<Path> listRecursively(Path dir) {
+        Objects.requireNonNull(dir, "dir must not be null");
+        try (Stream<Path> walk = Files.walk(dir)) {
+            return walk.filter(Files::isRegularFile).sorted().collect(Collectors.toList());
+        } catch (IOException e) {
+            throw new UncheckedIOException("Failed to walk directory: " + dir, e);
+        }
+    }
+
+    /**
+     * 정규식이 <b>매칭되는 라인</b>을 반환한다 — grep 본연의 시맨틱
+     * (기존 {@code EgovFileUtil.grep()}은 패턴 기준 split 조각을 반환하는 오동작).
+     * 부분 매칭(find) 기준이며, 라인 전체 매칭이 필요하면 앵커({@code ^...$})를 사용한다.
+     */
+    public static List<String> grepLines(Path file, String regex, Charset charset) {
+        Objects.requireNonNull(regex, "regex must not be null");
+        Pattern pattern = Pattern.compile(regex);
+        List<String> matched = new ArrayList<>();
+        for (String line : readLines(file, charset)) {
+            if (pattern.matcher(line).find()) {
+                matched.add(line);
+            }
+        }
+        return matched;
+    }
+
+    /**
+     * UTF-8 기준 {@link #grepLines(Path, String, Charset)}.
+     */
+    public static List<String> grepLines(Path file, String regex) {
+        return grepLines(file, regex, StandardCharsets.UTF_8);
+    }
+
+    // ---------------------------------------------------------------- 기타
+
+    /**
+     * 파일이 없으면 생성하고, 있으면 최종 수정 시각을 현재로 갱신한다.
+     *
+     * @return 갱신된 최종 수정 시각(epoch millis)
+     */
+    public static long touch(Path file) {
+        Objects.requireNonNull(file, "file must not be null");
+        try {
+            createParentDirectories(file);
+            if (!Files.exists(file)) {
+                Files.createFile(file);
+            }
+            long now = System.currentTimeMillis();
+            Files.setLastModifiedTime(file, FileTime.fromMillis(now));
+            return now;
+        } catch (IOException e) {
+            throw new UncheckedIOException("Failed to touch file: " + file, e);
+        }
+    }
+
+    /**
+     * 신뢰할 수 없는 상대 경로를 기준 디렉터리 내부로 안전하게 해석한다(경로 조작 방어 — CWE-22).
+     * 널 바이트·절대 경로·{@code ..} 탈출(정규화 후 기준 이탈)을 차단한다.
+     *
+     * <p>정규화는 어휘적(lexical)이다 — 실재하는 <b>심볼릭 링크</b>가 기준 디렉터리 밖을
+     * 가리키는 경우는 걸러지지 않는다. 기준 디렉터리 안에 신뢰할 수 없는 주체가 링크를 만들 수
+     * 있는 배치라면 호출 후 {@link Path#toRealPath}로 실경로를 확정해 한 번 더 확인한다.</p>
+     *
+     * <p>경로 구분자 해석은 <b>플랫폼을 따른다</b>. {@code ..\\escape}는 Windows 에서는 탈출로
+     * 차단되지만, 역슬래시가 일반 문자인 POSIX 계열에서는 그런 이름의 <b>파일 하나</b>로
+     * 해석되어 기준 디렉터리 안에 그대로 남는다(탈출은 아니다). 플랫폼 간 이식이 필요한
+     * 입력은 호출 전에 구분자를 정규화한다.</p>
+     *
+     * <p>Windows 에서는 예약 장치명(CON·PRN·AUX·NUL·COM1~9·LPT1~9, 확장자 유무 무관)을 구성요소로 가진
+     * 경로를 거부한다 — 파일이 아니라 장치로 열려 내용이 사라지거나 블로킹될 수 있다.</p>
+     *
+     * @param baseDir           기준 디렉터리(신뢰 값)
+     * @param untrustedRelative 사용자 입력 등 신뢰할 수 없는 상대 경로
+     * @return 기준 디렉터리 내부로 확정된 절대 경로
+     * @throws IllegalArgumentException 기준 디렉터리를 벗어나는 경로이거나 Windows 예약 장치명을 포함하는 경우
+     */
+    public static Path resolveSecurely(Path baseDir, String untrustedRelative) {
+        Objects.requireNonNull(baseDir, "baseDir must not be null");
+        if (untrustedRelative == null || untrustedRelative.isEmpty()) {
+            throw new IllegalArgumentException("path must not be null or empty");
+        }
+        if (untrustedRelative.indexOf('\0') >= 0) {
+            throw new IllegalArgumentException("path must not contain null byte");
+        }
+        Path base = baseDir.toAbsolutePath().normalize();
+        Path resolved = base.resolve(untrustedRelative).normalize();
+        if (!resolved.startsWith(base)) {
+            throw new IllegalArgumentException(
+                    "path escapes the base directory (path traversal blocked): " + untrustedRelative);
+        }
+        rejectWindowsReservedNames(base, resolved, untrustedRelative);
+        return resolved;
+    }
+
+    /** 기준 디렉터리 아래의 신뢰할 수 없는 구성요소에 Windows 예약 장치명이 있으면 거부한다(Windows 에서만). */
+    private static void rejectWindowsReservedNames(Path base, Path resolved, String original) {
+        if (hasWindowsReservedName(base, resolved)) {
+            throw new IllegalArgumentException(
+                    "path contains a Windows reserved device name (device access blocked): " + original);
+        }
+    }
+
+    private static boolean hasWindowsReservedName(Path base, Path resolved) {
+        if (!WINDOWS || resolved.getNameCount() <= base.getNameCount()) {
+            return false;
+        }
+        for (Path component : resolved.subpath(base.getNameCount(), resolved.getNameCount())) {
+            if (WINDOWS_RESERVED_NAME.matcher(component.toString()).matches()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * {@link #resolveSecurely(Path, String) resolveSecurely}의 <b>판정형</b> — 거부 사유가 무엇이든
+     * 예외 대신 {@link Optional#empty()}를 반환한다.
+     *
+     * <p>일괄 검증·필터처럼 항목마다 예외를 던질 수 없는 자리를 위한 형태다. 예외형만 있으면
+     * 호출부마다 try-catch 가 강제되고, 그 반복은 결국 {@code catch {}} 무시로 이어져 방어가
+     * 무력해진다. 거부 원인 구분이 필요하면 예외형 {@link #resolveSecurely}를 쓴다.</p>
+     *
+     * <p>예외형과 달리 운영체제가 허용하지 않는 문자가 섞인 입력({@link InvalidPathException})도
+     * 빈 값으로 판정한다.</p>
+     *
+     * <p>심볼릭 링크·경로 구분자에 대한 주의는 {@link #resolveSecurely}와 같다.</p>
+     *
+     * @param baseDir           기준 디렉터리(신뢰 값 — {@code null}이면 호출 코드 결함이므로 예외)
+     * @param untrustedRelative 사용자 입력 등 신뢰할 수 없는 상대 경로
+     * @return 기준 디렉터리 내부로 확정된 절대 경로, 거부되면 빈 값
+     */
+    public static Optional<Path> tryResolveSecurely(Path baseDir, String untrustedRelative) {
+        Objects.requireNonNull(baseDir, "baseDir must not be null");
+        if (untrustedRelative == null || untrustedRelative.isEmpty()
+                || untrustedRelative.indexOf('\0') >= 0) {
+            return Optional.empty();
+        }
+        try {
+            Path base = baseDir.toAbsolutePath().normalize();
+            Path resolved = base.resolve(untrustedRelative).normalize();
+            if (!resolved.startsWith(base) || hasWindowsReservedName(base, resolved)) {
+                return Optional.empty();
+            }
+            return Optional.of(resolved);
+        } catch (InvalidPathException e) {
+            return Optional.empty();
+        }
+    }
+
+    /**
+     * 경로가 <b>허용 루트 N개 중 하나의 하위</b>(루트 자신 포함)인지 판정한다.
+     *
+     * <p>업로드 저장소·이미지·문서 변환 디렉터리처럼 허용 루트가 여러 개인 배치에서, DB 등에
+     * 보관된 전체 경로가 여전히 허용 범위 안인지 확인하는 용도다. 비교는 정규화 후
+     * <b>경로 구성요소 단위</b>로 하므로 {@code /data-evil}이 {@code /data}의 하위로 오인되지
+     * 않는다. 문자열 접두 비교가 아니다.</p>
+     *
+     * <p>정규화는 어휘적(lexical)이다 — 실재하는 심볼릭 링크가 루트 밖을 가리키는 경우까지
+     * 봉쇄해야 하면 호출 전에 {@link Path#toRealPath}로 실경로를 확정한다.</p>
+     *
+     * @param candidate    검사할 경로
+     * @param allowedRoots 허용 루트 목록(1개 이상 — 0개는 설정 결함이므로 예외)
+     * @return 허용 루트 중 하나의 하위이면 {@code true}
+     * @throws IllegalArgumentException 허용 루트가 비어 있는 경우(fail-closed)
+     */
+    public static boolean isContainedIn(Path candidate, Path... allowedRoots) {
+        Objects.requireNonNull(candidate, "candidate must not be null");
+        requireRoots(allowedRoots);
+        Path normalized = candidate.toAbsolutePath().normalize();
+        for (Path root : allowedRoots) {
+            if (normalized.startsWith(root.toAbsolutePath().normalize())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * {@link #isContainedIn(Path, Path...)}의 문자열 입력형 — DB에 보관된 경로 문자열을 그대로
+     * 검사한다. {@code null}·빈 문자열·경로로 해석 불가한 문자열은 {@code false}로 판정한다.
+     *
+     * @param candidatePath 검사할 경로 문자열(신뢰할 수 없는 값)
+     * @param allowedRoots  허용 루트 목록(1개 이상)
+     * @return 허용 루트 중 하나의 하위이면 {@code true}
+     * @throws IllegalArgumentException 허용 루트가 비어 있는 경우(fail-closed)
+     */
+    public static boolean isContainedIn(String candidatePath, Path... allowedRoots) {
+        requireRoots(allowedRoots);
+        if (candidatePath == null || candidatePath.isEmpty()) {
+            return false;
+        }
+        Path parsed;
+        try {
+            parsed = Paths.get(candidatePath);
+        } catch (InvalidPathException e) {
+            return false;
+        }
+        return isContainedIn(parsed, allowedRoots);
+    }
+
+    /**
+     * {@link #isContainedIn(Path, Path...)}의 <b>봉쇄형</b> — 허용 루트 밖이면
+     * {@link IllegalArgumentException}을 던지고, 안이면 정규화된 절대 경로를 반환한다.
+     *
+     * <p>심볼릭 링크에 대한 주의는 {@link #isContainedIn(Path, Path...)}과 같다.</p>
+     *
+     * @param candidate    검사할 경로
+     * @param allowedRoots 허용 루트 목록(1개 이상)
+     * @return 정규화된 절대 경로
+     * @throws IllegalArgumentException 허용 루트 밖이거나 허용 루트가 비어 있는 경우
+     */
+    public static Path requireContainedIn(Path candidate, Path... allowedRoots) {
+        if (!isContainedIn(candidate, allowedRoots)) {
+            throw new IllegalArgumentException(
+                    "path is outside every allowed root (containment blocked): " + candidate);
+        }
+        return candidate.toAbsolutePath().normalize();
+    }
+
+    /**
+     * {@link #requireContainedIn(Path, Path...)}의 문자열 입력형. 경로로 해석 불가한 문자열은
+     * 원인({@link InvalidPathException})을 연결한 {@link IllegalArgumentException}으로 거부한다.
+     *
+     * @param candidatePath 검사할 경로 문자열(신뢰할 수 없는 값)
+     * @param allowedRoots  허용 루트 목록(1개 이상)
+     * @return 정규화된 절대 경로
+     * @throws IllegalArgumentException 허용 루트 밖·해석 불가·허용 루트가 비어 있는 경우
+     */
+    public static Path requireContainedIn(String candidatePath, Path... allowedRoots) {
+        requireRoots(allowedRoots);
+        if (candidatePath == null || candidatePath.isEmpty()) {
+            throw new IllegalArgumentException("path must not be null or empty");
+        }
+        Path parsed;
+        try {
+            parsed = Paths.get(candidatePath);
+        } catch (InvalidPathException e) {
+            throw new IllegalArgumentException("path is not a valid file system path: " + candidatePath, e);
+        }
+        return requireContainedIn(parsed, allowedRoots);
+    }
+
+    private static void requireRoots(Path[] allowedRoots) {
+        if (allowedRoots == null || allowedRoots.length == 0) {
+            throw new IllegalArgumentException("at least one allowed root is required");
+        }
+        for (Path root : allowedRoots) {
+            Objects.requireNonNull(root, "allowed root must not be null");
+        }
+    }
+
+    /**
+     * 파일명에서 확장자를 반환한다(없으면 빈 문자열, 구분자 뒤 이름만 검사).
+     */
+    public static String getExtension(String filename) {
+        String name = fileNameOnly(filename);
+        int dot = name.lastIndexOf('.');
+        return (dot < 0) ? "" : name.substring(dot + 1);
+    }
+
+    /**
+     * 파일명에서 확장자를 제외한 이름을 반환한다.
+     */
+    public static String getBaseName(String filename) {
+        String name = fileNameOnly(filename);
+        int dot = name.lastIndexOf('.');
+        return (dot < 0) ? name : name.substring(0, dot);
+    }
+
+    private static String fileNameOnly(String filename) {
+        if (filename == null) {
+            return "";
+        }
+        int sep = Math.max(filename.lastIndexOf('/'), filename.lastIndexOf('\\'));
+        return (sep < 0) ? filename : filename.substring(sep + 1);
+    }
+
+    private static Charset charset(Charset charset) {
+        return (charset != null) ? charset : StandardCharsets.UTF_8;
+    }
+
+    private static void createParentDirectories(Path file) throws IOException {
+        Path parent = file.toAbsolutePath().getParent();
+        if (parent != null) {
+            Files.createDirectories(parent);
+        }
+    }
+
+}

--- a/Foundation/org.egovframe.rte.fdl.filehandling/src/test/java/org/egovframe/rte/fdl/filehandling/EgovContentDispositionsSecurityTest.java
+++ b/Foundation/org.egovframe.rte.fdl.filehandling/src/test/java/org/egovframe/rte/fdl/filehandling/EgovContentDispositionsSecurityTest.java
@@ -1,0 +1,78 @@
+package org.egovframe.rte.fdl.filehandling;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * EgovContentDispositions 의 <b>헤더 인젝션(CWE-113)</b> 회귀 검증 — 기능 테스트와 별도로
+ * 공격자가 파일명에 실어 보낼 법한 입력을 모아, 어떤 입력에도 헤더 값에 CR/LF 가 남지 않고
+ * quoted-string 이 닫히지 않은 채 끝나지 않음을 고정한다.
+ */
+public class EgovContentDispositionsSecurityTest {
+
+    private static final String BS = String.valueOf((char) 92);
+
+    private static final List<String> HOSTILE = List.of(
+            "evil.txt\r\nSet-Cookie: pwn=1",
+            "evil.txt\nX-Injected: 1",
+            "evil.txt\rX-Injected: 1",
+            "evil.txt\r\n\r\n<script>alert(1)</script>",
+            "a\"b\"c.txt",
+            "a" + BS + "\"b.txt",
+            "line sep.txt",       // U+2028 LINE SEPARATOR
+            "nextline.txt",      // U+0085 NEL
+            "tab\tname.txt",
+            "100%.txt", "it's*.txt", "semi;colon.txt", "eq=uals.txt",
+            "../../etc/passwd",
+            "x".repeat(2000) + ".txt");
+
+    @Test
+    public void 어떤_입력에도_헤더_값에_CR_LF가_남지_않는다() {
+        for (String name : HOSTILE) {
+            String header = EgovContentDispositions.attachment(name);
+            assertFalse(header.contains("\r") || header.contains("\n"),
+                    "CR/LF 잔존: " + name.replace("\r", "<CR>").replace("\n", "<LF>") + " -> " + header);
+        }
+    }
+
+    @Test
+    public void 인용부호는_항상_이스케이프되어_quoted_string이_깨지지_않는다() {
+        for (String name : HOSTILE) {
+            String header = EgovContentDispositions.attachment(name);
+            String quoted = header.substring(header.indexOf("filename=\"") + "filename=\"".length());
+            // 폴백 filename 값 안에 이스케이프되지 않은 " 가 있으면 파라미터 경계가 무너진다
+            int end = quoted.indexOf("\"; filename*=");
+            String value = (end >= 0) ? quoted.substring(0, end) : quoted.substring(0, quoted.lastIndexOf('"'));
+            assertFalse(value.replace(BS + BS, "").replace(BS + "\"", "").contains("\""),
+                    "이스케이프되지 않은 인용부호: " + header);
+        }
+    }
+
+    @Test
+    public void 유니코드_줄구분자는_비ASCII_경로로_퍼센트_인코딩된다() {
+        String header = EgovContentDispositions.attachment("line sep.txt");
+        assertTrue(header.contains("filename*=UTF-8''line%E2%80%A8sep.txt"), header);
+        assertTrue(header.contains("filename=\"line_sep.txt\""), "ASCII 폴백은 _ 치환: " + header);
+    }
+
+    @Test
+    public void RFC5987_attr_char_밖의_문자는_전부_인코딩된다() {
+        // ' * % 는 attr-char 가 아니므로 filename* 값에 그대로 나타나면 안 된다
+        String header = EgovContentDispositions.attachment("한글 it's*100%.txt");
+        String star = header.substring(header.indexOf("filename*=UTF-8''") + "filename*=UTF-8''".length());
+        assertFalse(star.contains("'") || star.contains("*") || star.contains(" "), star);
+        assertTrue(star.contains("%27") && star.contains("%2A") && star.contains("%25"), star);
+    }
+
+    @Test
+    public void 경로가_섞인_이름은_이름만_남고_상위_이동이_헤더에_실리지_않는다() {
+        assertEquals("attachment; filename=\"passwd\"", EgovContentDispositions.attachment("../../etc/passwd"));
+        assertEquals("attachment; filename=\"passwd\"",
+                EgovContentDispositions.attachment(".." + BS + ".." + BS + "etc" + BS + "passwd"));
+    }
+}

--- a/Foundation/org.egovframe.rte.fdl.filehandling/src/test/java/org/egovframe/rte/fdl/filehandling/EgovContentDispositionsTest.java
+++ b/Foundation/org.egovframe.rte.fdl.filehandling/src/test/java/org/egovframe/rte/fdl/filehandling/EgovContentDispositionsTest.java
@@ -1,0 +1,71 @@
+package org.egovframe.rte.fdl.filehandling;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * EgovContentDispositions(RFC 6266/5987 헤더 값 생성) 검증.
+ */
+public class EgovContentDispositionsTest {
+
+    @Test
+    public void ASCII_파일명은_기존_형식을_유지한다() {
+        assertEquals("attachment; filename=\"report.pdf\"", EgovContentDispositions.attachment("report.pdf"));
+        assertEquals("inline; filename=\"chart.png\"", EgovContentDispositions.inline("chart.png"));
+    }
+
+    @Test
+    public void 한글_파일명은_filename스타에_ASCII_폴백을_병기한다() {
+        // 보(EB B3 B4)·고(EA B3 A0)·서(EC 84 9C) — attr-char 인 '.' 과 확장자는 그대로 남는다
+        assertEquals("attachment; filename=\"___.hwp\"; filename*=UTF-8''%EB%B3%B4%EA%B3%A0%EC%84%9C.hwp",
+                EgovContentDispositions.attachment("보고서.hwp"));
+    }
+
+    @Test
+    public void CR_LF_등_제어문자는_제거된다_헤더_인젝션_차단() {
+        String header = EgovContentDispositions.attachment("evil\r\nSet-Cookie: x=1.txt");
+        assertFalse(header.contains("\r"), header);
+        assertFalse(header.contains("\n"), header);
+        assertEquals("attachment; filename=\"evilSet-Cookie: x=1.txt\"", header);
+    }
+
+    @Test
+    public void 경로는_잘리고_파일명만_실린다() {
+        assertEquals("attachment; filename=\"passwd\"", EgovContentDispositions.attachment("../../etc/passwd"));
+        String windows = EgovContentDispositions.attachment("C:\\upload\\비밀문서.hwp");
+        assertFalse(windows.contains("upload"), windows);
+        assertTrue(windows.endsWith("filename*=UTF-8''%EB%B9%84%EB%B0%80%EB%AC%B8%EC%84%9C.hwp"), windows);
+    }
+
+    @Test
+    public void 인용부호와_역슬래시는_quoted_string_규칙으로_이스케이프한다() {
+        assertEquals("attachment; filename=\"a\\\"b.txt\"", EgovContentDispositions.attachment("a\"b.txt"));
+    }
+
+    @Test
+    public void 공백_괄호는_폴백에_남고_filename스타에서는_퍼센트_인코딩된다() {
+        assertEquals("attachment; filename=\"__ __ (2026).xlsx\""
+                        + "; filename*=UTF-8''%EC%97%B0%EB%A7%90%20%EC%A0%95%EC%82%B0%20%282026%29.xlsx",
+                EgovContentDispositions.attachment("연말 정산 (2026).xlsx"));
+    }
+
+    @Test
+    public void null_빈값_정리후_잔여없음은_예외다() {
+        assertThrows(IllegalArgumentException.class, () -> EgovContentDispositions.attachment(null));
+        assertThrows(IllegalArgumentException.class, () -> EgovContentDispositions.attachment(""));
+        assertThrows(IllegalArgumentException.class, () -> EgovContentDispositions.attachment("\r\n"));
+    }
+
+    @Test
+    public void 확장자만_ASCII인_통상_사례_폴백은_확장자를_보존한다() {
+        String header = EgovContentDispositions.attachment("연차보고서.xls");
+        assertNotNull(header);
+        assertTrue(header.contains("filename=\"_____.xls\""), "폴백에서 확장자 보존: " + header);
+    }
+
+}

--- a/Foundation/org.egovframe.rte.fdl.filehandling/src/test/java/org/egovframe/rte/fdl/filehandling/EgovFilesSecurityTest.java
+++ b/Foundation/org.egovframe.rte.fdl.filehandling/src/test/java/org/egovframe/rte/fdl/filehandling/EgovFilesSecurityTest.java
@@ -1,0 +1,140 @@
+package org.egovframe.rte.fdl.filehandling;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * EgovFiles 경로 봉쇄의 <b>공격 입력</b> 검증 — 기능 테스트({@link EgovFilesTest})와 별도로,
+ * 경로 조작(CWE-22)에 실제로 쓰이는 표기 변형을 한 곳에 모아 회귀를 막는다.
+ *
+ * <p>판정 기준은 하나다: 기준 디렉터리 <b>밖으로 확정되는 경로가 하나라도 나오는가.</b>
+ * 리터럴로 남아 기준 안에 놓이는 입력(URL 인코딩·전각 점)은 탈출이 아니므로 허용이 맞다.</p>
+ */
+public class EgovFilesSecurityTest {
+
+    private static final String BS = String.valueOf((char) 92);
+
+    @TempDir
+    Path tempDir;
+
+    private Path base() throws Exception {
+        return Files.createDirectories(tempDir.resolve("base"));
+    }
+
+    // ------------------------------------------------------------ 모든 OS
+
+    @Test
+    public void 상위_이동_변형은_전부_차단된다() throws Exception {
+        Path base = base();
+        List<String> attacks = List.of(
+                "../pwn", "../../pwn", "sub/../../pwn", "a/b/../../../pwn", "..");
+        for (String attack : attacks) {
+            assertThrows(IllegalArgumentException.class,
+                    () -> EgovFiles.resolveSecurely(base, attack), "차단돼야 한다: " + attack);
+            assertFalse(EgovFiles.tryResolveSecurely(base, attack).isPresent(), "판정형도 거부: " + attack);
+        }
+    }
+
+    @Test
+    public void 인코딩_변형은_해석하지_않고_리터럴_이름으로_기준_안에_둔다() throws Exception {
+        Path base = base();
+        // 퍼센트 인코딩·전각 점은 파일시스템에 그런 이름의 항목일 뿐이다 — 디코딩해 탈출로 바꾸지 않는다
+        for (String literal : List.of("%2e%2e/pwn", "%2e%2e%2fpwn", "．．/pwn", "....//pwn")) {
+            Path resolved = EgovFiles.resolveSecurely(base, literal);
+            assertTrue(resolved.startsWith(base), "기준 안이어야 한다: " + literal + " -> " + resolved);
+        }
+    }
+
+    @Test
+    public void 널바이트와_빈값은_거부된다() throws Exception {
+        Path base = base();
+        assertThrows(IllegalArgumentException.class, () -> EgovFiles.resolveSecurely(base, "ok.txt" + (char) 0));
+        assertThrows(IllegalArgumentException.class, () -> EgovFiles.resolveSecurely(base, "ok" + (char) 0 + "/../pwn"));
+        assertThrows(IllegalArgumentException.class, () -> EgovFiles.resolveSecurely(base, ""));
+        assertFalse(EgovFiles.tryResolveSecurely(base, "ok.txt" + (char) 0).isPresent());
+        assertFalse(EgovFiles.tryResolveSecurely(base, "").isPresent());
+    }
+
+    @Test
+    public void POSIX_절대_경로는_기준_밖으로_차단된다() throws Exception {
+        Path base = base();
+        // Windows 에서는 루트 상대(현재 드라이브 루트)로 해석돼 역시 기준 밖이다
+        assertThrows(IllegalArgumentException.class, () -> EgovFiles.resolveSecurely(base, "/etc/passwd"));
+        assertThrows(IllegalArgumentException.class, () -> EgovFiles.resolveSecurely(base, "//server/share/pwn"));
+    }
+
+    // ------------------------------------------------------------ Windows
+
+    @Test
+    @EnabledOnOs(OS.WINDOWS)
+    public void 윈도우_드라이브_UNC_루트상대_경로는_차단된다() throws Exception {
+        Path base = base();
+        for (String attack : List.of(
+                "C:" + BS + "Windows" + BS + "pwn",
+                BS + "pwn",
+                BS + BS + "server" + BS + "share" + BS + "pwn",
+                ".." + BS + ".." + BS + "pwn")) {
+            assertThrows(IllegalArgumentException.class,
+                    () -> EgovFiles.resolveSecurely(base, attack), "차단돼야 한다: " + attack);
+        }
+    }
+
+    @Test
+    @EnabledOnOs(OS.WINDOWS)
+    public void 윈도우_드라이브_상대_경로는_기준_드라이브_기준으로_붙어_기준_안에_남는다() throws Exception {
+        Path base = base();
+        // "C:pwn" 은 드라이브 상대 표기 — Java 가 기준 경로의 드라이브에 이어 붙이므로 탈출이 아니다
+        Path resolved = EgovFiles.resolveSecurely(base, base.getRoot().toString().substring(0, 2) + "pwn");
+        assertTrue(resolved.startsWith(base), resolved.toString());
+    }
+
+    @Test
+    @EnabledOnOs(OS.WINDOWS)
+    public void 윈도우_ADS와_끝_공백은_경로로_해석되지_않아_거부된다() throws Exception {
+        Path base = base();
+        // 대체 데이터 스트림 구분자(:)와 끝 공백은 Windows 경로 파서가 InvalidPathException 으로 거부한다
+        assertFalse(EgovFiles.tryResolveSecurely(base, "ok.txt:hidden").isPresent());
+        assertFalse(EgovFiles.tryResolveSecurely(base, "ok.txt::$DATA").isPresent());
+        assertFalse(EgovFiles.tryResolveSecurely(base, "ok.txt ").isPresent());
+    }
+
+    @Test
+    @EnabledOnOs(OS.WINDOWS)
+    public void 윈도우_예약_장치명은_거부된다() throws Exception {
+        // 예약 장치명은 파일이 아니라 장치로 열린다 — NUL 은 내용이 사라지고 CON 은 콘솔에 붙어 블로킹될 수 있다.
+        // 확장자가 붙어도(NUL.txt) 장치이며, 중간 구성요소로 와도 마찬가지다
+        Path base = base();
+        for (String name : List.of("NUL", "nul", "NUL.txt", "CON", "PRN.log", "AUX", "COM1", "com9.dat",
+                "LPT1", "sub/NUL/x.txt")) {
+            assertThrows(IllegalArgumentException.class, () -> EgovFiles.resolveSecurely(base, name), name);
+            assertTrue(EgovFiles.tryResolveSecurely(base, name).isEmpty(), name);
+        }
+        // 예약명을 접두로 가질 뿐인 정상 이름은 통과한다
+        for (String ok : List.of("console.txt", "nullable.txt", "com10.txt", "aux2.txt", "lpt0.txt", "prn_report.txt")) {
+            assertDoesNotThrow(() -> EgovFiles.resolveSecurely(base, ok), ok);
+        }
+    }
+
+    // ------------------------------------------------------------ 확장자 추출
+
+    @Test
+    public void 확장자_추출은_경로를_먼저_떼고_마지막_점만_본다() {
+        assertTrue(EgovFiles.getExtension("../../etc/shell.jsp").equals("jsp"));
+        assertTrue(EgovFiles.getExtension("dir" + BS + "shell.jsp").equals("jsp"));
+        assertTrue(EgovFiles.getExtension("shell.jsp.").isEmpty(), "점으로 끝나면 확장자 없음");
+        assertTrue(EgovFiles.getExtension("shell．jsp").isEmpty(), "전각 점은 구분자가 아니다");
+        assertTrue(EgovFiles.getExtension(null).isEmpty());
+        assertTrue(EgovFiles.getBaseName("../../etc/shell.jsp").equals("shell"));
+    }
+}

--- a/Foundation/org.egovframe.rte.fdl.filehandling/src/test/java/org/egovframe/rte/fdl/filehandling/EgovFilesTest.java
+++ b/Foundation/org.egovframe.rte.fdl.filehandling/src/test/java/org/egovframe/rte/fdl/filehandling/EgovFilesTest.java
@@ -1,0 +1,273 @@
+package org.egovframe.rte.fdl.filehandling;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * EgovFiles(NIO.2 무상태 파일 유틸) 검증.
+ */
+public class EgovFilesTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    public void 한글_텍스트_UTF8_왕복_읽기쓰기() {
+        Path file = tempDir.resolve("한글.txt");
+        EgovFiles.writeString(file, "전자정부 표준프레임워크\n파일 처리 현대화");
+        assertEquals("전자정부 표준프레임워크\n파일 처리 현대화", EgovFiles.readString(file));
+    }
+
+    @Test
+    public void 쓰기_시_부모_디렉터리_자동_생성() {
+        Path file = tempDir.resolve("a/b/c/deep.txt");
+        EgovFiles.writeString(file, "deep");
+        assertEquals("deep", EgovFiles.readString(file));
+    }
+
+    @Test
+    public void 지정_문자셋_읽기쓰기() {
+        Path file = tempDir.resolve("euckr.txt");
+        EgovFiles.writeString(file, "고정길이 전문", java.nio.charset.Charset.forName("EUC-KR"));
+        assertEquals("고정길이 전문", EgovFiles.readString(file, java.nio.charset.Charset.forName("EUC-KR")));
+    }
+
+    @Test
+    public void 파일_복사와_디렉터리_재귀_복사() throws Exception {
+        Path srcDir = tempDir.resolve("src");
+        Files.createDirectories(srcDir.resolve("sub/subsub"));
+        EgovFiles.writeString(srcDir.resolve("root.txt"), "r");
+        EgovFiles.writeString(srcDir.resolve("sub/subsub/leaf.txt"), "l");
+
+        Path destDir = tempDir.resolve("dest");
+        EgovFiles.copy(srcDir, destDir);
+
+        assertEquals("r", EgovFiles.readString(destDir.resolve("root.txt")));
+        assertEquals("l", EgovFiles.readString(destDir.resolve("sub/subsub/leaf.txt")));
+        assertTrue(Files.exists(srcDir.resolve("root.txt")), "복사는 원본을 보존한다");
+    }
+
+    @Test
+    public void 이동은_원본을_제거한다() {
+        Path src = tempDir.resolve("move-src.txt");
+        Path dest = tempDir.resolve("moved/move-dest.txt");
+        EgovFiles.writeString(src, "mv");
+        EgovFiles.move(src, dest);
+        assertFalse(Files.exists(src));
+        assertEquals("mv", EgovFiles.readString(dest));
+    }
+
+    @Test
+    public void 깊이_3단계_트리도_전부_삭제된다_기존_rm의_1단계_한계_해소() throws Exception {
+        Path root = tempDir.resolve("tree");
+        Files.createDirectories(root.resolve("d1/d2"));
+        EgovFiles.writeString(root.resolve("f0.txt"), "0");
+        EgovFiles.writeString(root.resolve("d1/f1.txt"), "1");
+        EgovFiles.writeString(root.resolve("d1/d2/f2.txt"), "2");
+
+        long deleted = EgovFiles.deleteRecursively(root);
+
+        assertEquals(6, deleted); // root, d1, d2, f0, f1, f2
+        assertFalse(Files.exists(root));
+    }
+
+    @Test
+    public void 없는_경로_삭제는_0을_반환한다() {
+        assertEquals(0, EgovFiles.deleteRecursively(tempDir.resolve("ghost")));
+    }
+
+    @Test
+    public void 목록은_실제_항목을_이름순으로_반환한다_기존_ls_빈_리스트_해소() throws Exception {
+        Files.createDirectories(tempDir.resolve("listdir/sub"));
+        EgovFiles.writeString(tempDir.resolve("listdir/b.txt"), "b");
+        EgovFiles.writeString(tempDir.resolve("listdir/a.txt"), "a");
+        EgovFiles.writeString(tempDir.resolve("listdir/sub/c.txt"), "c");
+
+        List<Path> shallow = EgovFiles.list(tempDir.resolve("listdir"));
+        assertEquals(3, shallow.size());
+        assertEquals("a.txt", shallow.get(0).getFileName().toString());
+
+        List<Path> deep = EgovFiles.listRecursively(tempDir.resolve("listdir"));
+        assertEquals(3, deep.size()); // 파일만(a, b, sub/c)
+    }
+
+    @Test
+    public void grepLines는_매칭되는_라인만_반환한다_기존_grep_split_오동작_해소() {
+        Path file = tempDir.resolve("grep.txt");
+        EgovFiles.writeString(file, "alpha ERROR one\nbeta info\ngamma ERROR two\ndelta warn");
+
+        List<String> matched = EgovFiles.grepLines(file, "ERROR");
+
+        assertEquals(2, matched.size());
+        assertEquals("alpha ERROR one", matched.get(0));
+        assertEquals("gamma ERROR two", matched.get(1));
+    }
+
+    @Test
+    public void touch는_파일을_만들고_수정시각을_갱신한다() throws Exception {
+        Path file = tempDir.resolve("touch.txt");
+        long stamped = EgovFiles.touch(file);
+        assertTrue(Files.exists(file));
+        assertTrue(stamped > 0);
+    }
+
+    @Test
+    public void 경로_조작은_차단된다() {
+        Path base = tempDir.resolve("base");
+        assertEquals(base.toAbsolutePath().normalize().resolve("ok/file.txt"),
+                EgovFiles.resolveSecurely(base, "ok/file.txt"));
+        assertThrows(IllegalArgumentException.class, () -> EgovFiles.resolveSecurely(base, "../escape.txt"));
+        assertThrows(IllegalArgumentException.class, () -> EgovFiles.resolveSecurely(base, "a/../../escape.txt"));
+        assertThrows(IllegalArgumentException.class,
+                () -> EgovFiles.resolveSecurely(base, tempDir.resolve("abs.txt").toAbsolutePath().toString()));
+        assertThrows(IllegalArgumentException.class, () -> EgovFiles.resolveSecurely(base, "bad\0name"));
+    }
+
+    @Test
+    public void 실패는_UncheckedIOException으로_정직하게_전파된다_침묵_실패_해소() {
+        assertThrows(UncheckedIOException.class, () -> EgovFiles.readString(tempDir.resolve("missing.txt")));
+        assertThrows(UncheckedIOException.class,
+                () -> EgovFiles.copy(tempDir.resolve("missing-src.txt"), tempDir.resolve("t.txt")));
+        assertThrows(UncheckedIOException.class,
+                () -> EgovFiles.move(tempDir.resolve("missing-src.txt"), tempDir.resolve("t.txt")));
+    }
+
+    @Test
+    public void 확장자와_기본이름_추출() {
+        assertEquals("xlsx", EgovFiles.getExtension("dir/보고서.최종.xlsx"));
+        assertEquals("보고서.최종", EgovFiles.getBaseName("dir\\보고서.최종.xlsx"));
+        assertEquals("", EgovFiles.getExtension("noext"));
+        assertEquals("noext", EgovFiles.getBaseName("noext"));
+    }
+
+    @Test
+    public void 라인_읽기_UTF8() {
+        Path file = tempDir.resolve("lines.txt");
+        EgovFiles.writeString(file, "하나\n둘\n셋");
+        assertEquals(List.of("하나", "둘", "셋"), EgovFiles.readLines(file, StandardCharsets.UTF_8));
+    }
+
+    // ---------------------------------------------------------------- 판정형·다중 허용 루트
+
+    @Test
+    public void 판정형_tryResolveSecurely는_거부를_빈값으로_돌려준다() {
+        Path base = tempDir.resolve("base");
+
+        assertEquals(base.toAbsolutePath().normalize().resolve("ok/file.txt"),
+                EgovFiles.tryResolveSecurely(base, "ok/file.txt").orElseThrow());
+
+        assertTrue(EgovFiles.tryResolveSecurely(base, "../escape.txt").isEmpty(), "탈출 시도는 빈값");
+        assertTrue(EgovFiles.tryResolveSecurely(base, null).isEmpty(), "null 입력은 빈값(무예외)");
+        assertTrue(EgovFiles.tryResolveSecurely(base, "").isEmpty(), "빈 문자열은 빈값(무예외)");
+        assertTrue(EgovFiles.tryResolveSecurely(base, "bad\0name").isEmpty(), "널 바이트는 빈값(무예외)");
+    }
+
+    @Test
+    public void 다중_허용_루트_중_하나의_하위이면_포함으로_판정한다() {
+        Path storeRoot = tempDir.resolve("store");
+        Path imageRoot = tempDir.resolve("image");
+
+        assertTrue(EgovFiles.isContainedIn(imageRoot.resolve("2026/a.png"), storeRoot, imageRoot),
+                "두 번째 허용 루트의 하위");
+        assertTrue(EgovFiles.isContainedIn(storeRoot, storeRoot, imageRoot), "루트 자신도 포함");
+        assertFalse(EgovFiles.isContainedIn(tempDir.resolve("outside/f.txt"), storeRoot, imageRoot));
+        assertFalse(EgovFiles.isContainedIn(storeRoot.resolve("../escape.txt"), storeRoot, imageRoot),
+                "정규화 후 루트 밖이면 제외");
+    }
+
+    @Test
+    public void 유사_접두_디렉터리명은_하위로_오인되지_않는다() {
+        Path dataRoot = tempDir.resolve("data");
+        assertFalse(EgovFiles.isContainedIn(tempDir.resolve("data-evil/f.txt"), dataRoot),
+                "경로 구성요소 단위 비교 — 문자열 접두 비교가 아니다");
+    }
+
+    @Test
+    public void 허용_루트_0개는_설정_결함으로_즉시_예외다() {
+        Path candidate = tempDir.resolve("f.txt");
+        assertThrows(IllegalArgumentException.class, () -> EgovFiles.isContainedIn(candidate));
+        assertThrows(IllegalArgumentException.class, () -> EgovFiles.isContainedIn(candidate.toString()));
+        assertThrows(IllegalArgumentException.class, () -> EgovFiles.requireContainedIn(candidate));
+    }
+
+    @Test
+    public void 문자열형_판정은_해석_불가_입력을_false로_돌려준다() {
+        Path root = tempDir.resolve("root");
+        assertFalse(EgovFiles.isContainedIn((String) null, root));
+        assertFalse(EgovFiles.isContainedIn("", root));
+        assertFalse(EgovFiles.isContainedIn("bad\0path", root));
+        assertTrue(EgovFiles.isContainedIn(root.resolve("db-stored/file.pdf").toString(), root));
+    }
+
+    @Test
+    public void 봉쇄형_requireContainedIn은_루트_밖이면_예외_안이면_정규화_경로를_반환한다() {
+        Path root = tempDir.resolve("root");
+
+        assertEquals(root.toAbsolutePath().normalize().resolve("sub/f.txt"),
+                EgovFiles.requireContainedIn(root.resolve("sub/f.txt"), root));
+        assertEquals(root.toAbsolutePath().normalize().resolve("f.txt"),
+                EgovFiles.requireContainedIn(root.resolve("sub/../f.txt"), root), "반환값은 정규화된다");
+
+        assertThrows(IllegalArgumentException.class,
+                () -> EgovFiles.requireContainedIn(tempDir.resolve("outside/f.txt"), root));
+        assertThrows(IllegalArgumentException.class,
+                () -> EgovFiles.requireContainedIn(root.resolve("../escape.txt"), root));
+        assertThrows(IllegalArgumentException.class,
+                () -> EgovFiles.requireContainedIn("bad\0path", root), "해석 불가 문자열은 cause 를 달아 거부");
+        assertThrows(IllegalArgumentException.class, () -> EgovFiles.requireContainedIn((String) null, root));
+    }
+
+
+    // ---------------------------------------------------------------- 플랫폼 의존 동작 고정
+
+    @Test
+    @EnabledOnOs(OS.WINDOWS)
+    public void 윈도우에서는_역슬래시가_구분자라_탈출로_차단된다() {
+        Path base = tempDir.resolve("base");
+        assertThrows(IllegalArgumentException.class, () -> EgovFiles.resolveSecurely(base, "..\\escape.txt"));
+        assertThrows(IllegalArgumentException.class, () -> EgovFiles.resolveSecurely(base, "C:\\evil.txt"));
+    }
+
+    @Test
+    @DisabledOnOs(OS.WINDOWS)
+    public void POSIX에서는_역슬래시가_일반_문자라_기준_안의_파일명이_된다() {
+        Path base = tempDir.resolve("base");
+        // 탈출이 아니라 그런 이름의 파일 하나로 해석된다 — 기준 디렉터리 밖으로 나가지 않는다.
+        Path resolved = EgovFiles.resolveSecurely(base, "..\\escape.txt");
+        assertTrue(resolved.startsWith(base.toAbsolutePath().normalize()),
+                "역슬래시 입력도 기준 디렉터리 안에 머문다");
+        assertEquals("..\\escape.txt", resolved.getFileName().toString());
+    }
+
+    @Test
+    @DisabledOnOs(OS.WINDOWS)
+    public void 심볼릭_링크는_어휘적_정규화로_걸러지지_않는다_계약_고정() throws Exception {
+        Path base = Files.createDirectories(tempDir.resolve("base"));
+        Path outside = Files.createDirectories(tempDir.resolve("outside"));
+        Files.createSymbolicLink(base.resolve("link"), outside);
+
+        // 어휘적 정규화라 링크 경유 경로는 통과한다(javadoc 에 명시된 계약).
+        Path viaLink = EgovFiles.resolveSecurely(base, "link/secret.txt");
+        assertTrue(EgovFiles.isContainedIn(viaLink, base), "어휘적으로는 기준 안으로 판정된다");
+
+        // 실경로로 확정하면 기준 밖임이 드러난다 — 봉쇄가 필요하면 이 단계를 덧붙여야 한다.
+        Files.write(outside.resolve("secret.txt"), "x".getBytes(StandardCharsets.UTF_8));
+        assertFalse(viaLink.toRealPath().startsWith(base.toRealPath()),
+                "실경로 기준으로는 기준 디렉터리 밖이다");
+    }
+
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [ ] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [X] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

### 배경

`fdl.filehandling` 의 기존 `EgovFileUtil` 은 Commons VFS 기반이며 구조적 제약이 있습니다.

| 제약 | 내용 |
|---|---|
| 전역 상태 | `cd()` 로 **프로세스 전역** 기준 디렉터리를 두어 스레드 안전하지 않습니다 |
| 침묵 실패 | `rm`/`cp`/`mv` 실패를 debug 로그만 남기고 **정상 복귀**합니다 |
| 문자셋 | 텍스트 IO 가 **플랫폼 기본 문자셋**(MS949/UTF-8)에 의존합니다 |
| 경로 방어 부재 | **신뢰할 수 없는 경로를 기준 디렉터리 안으로 강제하는 수단이 없습니다** |

특히 마지막 항목 때문에, 업로드·다운로드 경로를 다루는 코드가 매번 자체 방어를 재구현하게 됩니다.
그 재구현이 대개 `replaceAll("\\.\\.", "")` 같은 **문자 삭제**로 이뤄지는데, 이는 결과가 기준
디렉터리 밖인지 **판정하지 않고**, `..` 없는 절대 경로는 그대로 통과시키며, 정상 파일명
(`report..v2.txt` → `reportv2.txt`)까지 훼손합니다.

### 추가한 것

**`EgovFiles`** — NIO.2 기반 **무상태** 파일 유틸

| API | 용도 |
|---|---|
| `resolveSecurely(base, 입력)` | 기준 디렉터리 밖으로 나가는 경로를 **차단**(정규화 후 봉쇄 검증 + 절대 경로·널 바이트 차단) |
| `tryResolveSecurely(base, 입력)` | 같은 검사의 **판정형** — 거부를 `Optional.empty()` 로 |
| `isContainedIn(경로, 루트…)` | 경로가 **허용 루트 N개 중 하나의 하위**인지 판정 |
| `requireContainedIn(경로, 루트…)` | 위의 **봉쇄형** — 밖이면 예외 |
| `deleteRecursively` · `grepLines` · `list` · 텍스트 IO 등 | 기존 유틸의 결함을 고친 대체 구현 |

판정형을 따로 둔 이유는, 예외 단일형만 있으면 **호출부마다 `try-catch` 가 강제되고 그 반복이
결국 `catch {}` 무시로 이어져** 방어가 무력해지기 때문입니다. 일괄 검증·필터처럼 예외를 던질 수
없는 자리를 위한 것입니다.

**`EgovContentDispositions`** — RFC 6266/5987 `Content-Disposition` 값 생성.
비ASCII 파일명에 `filename*=UTF-8''…` 를 쓰되 **구형 에이전트용 ASCII 폴백을 병기**하고
제어문자를 제거합니다.

### 플랫폼 의존 동작 — 명시하고 테스트로 고정했습니다

Windows 와 Linux 에서 실제로 동작이 갈리는 지점이 두 곳 있습니다. 양쪽에서 같은 입력을 실측해
확인한 뒤, **javadoc 에 명시하고 회귀 테스트로 고정**했습니다.

**① 심볼릭 링크는 걸러지지 않습니다 (POSIX)**

정규화(`normalize()`)는 **어휘적**이라 심볼릭 링크를 풀지 않습니다. 기준 디렉터리 안에 밖을
가리키는 링크가 있으면 `resolveSecurely` 는 이를 통과시킵니다.

| 확인 | Windows | Linux |
|---|---|---|
| 기준 디렉터리 안에 심볼릭 링크 생성 | 권한 없어 실패 | 성공 |
| `resolveSecurely(base, "link/secret.txt")` | — | **허용** |
| `isContainedIn(링크경유, base)` | — | **true** |
| `toRealPath()` 가 base 하위인가 | — | **false** |

이는 어휘적 정규화의 일반적인 한계이며, `toRealPath()` 는 파일이 실재해야 하므로 기본 경로에
넣기 어렵습니다. 따라서 **계약으로 명시**했습니다 — 기준 디렉터리 안에 신뢰할 수 없는 주체가
링크를 만들 수 있는 배치라면 호출 후 `toRealPath()` 로 한 번 더 확인해야 합니다.
경로 API 6종 전부의 javadoc 에 이 주의를 달았습니다.

**② 경로 구분자 해석은 플랫폼을 따릅니다**

| 입력 | Windows | Linux |
|---|---|---|
| `../escape.txt` | 차단 | 차단 |
| `..\escape.txt` | **차단**(구분자) | **허용** — 그 이름의 파일 하나(탈출 아님) |
| `C:\evil.txt` | **차단**(절대 경로) | **허용** — 그 이름의 파일 하나 |
| `bad\0name` | 차단 | 차단 |

POSIX 에서 역슬래시는 일반 문자이므로 `..\escape.txt` 는 **기준 디렉터리 안의 파일 이름**으로
해석됩니다. **탈출이 아니라 기준 안에 머무릅니다.** 다만 Windows 클라이언트가 보낸 경로를
Linux 서버가 처리하면 역슬래시가 든 이름이 생기므로, 이식이 필요하면 호출 전에 구분자를
정규화하라고 javadoc 에 적었습니다.

### 범위

- **기존 클래스 수정 0** — `EgovFileUtil` 을 포함해 어떤 기존 파일도 건드리지 않았습니다
- **pom 변경 0 · 외부 의존 0** — JDK 표준(`java.nio.file`)만 씁니다
- 원격 파일시스템(SFTP 등)이 필요한 경우에는 **`EgovFileUtil` 을 계속 사용**하고, 로컬 파일
  처리에 이 클래스를 쓰는 구성입니다

## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [X] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

**45건 신규**(`EgovFilesTest` 23 · `EgovContentDispositionsTest` 8 · 보안 회귀 `EgovFilesSecurityTest` 9 · `EgovContentDispositionsSecurityTest` 5), `fdl.filehandling` 모듈 전건 통과.

```
mvn -B -Dfile.encoding=UTF-8 -Duser.timezone=Asia/Seoul -pl :egovframe-rte-fdl-filehandling -am clean test
```

| 환경 | 기본 로케일(Locale) | 모듈 실행 건수 | 결과 |
|---|---|---:|---|
| 이관 전 | — | 31 | — |
| **Windows** | ko_KR | **76** | `Tests run: 76, Failures: 0, Errors: 0, Skipped: 2` |
| **Linux** (Ubuntu 22.04 / OpenJDK 17 / ext4) | C.UTF-8 | **76** | `Tests run: 76, Failures: 0, Errors: 0, Skipped: 5` |

`Skipped` 는 플랫폼 조건부 테스트입니다 — Windows 에서는 POSIX 전용 2건이, Linux 에서는
Windows 전용 5건(기능 1 · 보안 회귀 4)이 건너뛰어집니다(`@EnabledOnOs`/`@DisabledOnOs`).

`EgovFilesTest` 23건의 내역:

| 구분 | 건수 | 내용 |
|---|---:|---|
| 경로 조작 차단 | 2 | 예외형 `resolveSecurely`(`../` · `a/../../` · 절대 경로 · 널 바이트) · 판정형 `tryResolveSecurely` 등가 동작 |
| 허용 루트 판정·봉쇄 | 4 | 다중 루트 중 하나의 하위(루트 자신 포함) · **유사 접두(`data-evil` vs `data`) 오인 방지** · 루트 0개는 fail-closed 예외 · 봉쇄형 `requireContainedIn` |
| 문자열형 판정 | 1 | 해석 불가 입력(`null`·빈 문자열·널 바이트)을 `false` 로, DB 보관 전체 경로는 정상 판정 |
| **플랫폼 의존 고정** | **3** | Windows 역슬래시 탈출 차단 · POSIX 역슬래시는 기준 안 파일명 · **심볼릭 링크 계약**(어휘적으로는 통과, `toRealPath` 로는 기준 밖) |
| 파일 IO — 기존 결함 대체 | 4 | `deleteRecursively` 깊이 3단계(기존 `rm` 의 1단계 한계) · `list` 실제 목록(기존 `ls` 빈 리스트) · `grepLines` 매칭 라인(기존 `grep` split 오동작) · **실패의 예외 전파**(침묵 실패 해소) |
| 파일 IO — 일반 | 9 | UTF-8 왕복 · 지정 문자셋 · 부모 디렉터리 자동 생성 · 복사/재귀 복사 · 이동 · 없는 경로 삭제는 0 · `touch` · 확장자·기본이름 추출 · 라인 읽기 |

`EgovContentDispositionsTest` 8건: 한글 파일명 `filename*` 인코딩 · ASCII 폴백 병기 ·
제어문자 제거 · 계약(`null`/빈 입력).

**보안 회귀 테스트**는 기능 테스트와 분리해 두었습니다. 공격에 실제로 쓰이는 입력 변형을 표로 모아
두고 **한 건이라도 통과하면 실패**하도록 했으며, 새 우회 기법이 알려지면 표에 한 줄을 더하면 됩니다.

| 클래스 | 건수 | 내용 |
|---|---:|---|
| `EgovFilesSecurityTest` | 9 | 상위 이동 변형(`../`·`sub/../../`·`a/b/../../../`·`..`) 전부 차단 · **인코딩 변형은 해석하지 않음**(`%2e%2e/`·전각 점은 기준 안의 리터럴 이름) · 널 바이트·빈값 거부 · POSIX 절대 경로·`//server/share` 차단 · Windows 드라이브 절대·루트 상대·UNC·역슬래시 상위 이동 차단 · 드라이브 상대(`C:x`)는 기준 드라이브에 붙어 기준 안 · ADS·끝 공백은 경로로 해석되지 않아 거부 · **Windows 예약 장치명 거부**(`NUL`·`CON`·`COM1`… 확장자 유무 무관, 중간 구성요소 포함 · `console.txt` 같은 접두 이름은 통과) · 확장자 추출에 경로 미혼입 |
| `EgovContentDispositionsSecurityTest` | 5 | CR/LF·단독 CR·단독 LF · 인용부호·역슬래시-인용부호 · U+2028·U+0085 · 탭 · `%`·`'`·`*`·`;`·`=` · 경로 혼입 · 2,000자 — 어떤 입력에도 **헤더 값에 CR/LF 가 남지 않고** quoted-string 이 깨지지 않으며, RFC 5987 attr-char 밖 문자는 전부 퍼센트 인코딩되고, 경로가 섞인 이름은 이름만 남습니다 |

**수동 확인**: 경로 봉쇄는 파일시스템 의미론에 직접 좌우되므로, 단위 테스트와 별도로 동일 입력을
Windows 와 Linux(ext4)에서 각각 실행해 결과를 대조했습니다. 그 과정에서 드러난 차이 2가지를
위 "플랫폼 의존 동작" 절에 정리하고 테스트로 고정했습니다.

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

해당 없음 — 뷰나 화면이 아닌 **라이브러리 클래스 추가**이며, 검증은 위 JUnit 으로 수행했습니다.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

해당 없음 — 위 JUnit 테스트 결과로 갈음합니다.

---

<sub>base: `eGovFramework:main` @ `cd9fd9c` (2026-09-08 fetch 기준) · 단일 커밋</sub>
