### PR TITLE
feat: 로케일별 숫자·통화·날짜 형식화 EgovLocaleFormats 추가

### DIFF
--- a/Foundation/org.egovframe.rte.fdl.string/src/main/java/org/egovframe/rte/fdl/string/EgovLocaleFormats.java
+++ b/Foundation/org.egovframe.rte.fdl.string/src/main/java/org/egovframe/rte/fdl/string/EgovLocaleFormats.java
@@ -1,0 +1,203 @@
+/*
+ * Copyright 2009-2026 MOIS(Ministry of the Interior and Safety).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.egovframe.rte.fdl.string;
+
+import java.text.NumberFormat;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.FormatStyle;
+import java.util.Locale;
+
+/**
+ * 로케일에 맞는 숫자·통화·백분율·날짜 형식화 유틸 클래스.
+ *
+ * <p><b>NOTE:</b> JDK 의 {@link NumberFormat}·{@link DateTimeFormatter} 를 얇게 감싼 것이다 —
+ * 인스턴스 생성·스타일 상수·스레드 안전성({@code NumberFormat} 은 공유 불가)의 잔손질을
+ * 줄이는 것이 전부이며, 그 이상을 감추지 않는다. 형식을 세밀히 제어할 자리는 JDK API 를
+ * 직접 쓴다.</p>
+ *
+ * <pre>
+ * EgovLocaleFormats.number(1234567.89)                    → "1,234,567.89"
+ * EgovLocaleFormats.currency(50000, Locale.KOREA)         → "₩50,000"
+ * EgovLocaleFormats.percent(0.756)                        → "76%"
+ * EgovLocaleFormats.date(LocalDate.now(), FormatStyle.LONG, Locale.KOREA)
+ *                                                         → "2026년 9월 1일"
+ * </pre>
+ *
+ * <p><b>계약</b> — 값이 {@code null} 이면 빈 문자열을 돌려준다(화면 표시용 — 예외로 화면을
+ * 깨뜨리지 않는다). 로케일 인자를 생략하면 JVM 기본 로케일이다.</p>
+ *
+ * <p>날짜는 {@code java.time} 만 받는다 — 공통컴포넌트 원본(java.util.Date 기반)에서 옮겨올
+ * 때는 {@code date.toInstant().atZone(zone).toLocalDate()} 로 변환해 넘긴다.</p>
+ *
+ * <pre>
+ * &lt;&lt; 개정이력(Modification Information) &gt;&gt;
+ *
+ *  수정일        수정자        수정내용
+ *  ----------  --------    ---------------------------
+ *  2026.09.01  실행환경팀     최초 생성 (공통컴포넌트 EgovNumberFormat·EgovDateFormat 의
+ *                            역할을 차용하되 java.time 기반으로 재작성 — 원본은 Date·int
+ *                            스타일 상수 기반이었고 통화·백분율까지 오버로드 22개로 흩어져
+ *                            있었다. 코드 이식 아님)
+ * </pre>
+ *
+ * @author 실행환경 개발팀
+ * @since 5.1
+ */
+public final class EgovLocaleFormats {
+
+	private EgovLocaleFormats() {
+	}
+
+	/**
+	 * 자릿수 구분이 든 숫자 형식({@code 1,234,567.89})으로 만든다 — JVM 기본 로케일.
+	 *
+	 * @param value 값({@code null} 이면 빈 문자열)
+	 * @return 형식화된 문자열
+	 */
+	public static String number(Number value) {
+		return number(value, Locale.getDefault());
+	}
+
+	/**
+	 * 자릿수 구분이 든 숫자 형식으로 만든다.
+	 *
+	 * @param value  값({@code null} 이면 빈 문자열)
+	 * @param locale 로케일(필수)
+	 * @return 형식화된 문자열
+	 */
+	public static String number(Number value, Locale locale) {
+		return format(value, NumberFormat.getNumberInstance(requireLocale(locale)));
+	}
+
+	/**
+	 * 통화 형식({@code ₩50,000})으로 만든다 — JVM 기본 로케일.
+	 *
+	 * @param value 값({@code null} 이면 빈 문자열)
+	 * @return 형식화된 문자열
+	 */
+	public static String currency(Number value) {
+		return currency(value, Locale.getDefault());
+	}
+
+	/**
+	 * 통화 형식으로 만든다 — 통화 기호·자릿수가 로케일을 따른다.
+	 *
+	 * @param value  값({@code null} 이면 빈 문자열)
+	 * @param locale 로케일(필수)
+	 * @return 형식화된 문자열
+	 */
+	public static String currency(Number value, Locale locale) {
+		return format(value, NumberFormat.getCurrencyInstance(requireLocale(locale)));
+	}
+
+	/**
+	 * 백분율 형식({@code 0.756} → {@code 76%})으로 만든다 — JVM 기본 로케일.
+	 *
+	 * <p>값은 <b>비율</b>이다 — {@code 76} 을 넘기면 {@code 7,600%} 가 된다.</p>
+	 *
+	 * @param ratio 비율({@code null} 이면 빈 문자열)
+	 * @return 형식화된 문자열
+	 */
+	public static String percent(Number ratio) {
+		return percent(ratio, Locale.getDefault());
+	}
+
+	/**
+	 * 백분율 형식으로 만든다.
+	 *
+	 * @param ratio  비율({@code null} 이면 빈 문자열)
+	 * @param locale 로케일(필수)
+	 * @return 형식화된 문자열
+	 */
+	public static String percent(Number ratio, Locale locale) {
+		return format(ratio, NumberFormat.getPercentInstance(requireLocale(locale)));
+	}
+
+	/**
+	 * 로케일 관례의 날짜 문자열로 만든다 — JVM 기본 로케일 · {@link FormatStyle#MEDIUM}.
+	 *
+	 * @param date 날짜({@code null} 이면 빈 문자열)
+	 * @return 형식화된 문자열
+	 */
+	public static String date(LocalDate date) {
+		return date(date, FormatStyle.MEDIUM, Locale.getDefault());
+	}
+
+	/**
+	 * 로케일 관례의 날짜 문자열로 만든다({@code 2026년 9월 1일} · {@code Sep 1, 2026}).
+	 *
+	 * @param date   날짜({@code null} 이면 빈 문자열)
+	 * @param style  길이({@link FormatStyle#SHORT}~{@link FormatStyle#FULL}, 필수)
+	 * @param locale 로케일(필수)
+	 * @return 형식화된 문자열
+	 */
+	public static String date(LocalDate date, FormatStyle style, Locale locale) {
+		if (date == null) {
+			return "";
+		}
+		requireStyle(style);
+		return date.format(DateTimeFormatter.ofLocalizedDate(style).withLocale(requireLocale(locale)));
+	}
+
+	/**
+	 * 로케일 관례의 일시 문자열로 만든다 — JVM 기본 로케일 · {@link FormatStyle#MEDIUM}.
+	 *
+	 * @param dateTime 일시({@code null} 이면 빈 문자열)
+	 * @return 형식화된 문자열
+	 */
+	public static String dateTime(LocalDateTime dateTime) {
+		return dateTime(dateTime, FormatStyle.MEDIUM, Locale.getDefault());
+	}
+
+	/**
+	 * 로케일 관례의 일시 문자열로 만든다.
+	 *
+	 * <p>{@link FormatStyle#LONG}·{@link FormatStyle#FULL} 은 시간대 표기가 필요해
+	 * {@link LocalDateTime} 으로는 형식화할 수 없다 — SHORT·MEDIUM 을 쓴다.</p>
+	 *
+	 * @param dateTime 일시({@code null} 이면 빈 문자열)
+	 * @param style    길이({@link FormatStyle#SHORT} 또는 {@link FormatStyle#MEDIUM}, 필수)
+	 * @param locale   로케일(필수)
+	 * @return 형식화된 문자열
+	 */
+	public static String dateTime(LocalDateTime dateTime, FormatStyle style, Locale locale) {
+		if (dateTime == null) {
+			return "";
+		}
+		requireStyle(style);
+		return dateTime.format(DateTimeFormatter.ofLocalizedDateTime(style).withLocale(requireLocale(locale)));
+	}
+
+	private static String format(Number value, NumberFormat numberFormat) {
+		// NumberFormat 은 스레드 안전하지 않다 — 매번 새 인스턴스를 받아 공유 문제를 차단한다.
+		return (value == null) ? "" : numberFormat.format(value);
+	}
+
+	private static Locale requireLocale(Locale locale) {
+		if (locale == null) {
+			throw new IllegalArgumentException("locale must not be null");
+		}
+		return locale;
+	}
+
+	private static void requireStyle(FormatStyle style) {
+		if (style == null) {
+			throw new IllegalArgumentException("style must not be null");
+		}
+	}
+}

