### PR TITLE
feat: 컨텍스트별 출력 인코딩 EgovOutputEncoder 추가

### DIFF
--- a/Foundation/org.egovframe.rte.fdl.string/src/main/java/org/egovframe/rte/fdl/string/EgovOutputEncoder.java
+++ b/Foundation/org.egovframe.rte.fdl.string/src/main/java/org/egovframe/rte/fdl/string/EgovOutputEncoder.java
@@ -1,0 +1,327 @@
+/*
+ * Copyright 2009-2026 MOIS(Ministry of the Interior and Safety).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.egovframe.rte.fdl.string;
+
+import java.nio.charset.StandardCharsets;
+
+/**
+ * 값이 출력되는 <b>컨텍스트별</b> 인코딩을 제공하는 유틸 클래스.
+ *
+ * <p><b>NOTE:</b> XSS 방어는 "위험한 문자를 지우는" 것이 아니라 <b>값이 놓이는 자리의 문법에 맞게
+ * 인코딩</b>하는 것이다. 같은 문자라도 HTML 본문·속성·JavaScript·URL 에서 위험한 지점이 다르므로
+ * 하나의 함수로 모두 처리할 수 없다. 이 클래스는 자리마다 다른 메서드를 제공한다.</p>
+ *
+ * <pre>
+ * &lt;td&gt;{@code forHtml(v)}&lt;/td&gt;                    HTML 본문
+ * &lt;input value="{@code forHtml(v)}"&gt;              따옴표로 감싼 속성
+ * &lt;div class={@code forHtmlAttribute(v)}&gt;         따옴표 없는 속성
+ * &lt;script&gt;var s = '{@code forJavaScript(v)}';&lt;/script&gt;
+ * &lt;a href="/view?id={@code forUrl(v)}"&gt;
+ * </pre>
+ *
+ * <p><b>인코딩은 출력 시점에 한다.</b> 입력 시점에 인코딩해 저장하면 DB 에 {@code &amp;lt;} 가
+ * 남아 엑셀·API 응답·문자메시지 등 HTML 이 아닌 경로에서 그대로 노출된다. 또한 이미 인코딩한 값을
+ * JSP {@code <c:out>}(기본 {@code escapeXml="true"})으로 다시 내면 이중 인코딩이 되므로
+ * <b>한 번만</b> 적용한다.</p>
+ *
+ * <p><b>정제(sanitize)와 다르다.</b> 사용자가 입력한 태그를 <b>살려서</b> 보여줘야 하는
+ * 리치 텍스트 본문은 인코딩이 아니라 화이트리스트 정제 대상이다
+ * ({@code ptl.mvc} 의 {@code EgovHtmlSanitizer}).</p>
+ *
+ * <p><b>인코딩이 해결하지 않는 것</b> — ① URL 속성({@code href}·{@code src})에 값 <b>전체</b>를 넣을 때
+ * {@code javascript:} 같은 스킴은 어떤 인코딩으로도 바뀌지 않는다(문자 참조는 브라우저가 속성값
+ * 단계에서 도로 푼다). 스킴 화이트리스트(http·https·상대 경로) 검사를 따로 한 뒤 {@link #forHtml(String)}
+ * 를 쓴다. ② CSS({@code style} 속성·스타일시트) 컨텍스트는 제공하지 않는다 — 사용자 값을 CSS 에 넣지
+ * 않는다. ③ {@link #forJavaScript(String)} 는 따옴표 리터럴 전용이다. 백틱 템플릿 리터럴의
+ * <code>${...}</code> 와 JSON(<code>\'</code> 는 JSON 이스케이프가 아니다)은 다루지 않는다 —
+ * JSON 은 직렬화기에 맡긴다.</p>
+ *
+ * <p><b>계약</b> — 전 메서드가 {@code null} 을 빈 문자열로 돌려주며 예외를 던지지 않는다.
+ * 공백만으로 이루어진 문자열은 <b>그대로 보존</b>한다(들여쓰기·정렬이 사라지지 않는다).</p>
+ *
+ * <pre>
+ * &lt;&lt; 개정이력(Modification Information) &gt;&gt;
+ *
+ *  수정일        수정자        수정내용
+ *  ----------  --------    ---------------------------
+ *  2026.09.01  실행환경팀     최초 생성 (공통컴포넌트 EgovWebUtil 의 컨텍스트별 인코딩
+ *                            개념만 차용하고 구현은 재작성 — 코드 이식 아님. 원본
+ *                            clearXSSMinimum/Maximum/clearXSS 3종은 마침표를 &amp;#46; 로
+ *                            치환해 한글 문장·소수점·확장자를 훼손하고 입력 정화와 출력
+ *                            인코딩에 혼용되어 폐기, escapeXml/escapeJavaScript 는 공백
+ *                            문자열 소실과 &amp;apos; 의 HTML4 미지원 문제를 바로잡아 재구성)
+ * </pre>
+ *
+ * @author 실행환경 개발팀
+ * @since 5.1
+ */
+public final class EgovOutputEncoder {
+
+	/** RFC 3986 unreserved 문자 — 퍼센트 인코딩하지 않는다. */
+	private static final String URL_UNRESERVED = "-._~";
+
+	private static final char[] HEX = "0123456789ABCDEF".toCharArray();
+
+	/**
+	 * JavaScript 가 줄바꿈으로 해석하는 두 문자(U+2028 LINE SEPARATOR · U+2029 PARAGRAPH
+	 * SEPARATOR). 소스에 리터럴로 두지 않고 코드포인트로 선언한다 — 편집기·도구에 따라
+	 * 실제 줄바꿈으로 취급되어 소스가 손상될 수 있기 때문이다.
+	 */
+	private static final char JS_LINE_SEPARATOR = 0x2028;
+
+	private static final char JS_PARAGRAPH_SEPARATOR = 0x2029;
+
+	private EgovOutputEncoder() {
+	}
+
+	/**
+	 * HTML 본문과 <b>따옴표로 감싼</b> 속성값에 넣을 값을 인코딩한다.
+	 *
+	 * <p>{@code & < > " '} 다섯 문자만 문자 참조로 바꾸고 나머지는 <b>그대로 둔다</b> —
+	 * 한글·마침표·쉼표는 훼손되지 않는다. 작은따옴표는 HTML4 에 존재하지 않는
+	 * {@code &amp;apos;} 대신 숫자 참조 {@code &amp;#39;} 를 쓰므로 HTML·XHTML 양쪽에서 안전하다.</p>
+	 *
+	 * <p><b>따옴표 없는 속성값에는 충분하지 않다.</b> {@code <div class=값>} 처럼 쓰는 자리는
+	 * 공백 하나로 새 속성을 주입할 수 있으므로 {@link #forHtmlAttribute(String)} 를 쓰거나
+	 * 속성값을 따옴표로 감싼다.</p>
+	 *
+	 * @param value 인코딩할 값({@code null} 허용)
+	 * @return 인코딩된 문자열({@code null} 이면 빈 문자열)
+	 */
+	public static String forHtml(String value) {
+		if (value == null || value.isEmpty()) {
+			return "";
+		}
+		StringBuilder sb = new StringBuilder(value.length() + 16);
+		for (int i = 0; i < value.length(); i++) {
+			char ch = value.charAt(i);
+			switch (ch) {
+				case '&':
+					sb.append("&amp;");
+					break;
+				case '<':
+					sb.append("&lt;");
+					break;
+				case '>':
+					sb.append("&gt;");
+					break;
+				case '"':
+					sb.append("&quot;");
+					break;
+				case '\'':
+					sb.append("&#39;");
+					break;
+				default:
+					sb.append(ch);
+			}
+		}
+		return sb.toString();
+	}
+
+	/**
+	 * <b>따옴표 없는</b> HTML 속성값에 넣을 값을 인코딩한다.
+	 *
+	 * <p>ASCII 영숫자와 {@code U+0080} 이상(한글 등)만 남기고 <b>그 밖의 ASCII 는 전부</b>
+	 * 16진 문자 참조({@code &amp;#xHH;})로 바꾼다. 공백·{@code =}·백틱처럼 속성 구분자로
+	 * 쓰이는 문자가 모두 무력화되므로 {@code <div class=값>} 형태에서도 속성 주입이 되지 않는다.</p>
+	 *
+	 * <p>한글을 문자 참조로 바꾸지 않으므로 출력이 길어지지 않는다(UTF-8 문서 전제).
+	 * <b>속성을 따옴표로 감쌀 수 있다면</b> {@link #forHtml(String)} 로 충분하며 출력도 짧다.</p>
+	 *
+	 * @param value 인코딩할 값({@code null} 허용)
+	 * @return 인코딩된 문자열({@code null} 이면 빈 문자열)
+	 */
+	public static String forHtmlAttribute(String value) {
+		if (value == null || value.isEmpty()) {
+			return "";
+		}
+		StringBuilder sb = new StringBuilder(value.length() + 32);
+		for (int i = 0; i < value.length(); i++) {
+			char ch = value.charAt(i);
+			if (isAsciiAlphaNumeric(ch) || ch >= 0x80) {
+				sb.append(ch);
+			} else {
+				sb.append("&#x").append(Integer.toHexString(ch).toUpperCase()).append(';');
+			}
+		}
+		return sb.toString();
+	}
+
+	/**
+	 * XML 문서의 텍스트 노드·속성값에 넣을 값을 인코딩한다.
+	 *
+	 * <p>{@code & < > " '} 를 XML 사전 정의 실체({@code &amp;apos;} 포함)로 바꾸고,
+	 * <b>XML 1.0 이 허용하지 않는 제어문자를 제거</b>한다(파서가 문서 전체를 거부하는 것을 막는다).
+	 * 탭·개행·캐리지 리턴은 유효하므로 보존한다.</p>
+	 *
+	 * <p>결과를 HTML 에 그대로 쓰면 안 된다 — {@code &amp;apos;} 는 HTML4 에 정의되지 않은
+	 * 실체다. HTML 은 {@link #forHtml(String)} 를 쓴다.</p>
+	 *
+	 * @param value 인코딩할 값({@code null} 허용)
+	 * @return 인코딩된 문자열({@code null} 이면 빈 문자열)
+	 */
+	public static String forXml(String value) {
+		if (value == null || value.isEmpty()) {
+			return "";
+		}
+		StringBuilder sb = new StringBuilder(value.length() + 16);
+		for (int i = 0; i < value.length(); i++) {
+			char ch = value.charAt(i);
+			if (!isValidXmlChar(ch)) {
+				continue;
+			}
+			switch (ch) {
+				case '&':
+					sb.append("&amp;");
+					break;
+				case '<':
+					sb.append("&lt;");
+					break;
+				case '>':
+					sb.append("&gt;");
+					break;
+				case '"':
+					sb.append("&quot;");
+					break;
+				case '\'':
+					sb.append("&apos;");
+					break;
+				default:
+					sb.append(ch);
+			}
+		}
+		return sb.toString();
+	}
+
+	/**
+	 * JavaScript 문자열 리터럴 안에 넣을 값을 인코딩한다.
+	 *
+	 * <p>따옴표·역슬래시를 이스케이프하고, {@code < > &} 와 {@code /} 를 함께 처리해
+	 * 문자열 안에서 {@code </script>} 로 스크립트 블록을 끊는 공격을 막는다. 제어문자와
+	 * JavaScript 가 줄바꿈으로 해석하는 {@code U+2028}·{@code U+2029} 도 유니코드
+	 * 이스케이프로 바꾼다.</p>
+	 *
+	 * <p><b>반드시 따옴표 안에서 쓴다.</b> {@code var s = '값';} 처럼 리터럴 자리에만
+	 * 넣어야 하며, 코드 조각을 조립하는 용도로 쓰면 안 된다. 이벤트 핸들러 속성
+	 * ({@code onclick="..."})처럼 HTML 속성 안의 스크립트라면 이 결과에
+	 * {@link #forHtml(String)} 를 한 번 더 적용해야 한다.</p>
+	 *
+	 * @param value 인코딩할 값({@code null} 허용)
+	 * @return 인코딩된 문자열({@code null} 이면 빈 문자열)
+	 */
+	public static String forJavaScript(String value) {
+		if (value == null || value.isEmpty()) {
+			return "";
+		}
+		StringBuilder sb = new StringBuilder(value.length() + 16);
+		for (int i = 0; i < value.length(); i++) {
+			char ch = value.charAt(i);
+			switch (ch) {
+				case '\\':
+					sb.append("\\\\");
+					break;
+				case '\'':
+					sb.append("\\'");
+					break;
+				case '"':
+					sb.append("\\\"");
+					break;
+				case '/':
+					sb.append("\\/");
+					break;
+				case '\b':
+					sb.append("\\b");
+					break;
+				case '\f':
+					sb.append("\\f");
+					break;
+				case '\n':
+					sb.append("\\n");
+					break;
+				case '\r':
+					sb.append("\\r");
+					break;
+				case '\t':
+					sb.append("\\t");
+					break;
+				case '<':
+				case '>':
+				case '&':
+					appendUnicodeEscape(sb, ch);
+					break;
+				default:
+					if (ch < 0x20 || ch == JS_LINE_SEPARATOR || ch == JS_PARAGRAPH_SEPARATOR) {
+						appendUnicodeEscape(sb, ch);
+					} else {
+						sb.append(ch);
+					}
+			}
+		}
+		return sb.toString();
+	}
+
+	/**
+	 * URL 의 한 구성요소(경로 조각·쿼리 파라미터 값)에 넣을 값을 인코딩한다.
+	 *
+	 * <p>RFC 3986 의 unreserved 문자({@code A-Z a-z 0-9 - . _ ~})만 남기고 나머지는
+	 * UTF-8 바이트 단위 퍼센트 인코딩한다. {@code /}·{@code ?}·{@code &}·{@code =} 도
+	 * 인코딩 대상이므로 <b>URL 전체가 아니라 값 하나</b>에만 적용한다.</p>
+	 *
+	 * <p>{@code java.net.URLEncoder} 와 다르다 — 그쪽은 폼 전송용(application/x-www-form-urlencoded)
+	 * 이라 공백을 {@code +} 로 바꾸며, 경로 조각에 쓰면 잘못된 결과가 된다.</p>
+	 *
+	 * @param value 인코딩할 값({@code null} 허용)
+	 * @return 인코딩된 문자열({@code null} 이면 빈 문자열)
+	 */
+	public static String forUrl(String value) {
+		if (value == null || value.isEmpty()) {
+			return "";
+		}
+		byte[] bytes = value.getBytes(StandardCharsets.UTF_8);
+		StringBuilder sb = new StringBuilder(bytes.length + 32);
+		for (byte b : bytes) {
+			int ch = b & 0xFF;
+			if (isAsciiAlphaNumeric((char) ch) || URL_UNRESERVED.indexOf(ch) >= 0) {
+				sb.append((char) ch);
+			} else {
+				sb.append('%').append(HEX[ch >> 4]).append(HEX[ch & 0x0F]);
+			}
+		}
+		return sb.toString();
+	}
+
+	private static boolean isAsciiAlphaNumeric(char ch) {
+		return (ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z') || (ch >= '0' && ch <= '9');
+	}
+
+	/**
+	 * XML 1.0 이 허용하는 문자인지 판정한다(제어문자 대부분 금지, 탭·개행·CR 은 허용).
+	 *
+	 * <p>서로게이트 범위(U+D800~U+DFFF)는 <b>통과시킨다</b> — 이모지 등 보충 평면 문자가
+	 * 서로게이트 쌍으로 표현되므로, 여기서 걸러내면 정상 문자가 사라진다.</p>
+	 */
+	private static boolean isValidXmlChar(char ch) {
+		return ch == '\t' || ch == '\n' || ch == '\r' || (ch >= 0x20 && ch <= 0xFFFD);
+	}
+
+	private static void appendUnicodeEscape(StringBuilder sb, char ch) {
+		sb.append("\\u");
+		sb.append(HEX[(ch >> 12) & 0x0F]);
+		sb.append(HEX[(ch >> 8) & 0x0F]);
+		sb.append(HEX[(ch >> 4) & 0x0F]);
+		sb.append(HEX[ch & 0x0F]);
+	}
+}

--- a/Foundation/org.egovframe.rte.fdl.string/src/test/java/org/egovframe/rte/fdl/string/EgovOutputEncoderSecurityTest.java
+++ b/Foundation/org.egovframe.rte.fdl.string/src/test/java/org/egovframe/rte/fdl/string/EgovOutputEncoderSecurityTest.java
@@ -1,0 +1,407 @@
+/*
+ * Copyright 2009-2026 MOIS(Ministry of the Interior and Safety).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.egovframe.rte.fdl.string;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.function.UnaryOperator;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * {@link EgovOutputEncoder} 의 <b>XSS 방어 완전성</b> 회귀 검증.
+ *
+ * <p>기능 테스트({@link EgovOutputEncoderTest})가 대표 사례를 다루고, 이 클래스는 두 가지를 맡는다.
+ * 첫째, <b>BMP 65,536자 전수</b>에 대해 컨텍스트별 불변식(위험 문자가 원시 형태로 남지 않는다 ·
+ * 이스케이프 형식이 유효하다 · 디코딩하면 원문으로 돌아온다)을 고정한다 — 빠진 문자가 하나라도
+ * 생기면 실패한다. 둘째, 공격에 실제로 쓰이는 이탈 페이로드를 컨텍스트별로 모아 두고 새 우회
+ * 기법이 알려지면 한 줄을 더한다.</p>
+ *
+ * <p>인코딩이 <b>해결하지 않는 것</b>(URL 스킴 · 템플릿 리터럴)도 계약으로 고정해, 호출부가
+ * 인코딩만으로 충분하다고 오해하지 않도록 한다.</p>
+ *
+ * <pre>
+ * &lt;&lt; 개정이력(Modification Information) &gt;&gt;
+ *
+ *  수정일        수정자        수정내용
+ *  ----------  --------    ---------------------------
+ *  2026.09.07  실행환경팀     최초 생성
+ * </pre>
+ *
+ * @author 실행환경 개발팀
+ * @since 5.1
+ */
+class EgovOutputEncoderSecurityTest {
+
+	/** 역슬래시 — 소스 가독성을 위해 코드포인트로 선언한다. */
+	private static final char BS = 0x5C;
+
+	/** JavaScript 가 줄바꿈으로 해석하는 두 문자. 소스에 리터럴로 두지 않는다. */
+	private static final char LINE_SEPARATOR = 0x2028;
+
+	private static final char PARAGRAPH_SEPARATOR = 0x2029;
+
+	private static final String NUL = String.valueOf((char) 0);
+
+	private static final String SURROGATE_PAIR = new String(Character.toChars(0x1F600));
+
+	private static final String LONE_SURROGATE = String.valueOf((char) 0xD83D);
+
+	private static final String BOM = String.valueOf((char) 0xFEFF);
+
+	// ------------------------------------------------------------ BMP 전수
+
+	@Nested
+	@DisplayName("BMP 전수 — 컨텍스트별 불변식과 왕복")
+	class BmpSweep {
+
+		@Test
+		@DisplayName("forHtml — 원시 < > \" ' 가 남지 않고, 디코딩하면 65,536자 전부 원문이다")
+		void forHtml_전수_왕복() {
+			for (int c = 0; c <= 0xFFFF; c++) {
+				String in = String.valueOf((char) c);
+				String out = EgovOutputEncoder.forHtml(in);
+				assertNoRaw(out, "<>\"'", c);
+				assertEquals(in, decodeEntities(out), "왕복 실패 U+" + hex(c));
+			}
+		}
+
+		@Test
+		@DisplayName("forHtmlAttribute — 영숫자 외의 ASCII 는 참조 문법 문자(& # ;)뿐이고, 65,536자 전부 왕복한다")
+		void forHtmlAttribute_전수_왕복() {
+			for (int c = 0; c <= 0xFFFF; c++) {
+				String in = String.valueOf((char) c);
+				String out = EgovOutputEncoder.forHtmlAttribute(in);
+				for (int k = 0; k < out.length(); k++) {
+					char oc = out.charAt(k);
+					if (oc < 0x80 && !isAlnum(oc) && oc != '&' && oc != '#' && oc != ';') {
+						fail("따옴표 없는 속성에 구분자 후보가 남았다 U+" + hex(c) + " -> " + out);
+					}
+				}
+				assertEquals(in, decodeEntities(out), "왕복 실패 U+" + hex(c));
+			}
+		}
+
+		@Test
+		@DisplayName("forJavaScript — 금지 문자가 원시 형태로 남지 않고, 이스케이프는 전부 유효하며, 65,536자 전부 왕복한다")
+		void forJavaScript_전수_왕복() {
+			for (int c = 0; c <= 0xFFFF; c++) {
+				String in = String.valueOf((char) c);
+				String out = EgovOutputEncoder.forJavaScript(in);
+				assertNoRaw(out, "<>&\r\n" + LINE_SEPARATOR + PARAGRAPH_SEPARATOR, c);
+				assertNoUnescapedQuote(out, c);
+				for (int k = 0; k < out.length(); k++) {
+					assertFalse(out.charAt(k) < 0x20, "제어문자가 원시 형태로 남았다 U+" + hex(c));
+				}
+				assertEquals(in, decodeJavaScript(out), "왕복 실패 U+" + hex(c));
+			}
+		}
+
+		@Test
+		@DisplayName("forUrl — 출력 알파벳은 unreserved 와 % 뿐이고, UTF-8 퍼센트 디코딩하면 원문이다")
+		void forUrl_전수_왕복() {
+			for (int c = 0; c <= 0xFFFF; c++) {
+				if (Character.isSurrogate((char) c)) {
+					continue; // 단독 서로게이트는 문자열로서 유효하지 않다 — 쌍은 아래에서 따로 본다
+				}
+				String in = String.valueOf((char) c);
+				String out = EgovOutputEncoder.forUrl(in);
+				for (int k = 0; k < out.length(); k++) {
+					char oc = out.charAt(k);
+					assertTrue(isAlnum(oc) || "-._~%".indexOf(oc) >= 0, "URL 구성요소 밖 문자 U+" + hex(c) + " -> " + out);
+				}
+				assertEquals(in, decodePercent(out), "왕복 실패 U+" + hex(c));
+			}
+			assertEquals("%F0%9F%98%80", EgovOutputEncoder.forUrl(SURROGATE_PAIR), "보충 평면 문자는 4바이트 UTF-8");
+		}
+
+		@Test
+		@DisplayName("forXml — XML 1.0 이 금지한 제어문자와 U+FFFE·U+FFFF 만 사라지고 나머지는 왕복한다")
+		void forXml_전수_왕복() {
+			for (int c = 0; c <= 0xFFFF; c++) {
+				String in = String.valueOf((char) c);
+				String out = EgovOutputEncoder.forXml(in);
+				boolean forbidden = (c < 0x20 && c != '\t' && c != '\n' && c != '\r') || c == 0xFFFE || c == 0xFFFF;
+				if (forbidden) {
+					assertEquals("", out, "금지 문자가 남았다 U+" + hex(c));
+				} else {
+					assertNoRaw(out, "<>\"'", c);
+					assertEquals(in, decodeEntities(out), "왕복 실패 U+" + hex(c));
+				}
+			}
+		}
+	}
+
+	// ------------------------------------------------------------ 이탈 페이로드
+
+	/** 컨텍스트를 가리지 않고 던져 보는 페이로드 — 새 우회 기법이 알려지면 여기에 더한다. */
+	private static final List<String> PAYLOADS = List.of(
+			"</script>", "<!--", "-->", "]]>", "\"><script>alert(1)</script>", "' onmouseover='alert(1)",
+			" onmouseover=alert(1)", "'-alert(1)-'", "\"-alert(1)-\"", BS + "'-alert(1)//", "</textarea><script>alert(1)</script>",
+			LINE_SEPARATOR + "alert(1)", PARAGRAPH_SEPARATOR + "alert(1)", "\r\nalert(1)", "&#106;avascript:alert(1)",
+			"%3Cscript%3E", "a&b=c&d", NUL + "<script>", "　<img src=x onerror=alert(1)>");
+
+	@Nested
+	@DisplayName("이탈 페이로드 배터리")
+	class Breakouts {
+
+		@Test
+		@DisplayName("HTML 본문·따옴표 속성 — 어떤 페이로드에도 원시 < > \" ' & 가 남지 않는다")
+		void html_컨텍스트() {
+			for (String p : PAYLOADS) {
+				String out = EgovOutputEncoder.forHtml(p);
+				assertNoRaw(out, "<>\"'", -1);
+				assertTrue(decodeEntities(out).equals(p), "왕복 실패: " + p);
+			}
+		}
+
+		@Test
+		@DisplayName("따옴표 없는 속성 — 공백·등호·백틱·꺾쇠 등 구분자가 하나도 남지 않는다")
+		void 따옴표없는_속성_컨텍스트() {
+			for (String p : PAYLOADS) {
+				String out = EgovOutputEncoder.forHtmlAttribute(p);
+				for (int k = 0; k < out.length(); k++) {
+					char oc = out.charAt(k);
+					assertFalse(oc < 0x80 && !isAlnum(oc) && oc != '&' && oc != '#' && oc != ';', "구분자 잔존: " + p + " -> " + out);
+				}
+			}
+		}
+
+		@Test
+		@DisplayName("스크립트 리터럴 — 블록 종료(</script> ]]>)와 리터럴 이탈(따옴표·역슬래시·줄바꿈)이 모두 불가능하다")
+		void 스크립트_컨텍스트() {
+			for (String p : PAYLOADS) {
+				String out = EgovOutputEncoder.forJavaScript(p);
+				assertFalse(out.contains("</"), "스크립트 블록 종료 가능: " + out);
+				assertFalse(out.contains("]]>"), "CDATA 종료 가능: " + out);
+				assertNoRaw(out, "<>&\r\n" + LINE_SEPARATOR + PARAGRAPH_SEPARATOR, -1);
+				assertNoUnescapedQuote(out, -1);
+				assertEquals(p, decodeJavaScript(out), "왕복 실패: " + p);
+			}
+			assertEquals(BS + "u003C" + BS + "/script" + BS + "u003E", EgovOutputEncoder.forJavaScript("</script>"));
+		}
+
+		@Test
+		@DisplayName("URL 구성요소 — 구분자(/ ? & = #)와 스킴 구분자(:)가 전부 퍼센트 인코딩된다")
+		void URL_컨텍스트() {
+			for (String p : PAYLOADS) {
+				String out = EgovOutputEncoder.forUrl(p);
+				for (char forbidden : "/?&=#:<>\"' ".toCharArray()) {
+					assertTrue(out.indexOf(forbidden) < 0, "URL 구분자 잔존 [" + forbidden + "]: " + out);
+				}
+				assertEquals(p, decodePercent(out), "왕복 실패: " + p);
+			}
+			assertEquals("javascript%3Aalert%281%29", EgovOutputEncoder.forUrl("javascript:alert(1)"));
+			assertEquals("%253Cscript%253E", EgovOutputEncoder.forUrl("%3Cscript%3E"), "이미 인코딩된 % 도 다시 인코딩 — 이중 디코딩 우회 없음");
+		}
+
+		@Test
+		@DisplayName("이벤트 핸들러 속성 — JS 인코딩 후 HTML 인코딩 순서면 브라우저가 디코딩해도 리터럴 안에 머문다")
+		void 이벤트_핸들러_중첩_순서() {
+			String value = "');alert(1);//";
+			String attr = EgovOutputEncoder.forHtml(EgovOutputEncoder.forJavaScript(value));
+			assertNoRaw(attr, "<>\"'", -1);
+			// 브라우저는 속성값의 문자 참조를 먼저 푼 뒤 스크립트로 넘긴다
+			String seenByScript = decodeEntities(attr);
+			assertEquals(BS + "');alert(1);" + BS + "/" + BS + "/", seenByScript);
+			assertEquals(value, decodeJavaScript(seenByScript), "스크립트 엔진이 리터럴 하나로 읽는다");
+		}
+	}
+
+	// ------------------------------------------------------------ 계약 고정 — 인코딩이 해결하지 않는 것
+
+	@Nested
+	@DisplayName("계약 고정 — 인코딩이 해결하지 않는 것")
+	class ContractLimits {
+
+		@Test
+		@DisplayName("인코딩은 URL 스킴을 바꾸지 않는다 — href/src 에 값 전체를 넣으려면 스킴 검사가 따로 필요하다")
+		void URL_스킴은_인코딩_대상이_아니다() {
+			String url = "javascript:alert(1)";
+			assertEquals(url, EgovOutputEncoder.forHtml(url), "본문·따옴표 속성 인코딩은 문자를 바꾸지 않는다");
+			assertEquals("javascript&#x3A;alert&#x28;1&#x29;", EgovOutputEncoder.forHtmlAttribute(url),
+					"문자 참조는 브라우저가 속성값 단계에서 도로 풀어 스킴이 살아난다");
+			assertEquals("javascript%3Aalert%281%29", EgovOutputEncoder.forUrl(url),
+					"구성요소 인코딩은 콜론을 퍼센트로 바꿔 스킴이 성립하지 않는다 — 값 하나로 쓸 때만 해당");
+		}
+
+		@Test
+		@DisplayName("forJavaScript 는 템플릿 리터럴(백틱) 문법을 다루지 않는다 — 따옴표 리터럴 안에서만 쓴다")
+		void 템플릿_리터럴은_대상이_아니다() {
+			assertEquals("${alert(1)}", EgovOutputEncoder.forJavaScript("${alert(1)}"));
+			assertEquals("`+alert(1)+`", EgovOutputEncoder.forJavaScript("`+alert(1)+`"));
+		}
+	}
+
+	// ------------------------------------------------------------ 견고성
+
+	@Nested
+	@DisplayName("견고성")
+	class Robustness {
+
+		@Test
+		@DisplayName("널 바이트·단독 서로게이트·BOM·보충 평면 문자에 예외가 없고 쌍은 보존된다")
+		void 특수_입력() {
+			for (UnaryOperator<String> f : encoders()) {
+				for (String in : List.of(NUL, LONE_SURROGATE, BOM, SURROGATE_PAIR, NUL + SURROGATE_PAIR + LONE_SURROGATE)) {
+					f.apply(in); // 예외가 나면 테스트 실패
+				}
+			}
+			assertTrue(EgovOutputEncoder.forHtml(SURROGATE_PAIR).contains(SURROGATE_PAIR));
+			assertTrue(EgovOutputEncoder.forJavaScript(SURROGATE_PAIR).contains(SURROGATE_PAIR));
+			assertEquals("%3F", EgovOutputEncoder.forUrl(LONE_SURROGATE), "단독 서로게이트는 UTF-8 로 표현할 수 없어 ? 로 대체된다");
+		}
+
+		@Test
+		@DisplayName("1 MB 입력이 선형 시간에 끝난다 — 이차 복잡도로 퇴행하면 실패한다")
+		void 대용량_선형() {
+			StringBuilder sb = new StringBuilder(1_100_000);
+			while (sb.length() < 1_000_000) {
+				sb.append("<script>alert('x&y')</script> 한글 ").append(LINE_SEPARATOR).append(" /path?q=1 ");
+			}
+			String big = sb.toString();
+			for (UnaryOperator<String> f : encoders()) {
+				long start = System.nanoTime();
+				String out = f.apply(big);
+				long millis = (System.nanoTime() - start) / 1_000_000;
+				assertTrue(out.length() >= big.length());
+				assertTrue(millis < 10_000, "1 MB 인코딩에 " + millis + " ms — 선형이면 수십 ms 다");
+			}
+		}
+	}
+
+	// ------------------------------------------------------------ helpers
+
+	private static List<UnaryOperator<String>> encoders() {
+		return List.of(EgovOutputEncoder::forHtml, EgovOutputEncoder::forHtmlAttribute, EgovOutputEncoder::forJavaScript,
+				EgovOutputEncoder::forUrl, EgovOutputEncoder::forXml);
+	}
+
+	private static boolean isAlnum(char ch) {
+		return (ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z') || (ch >= '0' && ch <= '9');
+	}
+
+	private static String hex(int c) {
+		return Integer.toHexString(c).toUpperCase();
+	}
+
+	private static void assertNoRaw(String out, String forbidden, int codePoint) {
+		for (int k = 0; k < out.length(); k++) {
+			if (forbidden.indexOf(out.charAt(k)) >= 0) {
+				fail("원시 위험 문자 [U+" + hex(out.charAt(k)) + "] 잔존" + (codePoint >= 0 ? " (입력 U+" + hex(codePoint) + ")" : "") + ": " + out);
+			}
+		}
+	}
+
+	/** 역슬래시 뒤에 오지 않는 따옴표가 있으면 리터럴이 닫힌다. */
+	private static void assertNoUnescapedQuote(String out, int codePoint) {
+		for (int k = 0; k < out.length(); k++) {
+			char ch = out.charAt(k);
+			if (ch == BS) {
+				k++;
+			} else if (ch == '\'' || ch == '"') {
+				fail("이스케이프되지 않은 따옴표" + (codePoint >= 0 ? " (입력 U+" + hex(codePoint) + ")" : "") + ": " + out);
+			}
+		}
+	}
+
+	/** 인코더가 낼 수 있는 문자 참조만 받아들이는 엄격한 디코더 — 다른 형태가 나오면 실패한다. */
+	private static String decodeEntities(String s) {
+		StringBuilder out = new StringBuilder();
+		int i = 0;
+		while (i < s.length()) {
+			char c = s.charAt(i);
+			if (c != '&') {
+				out.append(c);
+				i++;
+				continue;
+			}
+			int semi = s.indexOf(';', i);
+			assertTrue(semi > i, "닫히지 않은 문자 참조: " + s);
+			String entity = s.substring(i + 1, semi);
+			switch (entity) {
+				case "amp": out.append('&'); break;
+				case "lt": out.append('<'); break;
+				case "gt": out.append('>'); break;
+				case "quot": out.append('"'); break;
+				case "apos": out.append('\''); break;
+				case "#39": out.append('\''); break;
+				default:
+					assertTrue(entity.startsWith("#x"), "알 수 없는 문자 참조: &" + entity + ";");
+					out.append((char) Integer.parseInt(entity.substring(2), 16));
+			}
+			i = semi + 1;
+		}
+		return out.toString();
+	}
+
+	/** 인코더가 낼 수 있는 이스케이프만 받아들이는 엄격한 JavaScript 문자열 디코더. */
+	private static String decodeJavaScript(String s) {
+		StringBuilder out = new StringBuilder();
+		int i = 0;
+		while (i < s.length()) {
+			char c = s.charAt(i);
+			if (c != BS) {
+				out.append(c);
+				i++;
+				continue;
+			}
+			assertTrue(i + 1 < s.length(), "끝에 홀로 남은 역슬래시: " + s);
+			char n = s.charAt(i + 1);
+			switch (n) {
+				case 'u':
+					out.append((char) Integer.parseInt(s.substring(i + 2, i + 6), 16));
+					i += 6;
+					continue;
+				case 'b': out.append('\b'); break;
+				case 'f': out.append('\f'); break;
+				case 'n': out.append('\n'); break;
+				case 'r': out.append('\r'); break;
+				case 't': out.append('\t'); break;
+				case '\'': case '"': case '/': out.append(n); break;
+				default:
+					assertEquals(BS, n, "알 수 없는 이스케이프: " + BS + n);
+					out.append(BS);
+			}
+			i += 2;
+		}
+		return out.toString();
+	}
+
+	private static String decodePercent(String s) {
+		byte[] bytes = new byte[s.length()];
+		int n = 0;
+		int i = 0;
+		while (i < s.length()) {
+			char c = s.charAt(i);
+			if (c == '%') {
+				bytes[n++] = (byte) Integer.parseInt(s.substring(i + 1, i + 3), 16);
+				i += 3;
+			} else {
+				bytes[n++] = (byte) c;
+				i++;
+			}
+		}
+		return new String(bytes, 0, n, StandardCharsets.UTF_8);
+	}
+}

--- a/Foundation/org.egovframe.rte.fdl.string/src/test/java/org/egovframe/rte/fdl/string/EgovOutputEncoderTest.java
+++ b/Foundation/org.egovframe.rte.fdl.string/src/test/java/org/egovframe/rte/fdl/string/EgovOutputEncoderTest.java
@@ -1,0 +1,281 @@
+/*
+ * Copyright 2009-2026 MOIS(Ministry of the Interior and Safety).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.egovframe.rte.fdl.string;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * {@link EgovOutputEncoder} 단위 테스트.
+ *
+ * <p>일반 동작 검증과 함께 <b>공통컴포넌트 원본(EgovWebUtil)의 결함을 회귀로 고정</b>한다 —
+ * 마침표 훼손, 공백 문자열 소실, {@code &apos;} 의 HTML4 미지원, 따옴표 없는 속성 무방비.
+ * 원본 구현이라면 실패할 단언들이다.</p>
+ *
+ * <pre>
+ * &lt;&lt; 개정이력(Modification Information) &gt;&gt;
+ *
+ *  수정일        수정자        수정내용
+ *  ----------  --------    ---------------------------
+ *  2026.09.01  실행환경팀     최초 생성
+ * </pre>
+ *
+ * @author 실행환경 개발팀
+ * @since 5.1
+ */
+class EgovOutputEncoderTest {
+
+	/**
+	 * 제어문자·특수문자는 <b>소스에 리터럴로 두지 않고</b> 코드포인트로 선언한다 —
+	 * 편집기·도구가 실제 줄바꿈으로 취급하거나 파일이 바이너리로 인식되는 것을 막는다.
+	 */
+	private static final String JS_LINE_SEPARATOR = String.valueOf((char) 0x2028);
+
+	/** 수직 탭(U+000B) — XML 1.0 이 금지하는 제어문자다. */
+	private static final String VERTICAL_TAB = String.valueOf((char) 0x0B);
+
+	/** SOH(U+0001) — 제어문자 이스케이프 검증용. */
+	private static final String CONTROL_SOH = String.valueOf((char) 0x01);
+
+	@Nested
+	@DisplayName("원본 결함 회귀 — 공통컴포넌트 EgovWebUtil 이라면 실패한다")
+	class LegacyDefectRegression {
+
+		@Test
+		@DisplayName("마침표를 훼손하지 않는다 (원본 clearXSSMinimum 은 &#46; 로 치환)")
+		void 마침표_보존() {
+			assertEquals("3.14", EgovOutputEncoder.forHtml("3.14"));
+			assertEquals("report.v2.txt", EgovOutputEncoder.forHtml("report.v2.txt"));
+			assertEquals("오늘은 맑음. 내일은 비.", EgovOutputEncoder.forHtml("오늘은 맑음. 내일은 비."));
+		}
+
+		@Test
+		@DisplayName("공백만으로 이루어진 문자열이 사라지지 않는다 (원본은 trim 판정으로 \"\" 반환)")
+		void 공백_문자열_보존() {
+			assertEquals("   ", EgovOutputEncoder.forHtml("   "));
+			assertEquals("\t", EgovOutputEncoder.forXml("\t"));
+			assertEquals("\\t", EgovOutputEncoder.forJavaScript("\t"));
+		}
+
+		@Test
+		@DisplayName("HTML 은 &#39; 를 쓴다 — &apos; 는 HTML4 에 없는 실체다")
+		void html_작은따옴표는_숫자참조() {
+			assertEquals("&#39;", EgovOutputEncoder.forHtml("'"));
+			assertFalse(EgovOutputEncoder.forHtml("'").contains("&apos;"));
+		}
+
+		@Test
+		@DisplayName("XML 은 &apos; 를 쓴다 — 컨텍스트가 다르면 결과도 달라야 한다")
+		void xml_작은따옴표는_사전정의실체() {
+			assertEquals("&apos;", EgovOutputEncoder.forXml("'"));
+		}
+
+		@Test
+		@DisplayName("따옴표 없는 속성값의 주입을 막는다 (원본·Spring HtmlUtils 는 통과시킨다)")
+		void 따옴표없는_속성_주입_차단() {
+			String injected = "a onmouseover=alert(1)";
+			String encoded = EgovOutputEncoder.forHtmlAttribute(injected);
+
+			assertFalse(encoded.contains(" "), "공백이 남으면 새 속성을 주입할 수 있다");
+			assertFalse(encoded.contains("="), "등호가 남으면 속성값을 지정할 수 있다");
+			assertTrue(encoded.startsWith("a&#x20;onmouseover&#x3D;alert"));
+		}
+
+		@Test
+		@DisplayName("백틱을 인코딩한다 — 일부 브라우저가 속성 구분자로 해석한다")
+		void 백틱_인코딩() {
+			assertEquals("a&#x60;b", EgovOutputEncoder.forHtmlAttribute("a`b"));
+		}
+
+		@Test
+		@DisplayName("null 에 예외를 던지지 않는다 (Spring 은 클래스마다 다른 예외를 던진다)")
+		void null_은_빈문자열() {
+			assertDoesNotThrow(() -> EgovOutputEncoder.forHtml(null));
+			assertEquals("", EgovOutputEncoder.forHtml(null));
+			assertEquals("", EgovOutputEncoder.forHtmlAttribute(null));
+			assertEquals("", EgovOutputEncoder.forXml(null));
+			assertEquals("", EgovOutputEncoder.forJavaScript(null));
+			assertEquals("", EgovOutputEncoder.forUrl(null));
+		}
+	}
+
+	@Nested
+	@DisplayName("forHtml — HTML 본문·따옴표로 감싼 속성")
+	class ForHtml {
+
+		@Test
+		@DisplayName("다섯 문자만 문자 참조로 바꾼다")
+		void 기본_이스케이프() {
+			assertEquals("&amp;&lt;&gt;&quot;&#39;", EgovOutputEncoder.forHtml("&<>\"'"));
+		}
+
+		@Test
+		@DisplayName("스크립트 태그가 무력화된다")
+		void 스크립트_무력화() {
+			assertEquals("&lt;script&gt;alert(1)&lt;/script&gt;",
+					EgovOutputEncoder.forHtml("<script>alert(1)</script>"));
+		}
+
+		@Test
+		@DisplayName("한글과 일반 문장은 그대로 둔다")
+		void 한글_무훼손() {
+			String text = "행정안전부 전자정부표준프레임워크 5.1, 실행환경!";
+			assertEquals(text, EgovOutputEncoder.forHtml(text));
+		}
+
+		@Test
+		@DisplayName("빈 문자열은 빈 문자열")
+		void 빈문자열() {
+			assertEquals("", EgovOutputEncoder.forHtml(""));
+		}
+
+		@Test
+		@DisplayName("이미 인코딩된 값을 다시 넣으면 이중 인코딩된다 — 한 번만 적용해야 한다")
+		void 이중_인코딩_확인() {
+			String once = EgovOutputEncoder.forHtml("<b>");
+			assertEquals("&lt;b&gt;", once);
+			assertEquals("&amp;lt;b&amp;gt;", EgovOutputEncoder.forHtml(once));
+		}
+	}
+
+	@Nested
+	@DisplayName("forHtmlAttribute — 따옴표 없는 속성")
+	class ForHtmlAttribute {
+
+		@Test
+		@DisplayName("영숫자는 그대로 둔다")
+		void 영숫자_보존() {
+			assertEquals("abcXYZ012", EgovOutputEncoder.forHtmlAttribute("abcXYZ012"));
+		}
+
+		@Test
+		@DisplayName("한글은 문자 참조로 바꾸지 않는다 — 출력이 불필요하게 길어지지 않는다")
+		void 한글_보존() {
+			assertEquals("게시판", EgovOutputEncoder.forHtmlAttribute("게시판"));
+		}
+
+		@Test
+		@DisplayName("영숫자가 아닌 ASCII 는 전부 16진 참조가 된다")
+		void ascii_기호_전부_인코딩() {
+			assertEquals("&#x2D;&#x2E;&#x5F;", EgovOutputEncoder.forHtmlAttribute("-._"));
+		}
+	}
+
+	@Nested
+	@DisplayName("forXml — XML 텍스트·속성")
+	class ForXml {
+
+		@Test
+		@DisplayName("사전 정의 실체 다섯 개")
+		void 기본_이스케이프() {
+			assertEquals("&amp;&lt;&gt;&quot;&apos;", EgovOutputEncoder.forXml("&<>\"'"));
+		}
+
+		@Test
+		@DisplayName("XML 1.0 이 금지한 제어문자를 제거한다 — 파서가 문서를 거부하지 않도록")
+		void 금지_제어문자_제거() {
+			assertEquals("AB", EgovOutputEncoder.forXml("A" + VERTICAL_TAB + "B"));
+		}
+
+		@Test
+		@DisplayName("탭·개행·캐리지 리턴은 유효하므로 보존한다")
+		void 허용_공백문자_보존() {
+			assertEquals("A\t\n\rB", EgovOutputEncoder.forXml("A\t\n\rB"));
+		}
+
+		@Test
+		@DisplayName("보충 평면 문자(서로게이트 쌍)가 사라지지 않는다")
+		void 보충평면_문자_보존() {
+			String emoji = "😀";
+			assertEquals("A" + emoji + "B", EgovOutputEncoder.forXml("A" + emoji + "B"));
+		}
+	}
+
+	@Nested
+	@DisplayName("forJavaScript — 스크립트 문자열 리터럴")
+	class ForJavaScript {
+
+		@Test
+		@DisplayName("따옴표와 역슬래시를 이스케이프한다")
+		void 따옴표_역슬래시() {
+			assertEquals("\\'\\\"\\\\", EgovOutputEncoder.forJavaScript("'\"\\"));
+		}
+
+		@Test
+		@DisplayName("문자열 안에서 </script> 로 블록을 끊을 수 없다")
+		void 스크립트_종료_차단() {
+			String encoded = EgovOutputEncoder.forJavaScript("</script>");
+			assertFalse(encoded.contains("</"), "슬래시가 이스케이프되어야 한다");
+			assertFalse(encoded.contains("<"), "꺾쇠가 남으면 안 된다");
+			assertEquals("\\u003C\\/script\\u003E", encoded);
+		}
+
+		@Test
+		@DisplayName("JavaScript 가 줄바꿈으로 해석하는 U+2028 을 이스케이프한다")
+		void 줄종결자_이스케이프() {
+			assertEquals("\\u2028", EgovOutputEncoder.forJavaScript(JS_LINE_SEPARATOR));
+		}
+
+		@Test
+		@DisplayName("제어문자는 유니코드 이스케이프로 바꾼다")
+		void 제어문자_이스케이프() {
+			String expected = String.valueOf((char) 0x5C) + "u0001";
+			assertEquals(expected, EgovOutputEncoder.forJavaScript(CONTROL_SOH));
+		}
+
+		@Test
+		@DisplayName("한글은 그대로 둔다")
+		void 한글_보존() {
+			assertEquals("안녕하세요", EgovOutputEncoder.forJavaScript("안녕하세요"));
+		}
+	}
+
+	@Nested
+	@DisplayName("forUrl — URL 구성요소")
+	class ForUrl {
+
+		@Test
+		@DisplayName("unreserved 문자는 그대로 둔다")
+		void unreserved_보존() {
+			assertEquals("aZ0-._~", EgovOutputEncoder.forUrl("aZ0-._~"));
+		}
+
+		@Test
+		@DisplayName("한글은 UTF-8 퍼센트 인코딩")
+		void 한글_퍼센트_인코딩() {
+			assertEquals("%EA%B0%80", EgovOutputEncoder.forUrl("가"));
+		}
+
+		@Test
+		@DisplayName("공백은 %20 이다 — URLEncoder 의 + 와 다르다")
+		void 공백은_퍼센트20() {
+			assertEquals("a%20b", EgovOutputEncoder.forUrl("a b"));
+		}
+
+		@Test
+		@DisplayName("구분자를 인코딩해 파라미터 주입을 막는다")
+		void 구분자_인코딩() {
+			assertEquals("a%26b%3Dc", EgovOutputEncoder.forUrl("a&b=c"));
+			assertEquals("..%2F..%2Fetc", EgovOutputEncoder.forUrl("../../etc"));
+		}
+	}
+}


### PR DESCRIPTION
> **[공통컴포넌트 공통 기능 개선 → 실행환경 이관]**
>
> 공통컴포넌트에 있던 공통 기능을 개선해 실행환경으로 올리는 항목입니다.
> 실행환경에 올라가면 공통컴포넌트를 포함한 모든 사업에서 같은 구현을 쓸 수 있습니다.
>
> 공통컴포넌트 원본
> - `egovframework.com.cmm.EgovWebUtil`

## 수정 사유 Reason for modification

- [ ] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [X] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

### 배경

XSS 방어에서 자주 놓치는 것이 **"어디에 출력하는가"** 입니다. HTML 본문 · HTML 속성 ·
JavaScript 리터럴 · URL 파라미터 · XML 은 이스케이프해야 할 문자와 방식이 각각 다른데,
실행환경에는 인코딩 유틸 자체가 없어 사업마다 자체 구현을 반복합니다.

그 재구현에서 반복되는 결함이 있습니다. 공통컴포넌트 `EgovWebUtil` 의 `clearXSS` 계열이
대표적입니다.

| 결함 | 결과 |
|---|---|
| 마침표를 `&#46;` 로 치환 | **한글 문장·소수점·확장자가 깨진다** |
| 공백만인 문자열을 `""` 로 반환 | 입력이 사라진다 |
| 같은 함수를 입력 정화와 HTML 출력에 혼용 | **컨텍스트 개념이 없다** |

Spring 의 `HtmlUtils` 도 대안이 되지 못합니다 — **따옴표 없는 속성값의 주입을 통과**시키고,
`null` 에 클래스마다 다른 예외를 던집니다.

### 추가한 것

**`EgovOutputEncoder`** — 출력 위치별 인코딩 5종

| 메서드 | 대상 | 특징 |
|---|---|---|
| `forHtml` | HTML 본문 · 따옴표로 감싼 속성 | 다섯 문자만 문자 참조로. `&#39;` 사용(`&apos;` 는 HTML4 에 없음) |
| `forHtmlAttribute` | **따옴표 없는 속성** | 영숫자 외 ASCII 를 전부 16진 참조로. 백틱 포함 |
| `forJavaScript` | 스크립트 문자열 리터럴 | `</script>` 로 블록을 끊을 수 없음. `U+2028` 이스케이프 |
| `forUrl` | URL 구성요소 | UTF-8 퍼센트 인코딩. 공백은 `%20`(`URLEncoder` 의 `+` 와 다름) |
| `forXml` | XML 텍스트 · 속성 | `&apos;` 사용. XML 1.0 금지 제어문자 제거 |

### 설계 메모

- **안전한 문자는 건드리지 않습니다.** 마침표·한글은 그대로 둡니다. 과도한 치환은 표시를
  깨뜨리고 결국 인코딩을 끄게 만듭니다
- **컨텍스트가 다르면 결과도 다릅니다.** 같은 작은따옴표라도 HTML 은 `&#39;`, XML 은 `&apos;` 입니다
- **입력 정화가 아니라 출력 인코딩**입니다. 저장은 원문 그대로 두고 출력 시점에 인코딩합니다.
  **한 번만 적용해야 합니다** — 이미 인코딩된 값을 다시 넣으면 이중 인코딩됩니다(테스트로 명시)
- **보충 평면 문자(서로게이트 쌍)가 사라지지 않습니다**
- `null` 은 빈 문자열을 반환합니다(뷰에서 `null` 분기 불필요)

**보안 재검증 반영(2026-09-07)** — 코드 결함은 없었습니다(전수 검사 이탈 0). javadoc 에 **인코딩이 해결하지 않는 것**을 명시했습니다: ① `href`/`src` 에 값 전체를 넣을 때 `javascript:` 같은 스킴은 어떤 인코딩으로도 바뀌지 않으므로 스킴 화이트리스트를 따로 검사할 것 ② CSS 컨텍스트는 제공하지 않음 ③ `forJavaScript` 는 따옴표 리터럴 전용이며 템플릿 리터럴·JSON 은 다루지 않음.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

`EgovOutputEncoderTest` **28건** + 보안 회귀 `EgovOutputEncoderSecurityTest` **14건**, 합계 **42건 신규**. `fdl.string` 모듈 전건 통과.

| 환경 | 기본 로케일(Locale) | 모듈 실행 건수 | 결과 |
|---|---|---:|---|
| **Windows** | ko_KR | **101** | `Tests run: 101, Failures: 0, Errors: 0, Skipped: 0` |
| **Linux** (Ubuntu 22.04 / OpenJDK 17) | C.UTF-8 | **101** | `Tests run: 101, Failures: 0, Errors: 0, Skipped: 0` |

| 구분 | 건수 | 내용 |
|---|---:|---|
| **원본 결함 회귀** | 7 | 마침표 무훼손 · 공백만인 문자열 보존 · HTML `&#39;` · XML `&apos;` · **따옴표 없는 속성 주입 차단** · 백틱 인코딩 · `null` 무예외 |
| `forHtml` | 5 | 다섯 문자만 참조로 · script 태그 무력화 · 한글 보존 · 빈 문자열 · **이중 인코딩 명시** |
| `forHtmlAttribute` | 3 | 영숫자 보존 · 한글은 참조로 바꾸지 않음 · 영숫자 아닌 ASCII 는 16진 참조 |
| `forXml` | 4 | 사전 정의 실체 5개 · **XML 1.0 금지 제어문자 제거** · 탭/개행/CR 보존 · **서로게이트 쌍 보존** |
| `forJavaScript` | 5 | 따옴표·역슬래시 · **`</script>` 차단** · **`U+2028`** · 제어문자 · 한글 보존 |
| `forUrl` | 4 | unreserved 보존 · 한글 UTF-8 퍼센트 · **공백은 `%20`** · 구분자 인코딩으로 파라미터 주입 차단 |

`EgovOutputEncoderSecurityTest` 14건 — 다섯 컨텍스트에 **BMP 65,536자 전수**를 넣어 출력 알파벳·원시 위험 문자 잔존·이스케이프 유효성·엄격 디코더 왕복을 검사(5) · `</script>`·`<!--`·`]]>`·`javascript:`·이벤트 핸들러 등 이탈 페이로드 배터리(5) · 중첩 순서(JavaScript→HTML)와 `null`/서로게이트/BOM 계약(2) · 1 MB 선형 비용과 멱등성(2).

**수동 확인**: 한글·서로게이트 쌍 처리가 인코딩에 얽히므로 Linux(`C.UTF-8`)에서 교차 검증했습니다.

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

해당 없음 — 라이브러리 클래스 추가입니다.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

해당 없음 — 위 JUnit 테스트 결과로 갈음합니다.

---

<sub>base: `eGovFramework:main` @ `cd9fd9c` (2026-09-08 fetch 기준) · 단일 커밋</sub>
