### PR TITLE
feat: 한글 조사 자동 선택 EgovKoreanParticles 추가

### DIFF
--- a/Foundation/org.egovframe.rte.fdl.string/src/main/java/org/egovframe/rte/fdl/string/EgovKoreanParticles.java
+++ b/Foundation/org.egovframe.rte.fdl.string/src/main/java/org/egovframe/rte/fdl/string/EgovKoreanParticles.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright 2009-2026 MOIS(Ministry of the Interior and Safety).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.egovframe.rte.fdl.string;
+
+/**
+ * 단어의 받침 유무에 맞는 한글 조사를 골라 주는 유틸 클래스.
+ *
+ * <p><b>NOTE:</b> 메시지 템플릿에서 "{이름}는" 처럼 조사를 고정하면 "홍길동는" 같은 어색한
+ * 문장이 된다. 마지막 글자의 종성 유무로 다섯 쌍의 조사를 고른다 —
+ * 은/는 · 이/가 · 을/를 · 과/와 · 으로/로.</p>
+ *
+ * <pre>
+ * EgovKoreanParticles.attach("홍길동", Particle.TOPIC)     → "홍길동은"
+ * EgovKoreanParticles.attach("나이", Particle.TOPIC)       → "나이는"
+ * EgovKoreanParticles.attach("서울", Particle.TO)          → "서울로"     (ㄹ 받침 특칙)
+ * EgovKoreanParticles.particleOf("책상", Particle.SUBJECT) → "이"        (조사만)
+ * </pre>
+ *
+ * <p><b>계약</b> — 한글 음절(가~힣)이 아닌 글자로 끝나는 단어(영문·숫자·기호)는 <b>받침이
+ * 없는 것으로 간주</b>한다("MOU가"·"3를"). 소리 나는 대로 판정하려면 발음 사전이 필요해
+ * 유틸의 범위를 벗어난다 — 그런 자리는 호출부가 조사를 직접 지정한다.</p>
+ *
+ * <pre>
+ * &lt;&lt; 개정이력(Modification Information) &gt;&gt;
+ *
+ *  수정일        수정자        수정내용
+ *  ----------  --------    ---------------------------
+ *  2026.09.01  실행환경팀     최초 생성 (공통컴포넌트 EgovStringUtil 조사 3종(2024.10)의
+ *                            종성 판정을 차용하되 재구성 — 원본은 "조사를 반환한다"는 이름
+ *                            (getSubjectParticle)과 달리 명사+조사 전체를 돌려줘 이름과 동작이
+ *                            어긋났고, 과/와·으로/로(ㄹ 받침 특칙)가 없었다. 코드 이식 아님)
+ * </pre>
+ *
+ * @author 실행환경 개발팀
+ * @since 5.1
+ */
+public final class EgovKoreanParticles {
+
+	/** 한글 음절 시작(가). */
+	private static final char HANGUL_BASE = 0xAC00;
+
+	/** 한글 음절 끝(힣). */
+	private static final char HANGUL_LAST = 0xD7A3;
+
+	/** 종성 개수 — 음절 코드값을 이 값으로 나눈 나머지가 0 이면 받침이 없다. */
+	private static final int FINAL_CONSONANT_COUNT = 28;
+
+	/** 종성 ㄹ 의 색인 — 으로/로 특칙에 쓴다. */
+	private static final int FINAL_RIEUL = 8;
+
+	private EgovKoreanParticles() {
+	}
+
+	/**
+	 * 단어에 맞는 조사를 붙여 돌려준다.
+	 *
+	 * @param word     단어({@code null} 이면 {@code null})
+	 * @param particle 조사 종류
+	 * @return 단어 + 조사({@code "홍길동은"})
+	 */
+	public static String attach(String word, Particle particle) {
+		if (word == null) {
+			return null;
+		}
+		requireParticle(particle);
+		return word + particle.select(word);
+	}
+
+	/**
+	 * 단어에 맞는 <b>조사만</b> 돌려준다 — 템플릿 엔진에서 조사 자리만 채울 때 쓴다.
+	 *
+	 * @param word     단어({@code null} 이면 받침 없는 쪽 조사)
+	 * @param particle 조사 종류
+	 * @return 조사({@code "은"} 또는 {@code "는"})
+	 */
+	public static String particleOf(String word, Particle particle) {
+		requireParticle(particle);
+		return particle.select(word);
+	}
+
+	/**
+	 * 단어가 받침으로 끝나는지 판정한다(한글 음절 밖의 글자는 받침 없음으로 간주).
+	 *
+	 * @param word 단어({@code null}·빈 문자열은 받침 없음)
+	 * @return 받침이 있으면 {@code true}
+	 */
+	public static boolean endsWithFinalConsonant(String word) {
+		return finalConsonantIndexOf(word) > 0;
+	}
+
+	/**
+	 * 마지막 글자의 종성 색인을 돌려준다(0 = 받침 없음, 한글 음절 밖 = 0).
+	 */
+	private static int finalConsonantIndexOf(String word) {
+		if (word == null || word.isEmpty()) {
+			return 0;
+		}
+		char last = word.charAt(word.length() - 1);
+		if (last < HANGUL_BASE || last > HANGUL_LAST) {
+			return 0;
+		}
+		return (last - HANGUL_BASE) % FINAL_CONSONANT_COUNT;
+	}
+
+	private static void requireParticle(Particle particle) {
+		if (particle == null) {
+			throw new IllegalArgumentException("particle must not be null");
+		}
+	}
+
+	/**
+	 * 조사 종류 — 받침 있음/없음 한 쌍씩.
+	 */
+	public enum Particle {
+
+		/** 보조사 은/는. */
+		TOPIC("은", "는"),
+
+		/** 주격 이/가. */
+		SUBJECT("이", "가"),
+
+		/** 목적격 을/를. */
+		OBJECT("을", "를"),
+
+		/** 접속 과/와. */
+		AND("과", "와"),
+
+		/**
+		 * 방향·수단 으로/로 — <b>ㄹ 받침은 "로"</b> 를 쓴다("서울로", "연필로").
+		 */
+		TO("으로", "로") {
+			@Override
+			String select(String word) {
+				int index = finalConsonantIndexOf(word);
+				return (index == 0 || index == FINAL_RIEUL) ? withoutFinal() : withFinal();
+			}
+		};
+
+		private final String withFinal;
+
+		private final String withoutFinal;
+
+		Particle(String withFinal, String withoutFinal) {
+			this.withFinal = withFinal;
+			this.withoutFinal = withoutFinal;
+		}
+
+		/** 받침 있는 단어에 붙는 쪽. */
+		String withFinal() {
+			return withFinal;
+		}
+
+		/** 받침 없는 단어에 붙는 쪽. */
+		String withoutFinal() {
+			return withoutFinal;
+		}
+
+		/** 단어에 맞는 쪽을 고른다. */
+		String select(String word) {
+			return endsWithFinalConsonant(word) ? withFinal : withoutFinal;
+		}
+	}
+}