--- a/Foundation/org.egovframe.rte.fdl.string/src/test/java/org/egovframe/rte/fdl/string/EgovLocaleFormatsTest.java
+++ b/Foundation/org.egovframe.rte.fdl.string/src/test/java/org/egovframe/rte/fdl/string/EgovLocaleFormatsTest.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2009-2026 MOIS(Ministry of the Interior and Safety).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.egovframe.rte.fdl.string;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.FormatStyle;
+import java.util.Locale;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * {@link EgovLocaleFormats} 단위 테스트.
+ *
+ * <p>로케일을 <b>명시 지정</b>해 검증한다 — JVM 기본 로케일에 기대면 실행 환경에 따라
+ * 결과가 갈려 테스트가 흔들린다.</p>
+ *
+ * <pre>
+ * &lt;&lt; 개정이력(Modification Information) &gt;&gt;
+ *
+ *  수정일        수정자        수정내용
+ *  ----------  --------    ---------------------------
+ *  2026.09.01  실행환경팀     최초 생성
+ * </pre>
+ *
+ * @author 실행환경 개발팀
+ * @since 5.1
+ */
+class EgovLocaleFormatsTest {
+
+	@Nested
+	@DisplayName("숫자·통화·백분율")
+	class Numbers {
+
+		@Test
+		@DisplayName("자릿수 구분")
+		void 숫자() {
+			assertEquals("1,234,567.89", EgovLocaleFormats.number(1234567.89, Locale.KOREA));
+			assertEquals("1.234.567,89", EgovLocaleFormats.number(1234567.89, Locale.GERMANY));
+		}
+
+		@Test
+		@DisplayName("통화 — 기호·자릿수가 로케일을 따른다")
+		void 통화() {
+			assertEquals("₩50,000", EgovLocaleFormats.currency(50000, Locale.KOREA));
+			assertEquals("$50,000.00", EgovLocaleFormats.currency(50000, Locale.US));
+		}
+
+		@Test
+		@DisplayName("백분율 — 값은 비율이다")
+		void 백분율() {
+			assertEquals("76%", EgovLocaleFormats.percent(0.756, Locale.KOREA));
+			assertEquals("100%", EgovLocaleFormats.percent(1, Locale.KOREA));
+		}
+	}
+
+	@Nested
+	@DisplayName("날짜·일시")
+	class Dates {
+
+		private final LocalDate date = LocalDate.of(2026, 9, 1);
+
+		@Test
+		@DisplayName("한국어 관례")
+		void 한국어() {
+			assertEquals("2026년 9월 1일", EgovLocaleFormats.date(date, FormatStyle.LONG, Locale.KOREA));
+			assertEquals("2026. 9. 1.", EgovLocaleFormats.date(date, FormatStyle.MEDIUM, Locale.KOREA));
+		}
+
+		@Test
+		@DisplayName("영어 관례 — 같은 값, 다른 표기")
+		void 영어() {
+			assertEquals("Sep 1, 2026", EgovLocaleFormats.date(date, FormatStyle.MEDIUM, Locale.US));
+		}
+
+		@Test
+		@DisplayName("일시")
+		void 일시() {
+			String formatted = EgovLocaleFormats.dateTime(
+					LocalDateTime.of(2026, 9, 1, 14, 30, 0), FormatStyle.MEDIUM, Locale.KOREA);
+
+			assertTrue(formatted.contains("2026"), "실제 값: " + formatted);
+			assertTrue(formatted.contains("2:30") || formatted.contains("14:30"), "실제 값: " + formatted);
+		}
+	}
+
+	@Nested
+	@DisplayName("계약")
+	class Contract {
+
+		@Test
+		@DisplayName("null 값은 빈 문자열 — 화면을 깨뜨리지 않는다")
+		void null_값() {
+			assertEquals("", EgovLocaleFormats.number(null, Locale.KOREA));
+			assertEquals("", EgovLocaleFormats.currency(null, Locale.KOREA));
+			assertEquals("", EgovLocaleFormats.percent(null, Locale.KOREA));
+			assertEquals("", EgovLocaleFormats.date(null, FormatStyle.MEDIUM, Locale.KOREA));
+			assertEquals("", EgovLocaleFormats.dateTime(null, FormatStyle.MEDIUM, Locale.KOREA));
+		}
+
+		@Test
+		@DisplayName("로케일·스타일 인자가 null 이면 즉시 실패 — 값 null 과 구분한다")
+		void null_인자() {
+			assertThrows(IllegalArgumentException.class,
+					() -> EgovLocaleFormats.number(1, null));
+			assertThrows(IllegalArgumentException.class,
+					() -> EgovLocaleFormats.date(LocalDate.now(), null, Locale.KOREA));
+		}
+	}
+}