--- a/Foundation/org.egovframe.rte.fdl.string/src/test/java/org/egovframe/rte/fdl/string/EgovKoreanParticlesTest.java
+++ b/Foundation/org.egovframe.rte.fdl.string/src/test/java/org/egovframe/rte/fdl/string/EgovKoreanParticlesTest.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2009-2026 MOIS(Ministry of the Interior and Safety).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.egovframe.rte.fdl.string;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.egovframe.rte.fdl.string.EgovKoreanParticles.Particle;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * {@link EgovKoreanParticles} 단위 테스트.
+ *
+ * <p><b>공통컴포넌트 원본(EgovStringUtil 조사 3종)의 이름-동작 불일치를 회귀로 고정</b>한다 —
+ * 원본 {@code getSubjectParticle} 은 "조사를 반환한다"는 이름과 달리 명사+조사 전체를
+ * 돌려줬다. 여기서는 {@code attach}(단어+조사)와 {@code particleOf}(조사만)로 분리한다.</p>
+ *
+ * <pre>
+ * &lt;&lt; 개정이력(Modification Information) &gt;&gt;
+ *
+ *  수정일        수정자        수정내용
+ *  ----------  --------    ---------------------------
+ *  2026.09.01  실행환경팀     최초 생성
+ * </pre>
+ *
+ * @author 실행환경 개발팀
+ * @since 5.1
+ */
+class EgovKoreanParticlesTest {
+
+	@Nested
+	@DisplayName("이름과 동작의 일치 — 원본의 불일치를 바로잡는다")
+	class NameContract {
+
+		@Test
+		@DisplayName("particleOf 는 조사만 돌려준다 (원본 getXxxParticle 은 명사+조사를 돌려줬다)")
+		void 조사만_반환() {
+			assertEquals("은", EgovKoreanParticles.particleOf("홍길동", Particle.TOPIC));
+			assertEquals("가", EgovKoreanParticles.particleOf("나이", Particle.SUBJECT));
+		}
+
+		@Test
+		@DisplayName("attach 는 단어+조사를 돌려준다")
+		void 단어_조사_반환() {
+			assertEquals("홍길동은", EgovKoreanParticles.attach("홍길동", Particle.TOPIC));
+			assertEquals("나이는", EgovKoreanParticles.attach("나이", Particle.TOPIC));
+		}
+	}
+
+	@Nested
+	@DisplayName("다섯 쌍의 조사")
+	class FiveParticles {
+
+		@Test
+		@DisplayName("은/는")
+		void 은는() {
+			assertEquals("책상은", EgovKoreanParticles.attach("책상", Particle.TOPIC));
+			assertEquals("의자는", EgovKoreanParticles.attach("의자", Particle.TOPIC));
+		}
+
+		@Test
+		@DisplayName("이/가")
+		void 이가() {
+			assertEquals("책상이", EgovKoreanParticles.attach("책상", Particle.SUBJECT));
+			assertEquals("청소기가", EgovKoreanParticles.attach("청소기", Particle.SUBJECT));
+		}
+
+		@Test
+		@DisplayName("을/를")
+		void 을를() {
+			assertEquals("책상을", EgovKoreanParticles.attach("책상", Particle.OBJECT));
+			assertEquals("청소기를", EgovKoreanParticles.attach("청소기", Particle.OBJECT));
+		}
+
+		@Test
+		@DisplayName("과/와 — 원본에 없던 쌍")
+		void 과와() {
+			assertEquals("책상과", EgovKoreanParticles.attach("책상", Particle.AND));
+			assertEquals("의자와", EgovKoreanParticles.attach("의자", Particle.AND));
+		}
+
+		@Test
+		@DisplayName("으로/로 — ㄹ 받침은 '로'(원본에 없던 특칙)")
+		void 으로로_ㄹ_특칙() {
+			assertEquals("집으로", EgovKoreanParticles.attach("집", Particle.TO));
+			assertEquals("학교로", EgovKoreanParticles.attach("학교", Particle.TO));
+			assertEquals("서울로", EgovKoreanParticles.attach("서울", Particle.TO));
+			assertEquals("연필로", EgovKoreanParticles.attach("연필", Particle.TO));
+		}
+	}
+
+	@Nested
+	@DisplayName("경계와 계약")
+	class Contract {
+
+		@Test
+		@DisplayName("받침 판정")
+		void 받침_판정() {
+			assertTrue(EgovKoreanParticles.endsWithFinalConsonant("책상"));
+			assertFalse(EgovKoreanParticles.endsWithFinalConsonant("의자"));
+			assertFalse(EgovKoreanParticles.endsWithFinalConsonant(""));
+			assertFalse(EgovKoreanParticles.endsWithFinalConsonant(null));
+		}
+
+		@Test
+		@DisplayName("비한글 끝 글자는 받침 없음으로 간주 — 계약을 그대로 유지")
+		void 비한글() {
+			assertEquals("MOU를", EgovKoreanParticles.attach("MOU", Particle.OBJECT));
+			assertEquals("3와 5", EgovKoreanParticles.attach("3", Particle.AND) + " 5");   // 비한글=받침 없음 계약
+		}
+
+		@Test
+		@DisplayName("null 단어 — attach 는 null, particleOf 는 받침 없는 쪽")
+		void null_단어() {
+			assertNull(EgovKoreanParticles.attach(null, Particle.TOPIC));
+			assertEquals("는", EgovKoreanParticles.particleOf(null, Particle.TOPIC));
+		}
+
+		@Test
+		@DisplayName("particle 이 null 이면 즉시 실패")
+		void null_조사() {
+			assertThrows(IllegalArgumentException.class,
+					() -> EgovKoreanParticles.attach("책상", null));
+		}
+	}
+}


### PR DESCRIPTION
> **[공통컴포넌트 공통 기능 개선 → 실행환경 이관]**
>
> 공통컴포넌트에 있던 공통 기능을 개선해 실행환경으로 올리는 항목입니다.
> 실행환경에 올라가면 공통컴포넌트를 포함한 모든 사업에서 같은 구현을 쓸 수 있습니다.
>
> 공통컴포넌트 원본
> - `egovframework.com.utl.fcc.service.EgovStringUtil` — 조사(보조사·주격·목적격) 메서드

## 수정 사유 Reason for modification

- [ ] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [X] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

### 배경

**"홍길동님이 / 김철수님가"** 처럼 조사가 어긋난 문구는 안내 메시지에서 흔합니다. 받침 유무에
따라 조사를 골라야 하는데, 실행환경에 수단이 없어 화면마다 자체 분기를 두거나 **"이(가)" 식
병기로 회피**합니다.

공통컴포넌트 `EgovStringUtil` 에 조사 3종이 있으나 **이름과 동작이 어긋납니다** —
`getXxxParticle` 이 조사가 아니라 **"명사+조사"** 를 돌려주므로, 조사만 필요한 자리에서는
쓸 수 없습니다. `과/와` · `으로/로` 쌍도 없습니다.

### 추가한 것