### PR DESCRIPTION
> **[공통컴포넌트 공통 기능 개선 → 실행환경 이관]**
>
> 공통컴포넌트에 있던 공통 기능을 개선해 실행환경으로 올리는 항목입니다.
> 실행환경에 올라가면 공통컴포넌트를 포함한 모든 사업에서 같은 구현을 쓸 수 있습니다.
>
> 공통컴포넌트 원본
> - `egovframework.com.utl.fcc.service.EgovDateFormat`
> - `egovframework.com.utl.fcc.service.EgovNumberFormat`

## 수정 사유 Reason for modification

- [ ] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [X] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

### 배경

숫자 천단위 구분·통화 기호·날짜 표기는 **로케일(Locale)마다 다릅니다**(`1,234.56` vs `1.234,56`).
실행환경에 수단이 없어 화면마다 `DecimalFormat` 패턴을 직접 쓰게 되는데, 그러면 로케일이
반영되지 않고 **형식이 코드에 박힙니다**.

### 추가한 것

**`EgovLocaleFormats`** — 로케일을 명시하는 형식화 유틸

| 메서드 | 예 |
|---|---|
| `number(값, 로케일)` | `1,234,567.89`(KOREA) / `1.234.567,89`(GERMANY) |
| `currency(값, 로케일)` | `₩50,000`(KOREA) / `$50,000.00`(US) |
| `percent(비율, 로케일)` | `0.756` → `76%` |
| `date(날짜, 스타일, 로케일)` | `2026년 9월 1일`(KOREA, LONG) / `Sep 1, 2026`(US, MEDIUM) |
| `dateTime(일시, 스타일, 로케일)` | 로케일 관례에 따른 날짜+시각 |

각 메서드는 **로케일 인자를 받는 형태가 기본**이고, 생략하면 기본 로케일을 씁니다.

### 설계 메모

- **형식 패턴을 문자열로 받지 않습니다.** 패턴을 직접 쓰면 로케일 규칙을 무시하게 되므로,
  JDK 의 로케일 데이터(CLDR)가 결정하도록 맡깁니다
- `java.util.Date` 가 아니라 **`java.time`** 을 받습니다
- **`percent` 의 입력은 비율입니다**(`0.756` → `76%`). 이미 100을 곱한 값을 넣는 실수를
  막으려 이름과 javadoc 에 명시했습니다
- **값이 `null` 이면 빈 문자열**이지만, **로케일·스타일 인자가 `null` 이면 즉시 예외**입니다.
  전자는 화면을 깨뜨리지 않기 위함이고, 후자는 조용히 기본 로케일로 넘어가면 출력이 환경에
  따라 달라지는데 그 사실이 드러나지 않기 때문입니다

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

`EgovLocaleFormatsTest` **8건 신규**, `fdl.string` 모듈 전건 통과.

| 환경 | 기본 로케일 | 모듈 실행 건수 | 결과 |
|---|---|---:|---|
| **Windows** | ko_KR | **67** | `Tests run: 67, Failures: 0, Errors: 0, Skipped: 0` |
| **Linux** (Ubuntu 22.04 / OpenJDK 17) | C.UTF-8 | **67** | `Tests run: 67, Failures: 0, Errors: 0, Skipped: 0` |

| 구분 | 건수 | 내용 |
|---|---:|---|
| 숫자·통화·백분율 | 3 | 자릿수 구분(KOREA vs GERMANY) · 통화 기호·자릿수가 로케일을 따름(KOREA vs US) · 백분율 입력은 비율 |
| 날짜·일시 | 3 | 한국어 관례 · **영어 관례(같은 값, 다른 표기)** · 일시 |
| 계약 | 2 | 값 `null` 은 빈 문자열 · **로케일·스타일 인자 `null` 은 즉시 실패**(값 `null` 과 구분) |

**수동 확인**: 형식화는 실행 환경의 기본 로케일에 좌우되기 쉬운 영역이므로, **단언에 로케일을
전부 명시**하고 기본 로케일이 다른 Linux(`C.UTF-8`)에서 교차 검증해 결과가 동일함을
확인했습니다.

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

해당 없음 — 라이브러리 클래스 추가입니다.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

해당 없음 — 위 JUnit 테스트 결과로 갈음합니다.

---

<sub>base: `eGovFramework:main` @ `cd9fd9c` (2026-09-08 fetch 기준) · 단일 커밋</sub>