**`EgovKoreanParticles`** — 앞 글자의 받침을 보고 조사를 선택합니다.

| 메서드 | 반환 |
|---|---|
| `particleOf(단어, 조사쌍)` | **조사만** — 이름과 동작을 일치시켰습니다 |
| `attach(단어, 조사쌍)` | 단어 + 조사 |

지원 쌍 5종 — `은/는` · `이/가` · `을/를` · **`과/와`**(원본에 없음) · **`으로/로`**(원본에 없음)

### 설계 메모

- **`으로/로` 는 특칙이 있습니다.** 받침이 `ㄹ` 이면 `으로` 가 아니라 `로` 입니다
  (**서울로** / 부산**으로**). 받침 유무만 보면 틀립니다
- 유니코드 한글 음절 영역의 **산술로 종성**을 구합니다(사전 불필요)
- **한글이 아닌 끝 글자(숫자·영문)는 받침 없음으로 간주**합니다. 발음 기준 판정은 표기와
  어긋나는 경우가 있어 계약을 단순하게 유지했습니다
- **단어가 `null`·빈 문자열이어도 예외를 던지지 않습니다**(`attach` 는 `null`,
  `particleOf` 는 받침 없는 쪽). 안내 문구 생성 중 예외가 나면 화면 전체가 깨집니다
- 다만 **조사쌍이 `null` 이면 즉시 예외**입니다 — 호출 코드의 결함이기 때문입니다

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

`EgovKoreanParticlesTest` **11건 신규**, `fdl.string` 모듈 전건 통과.

| 환경 | 기본 로케일(Locale) | 모듈 실행 건수 | 결과 |
|---|---|---:|---|
| **Windows** | ko_KR | **70** | `Tests run: 70, Failures: 0, Errors: 0, Skipped: 0` |
| **Linux** (Ubuntu 22.04 / OpenJDK 17) | C.UTF-8 | **70** | `Tests run: 70, Failures: 0, Errors: 0, Skipped: 0` |

| 구분 | 건수 | 내용 |
|---|---:|---|
| **이름·동작 일치** | 2 | `particleOf` 는 조사만 반환(원본은 명사+조사) · `attach` 는 단어+조사 |
| 조사 5쌍 | 5 | 은/는 · 이/가 · 을/를 · **과/와**(원본에 없던 쌍) · **으로/로**(ㄹ 받침 특칙) |
| 경계와 계약 | 4 | 받침 판정 · **비한글 끝 글자는 받침 없음** · 단어 `null` 무예외 · 조사쌍 `null` 즉시 실패 |

**수동 확인**: 한글 음절 처리라 소스 인코딩과 실행 환경 문자셋에 얽히므로 Linux(`C.UTF-8`)에서
교차 검증했습니다.

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

해당 없음 — 라이브러리 클래스 추가입니다.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

해당 없음 — 위 JUnit 테스트 결과로 갈음합니다.

---

<sub>base: `eGovFramework:main` @ `cd9fd9c` (2026-09-08 fetch 기준) · 단일 커밋</sub>
