### PR TITLE
feat: 공통코드 조회 캐시 EgovCodeCache 추가

### DIFF
--- a/Foundation/org.egovframe.rte.fdl.cmmn/src/main/java/org/egovframe/rte/fdl/cmmn/code/EgovCode.java
+++ b/Foundation/org.egovframe.rte.fdl.cmmn/src/main/java/org/egovframe/rte/fdl/cmmn/code/EgovCode.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright 2009-2026 MOIS(Ministry of the Interior and Safety).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.egovframe.rte.fdl.cmmn.code;
+
+import java.util.Objects;
+
+/**
+ * 공통코드 한 항목을 담는 <b>불변</b> 값 객체.
+ *
+ * <p><b>NOTE:</b> 코드그룹({@code groupId}) 아래에 코드({@code code})와 표시명({@code name})이
+ * 달리는 전형적인 코드 테이블 구조를 일반화한 것이다. 특정 테이블·업무에 매이지 않도록
+ * 필드를 기술 코어(그룹·코드·이름·설명·사용여부·정렬순서)로 한정했다.</p>
+ *
+ * <p>동일성은 <b>그룹 + 코드</b>로 판정한다 — 같은 그룹 안에서 코드는 유일하다는 것이
+ * 코드 테이블의 통상 계약이다.</p>
+ *
+ * <pre>
+ * &lt;&lt; 개정이력(Modification Information) &gt;&gt;
+ *
+ *  수정일        수정자        수정내용
+ *  ----------  --------    ---------------------------
+ *  2026.09.01  실행환경팀     최초 생성
+ * </pre>
+ *
+ * @author 실행환경 개발팀
+ * @since 5.1
+ */
+public final class EgovCode {
+
+	private final String groupId;
+
+	private final String code;
+
+	private final String name;
+
+	private final String description;
+
+	private final boolean enabled;
+
+	private final int sortOrder;
+
+	/**
+	 * 전체 필드를 지정해 생성한다.
+	 *
+	 * @param groupId     코드그룹 ID(필수)
+	 * @param code        코드 값(필수)
+	 * @param name        표시명(필수)
+	 * @param description 설명({@code null} 이면 빈 문자열)
+	 * @param enabled     사용 여부
+	 * @param sortOrder   정렬 순서(작을수록 앞)
+	 */
+	public EgovCode(String groupId, String code, String name,
+			String description, boolean enabled, int sortOrder) {
+		this.groupId = requireText(groupId, "groupId");
+		this.code = requireText(code, "code");
+		this.name = requireText(name, "name");
+		this.description = (description == null) ? "" : description;
+		this.enabled = enabled;
+		this.sortOrder = sortOrder;
+	}
+
+	/**
+	 * 필수 필드만으로 생성한다(사용 중 · 정렬 0 · 설명 없음).
+	 *
+	 * @param groupId 코드그룹 ID
+	 * @param code    코드 값
+	 * @param name    표시명
+	 * @return 코드 항목
+	 */
+	public static EgovCode of(String groupId, String code, String name) {
+		return new EgovCode(groupId, code, name, "", true, 0);
+	}
+
+	/**
+	 * 코드그룹 ID 를 반환한다.
+	 *
+	 * @return 코드그룹 ID
+	 */
+	public String getGroupId() {
+		return groupId;
+	}
+
+	/**
+	 * 코드 값을 반환한다.
+	 *
+	 * @return 코드 값
+	 */
+	public String getCode() {
+		return code;
+	}
+
+	/**
+	 * 표시명을 반환한다.
+	 *
+	 * @return 표시명
+	 */
+	public String getName() {
+		return name;
+	}
+
+	/**
+	 * 설명을 반환한다(없으면 빈 문자열).
+	 *
+	 * @return 설명
+	 */
+	public String getDescription() {
+		return description;
+	}
+
+	/**
+	 * 사용 여부를 반환한다.
+	 *
+	 * @return 사용 중이면 {@code true}
+	 */
+	public boolean isEnabled() {
+		return enabled;
+	}
+
+	/**
+	 * 정렬 순서를 반환한다(작을수록 앞).
+	 *
+	 * @return 정렬 순서
+	 */
+	public int getSortOrder() {
+		return sortOrder;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj) {
+			return true;
+		}
+		if (!(obj instanceof EgovCode)) {
+			return false;
+		}
+		EgovCode other = (EgovCode) obj;
+		return groupId.equals(other.groupId) && code.equals(other.code);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(groupId, code);
+	}
+
+	@Override
+	public String toString() {
+		return "EgovCode[" + groupId + ":" + code + "=" + name
+				+ (enabled ? "" : " (disabled)") + "]";
+	}
+
+	private static String requireText(String value, String fieldName) {
+		if (value == null || value.trim().isEmpty()) {
+			throw new IllegalArgumentException(fieldName + " must not be null or empty");
+		}
+		return value;
+	}
+}

--- a/Foundation/org.egovframe.rte.fdl.cmmn/src/main/java/org/egovframe/rte/fdl/cmmn/code/EgovCodeCache.java
+++ b/Foundation/org.egovframe.rte.fdl.cmmn/src/main/java/org/egovframe/rte/fdl/cmmn/code/EgovCodeCache.java
@@ -1,0 +1,239 @@
+/*
+ * Copyright 2009-2026 MOIS(Ministry of the Interior and Safety).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.egovframe.rte.fdl.cmmn.code;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * 공통코드를 <b>불변 스냅숏</b>으로 보관하는 조회 캐시.
+ *
+ * <p><b>NOTE:</b> 공통코드는 읽기가 압도적이고 변경이 드물며 전체가 메모리에 들어가는
+ * 크기다. 그래서 항목별 TTL 캐시가 아니라 <b>전량 스냅숏 + 명시적 {@link #reload()}</b> 로
+ * 다룬다 — 조회는 락 없이 즉답하고, 운영 중 코드 변경은 reload 한 번으로 통째 반영된다
+ * (프로퍼티 {@code refreshPropertyFiles}·접근제어 색인 스냅숏과 같은 실행환경 관례다).</p>
+ *
+ * <pre>
+ * // 구성 — 생성 시점에 전량 적재된다(원천 장애는 기동 실패로 드러난다)
+ * EgovCodeCache cache = new EgovCodeCache(
+ *         new EgovJdbcCodeLoader(dataSource, CODE_SQL));
+ *
+ * // 조회 — DB 왕복 없음
+ * List&lt;EgovCode&gt; codes = cache.getActiveCodes("COM001");          // 셀렉트박스
+ * String name = cache.getName("COM001", "A01").orElse("A01");     // 코드 → 이름
+ *
+ * // 운영 중 코드 변경 시
+ * cache.reload();
+ * </pre>
+ *
+ * <p><b>reload 실패는 기존 스냅숏을 유지한 채 예외로 알린다.</b> 원천이 잠시 죽었다고
+ * 멀쩡히 서비스 중인 코드가 사라지면 안 되고, 실패를 삼켜 "갱신된 줄 아는" 상태가 되어도
+ * 안 되기 때문이다.</p>
+ *
+ * <pre>
+ * &lt;&lt; 개정이력(Modification Information) &gt;&gt;
+ *
+ *  수정일        수정자        수정내용
+ *  ----------  --------    ---------------------------
+ *  2026.09.01  실행환경팀     최초 생성 (공통컴포넌트 EgovCmmUseService 의 역할을
+ *                            차용하되 캐시 부재(소비처 54곳이 매 화면 DB 조회)·복수 그룹
+ *                            조회의 N+1 을 전량 스냅숏으로 재구성. 특정 테이블·VO 종속은
+ *                            로더 SPI 로 분리 — 코드 이식 아님)
+ * </pre>
+ *
+ * @author 실행환경 개발팀
+ * @since 5.1
+ */
+public class EgovCodeCache {
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(EgovCodeCache.class);
+
+	/** 그룹 내 정렬 — 정렬 순서, 같으면 코드 값. */
+	private static final Comparator<EgovCode> GROUP_ORDER =
+			Comparator.comparingInt(EgovCode::getSortOrder).thenComparing(EgovCode::getCode);
+
+	private final EgovCodeLoader loader;
+
+	private volatile Snapshot snapshot;
+
+	/**
+	 * 캐시를 만들고 <b>즉시 전량 적재한다</b> — 원천 장애가 기동 실패로 드러난다(fail-fast).
+	 *
+	 * @param loader 코드 로더(필수)
+	 */
+	public EgovCodeCache(EgovCodeLoader loader) {
+		if (loader == null) {
+			throw new IllegalArgumentException("loader must not be null");
+		}
+		this.loader = loader;
+		this.snapshot = Snapshot.from(loader.loadAll());
+		LOGGER.info("공통코드 캐시 적재 완료 — 그룹 {}개, 코드 {}건",
+				snapshot.groups.size(), snapshot.totalCount);
+	}
+
+	/**
+	 * 그룹의 코드 전부를 반환한다(<b>사용 안 함 포함</b>, 정렬 순서 → 코드 순).
+	 *
+	 * <p>과거 데이터의 코드 이름 표시처럼 사용 안 함 코드도 필요한 자리를 위한 것이다.
+	 * 셀렉트박스처럼 사용 중만 필요하면 {@link #getActiveCodes(String)} 를 쓴다.</p>
+	 *
+	 * @param groupId 코드그룹 ID({@code null} 허용)
+	 * @return 불변 목록(그룹이 없으면 빈 목록)
+	 */
+	public List<EgovCode> getCodes(String groupId) {
+		GroupEntry entry = snapshot.groups.get(groupId);
+		return (entry == null) ? Collections.emptyList() : entry.all;
+	}
+
+	/**
+	 * 그룹의 <b>사용 중</b> 코드만 반환한다(정렬 순서 → 코드 순).
+	 *
+	 * @param groupId 코드그룹 ID({@code null} 허용)
+	 * @return 불변 목록(그룹이 없으면 빈 목록)
+	 */
+	public List<EgovCode> getActiveCodes(String groupId) {
+		GroupEntry entry = snapshot.groups.get(groupId);
+		return (entry == null) ? Collections.emptyList() : entry.active;
+	}
+
+	/**
+	 * 코드 항목 하나를 찾는다.
+	 *
+	 * @param groupId 코드그룹 ID({@code null} 허용)
+	 * @param code    코드 값({@code null} 허용)
+	 * @return 항목. 없으면 {@link Optional#empty()}
+	 */
+	public Optional<EgovCode> getCode(String groupId, String code) {
+		GroupEntry entry = snapshot.groups.get(groupId);
+		return (entry == null || code == null)
+				? Optional.empty() : Optional.ofNullable(entry.byCode.get(code));
+	}
+
+	/**
+	 * 코드의 표시명을 찾는다 — 가장 흔한 용도(코드 → 이름)의 지름길이다.
+	 *
+	 * @param groupId 코드그룹 ID({@code null} 허용)
+	 * @param code    코드 값({@code null} 허용)
+	 * @return 표시명. 없으면 {@link Optional#empty()} — 원본 코드 값을 그대로 내보내는
+	 *         폴백은 호출부가 {@code orElse(code)} 로 명시한다
+	 */
+	public Optional<String> getName(String groupId, String code) {
+		return getCode(groupId, code).map(EgovCode::getName);
+	}
+
+	/**
+	 * 보관 중인 코드그룹 ID 전부를 반환한다.
+	 *
+	 * @return 불변 집합
+	 */
+	public Set<String> getGroupIds() {
+		return snapshot.groups.keySet();
+	}
+
+	/**
+	 * 보관 중인 전체 코드 수를 반환한다(사용 안 함 포함).
+	 *
+	 * @return 코드 수
+	 */
+	public int size() {
+		return snapshot.totalCount;
+	}
+
+	/**
+	 * 원천에서 전량을 다시 읽어 스냅숏을 <b>원자적으로 교체</b>한다.
+	 *
+	 * <p>교체 전까지 조회는 기존 스냅숏으로 계속 응답하므로 무중단이다. 적재가 실패하면
+	 * <b>기존 스냅숏을 유지한 채</b> 예외를 던진다 — 부분 반영이나 침묵 실패는 없다.</p>
+	 *
+	 * @throws RuntimeException 로더가 던진 예외 그대로(원천 장애·데이터 결함)
+	 */
+	public synchronized void reload() {
+		Snapshot next = Snapshot.from(loader.loadAll());
+		this.snapshot = next;
+		LOGGER.info("공통코드 캐시 갱신 완료 — 그룹 {}개, 코드 {}건",
+				next.groups.size(), next.totalCount);
+	}
+
+	/** 한 그룹의 코드들 — 전체·사용 중·코드별 색인을 미리 만들어 둔다. */
+	private static final class GroupEntry {
+
+		private final List<EgovCode> all;
+
+		private final List<EgovCode> active;
+
+		private final Map<String, EgovCode> byCode;
+
+		private GroupEntry(List<EgovCode> sorted) {
+			List<EgovCode> activeOnly = new ArrayList<>();
+			Map<String, EgovCode> index = new LinkedHashMap<>();
+			for (EgovCode code : sorted) {
+				EgovCode duplicated = index.put(code.getCode(), code);
+				if (duplicated != null) {
+					// (그룹, 코드) 중복은 원천 데이터 결함이다 — 한쪽을 조용히 덮지 않는다.
+					throw new IllegalStateException("duplicate code in group '"
+							+ code.getGroupId() + "': " + code.getCode());
+				}
+				if (code.isEnabled()) {
+					activeOnly.add(code);
+				}
+			}
+			this.all = Collections.unmodifiableList(sorted);
+			this.active = Collections.unmodifiableList(activeOnly);
+			this.byCode = Collections.unmodifiableMap(index);
+		}
+	}
+
+	/** 불변 스냅숏 — 참조 교체만으로 전체가 갱신된다. */
+	private static final class Snapshot {
+
+		private final Map<String, GroupEntry> groups;
+
+		private final int totalCount;
+
+		private Snapshot(Map<String, GroupEntry> groups, int totalCount) {
+			this.groups = Collections.unmodifiableMap(groups);
+			this.totalCount = totalCount;
+		}
+
+		private static Snapshot from(List<EgovCode> codes) {
+			if (codes == null) {
+				throw new IllegalStateException("code loader returned null — return an empty list instead");
+			}
+			Map<String, List<EgovCode>> grouped = new LinkedHashMap<>();
+			for (EgovCode code : codes) {
+				if (code == null) {
+					throw new IllegalStateException("code loader returned a null element");
+				}
+				grouped.computeIfAbsent(code.getGroupId(), key -> new ArrayList<>()).add(code);
+			}
+			Map<String, GroupEntry> groups = new LinkedHashMap<>();
+			for (Map.Entry<String, List<EgovCode>> entry : grouped.entrySet()) {
+				entry.getValue().sort(GROUP_ORDER);
+				groups.put(entry.getKey(), new GroupEntry(entry.getValue()));
+			}
+			return new Snapshot(groups, codes.size());
+		}
+	}
+}

--- a/Foundation/org.egovframe.rte.fdl.cmmn/src/main/java/org/egovframe/rte/fdl/cmmn/code/EgovCodeLoader.java
+++ b/Foundation/org.egovframe.rte.fdl.cmmn/src/main/java/org/egovframe/rte/fdl/cmmn/code/EgovCodeLoader.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2009-2026 MOIS(Ministry of the Interior and Safety).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.egovframe.rte.fdl.cmmn.code;
+
+import java.util.List;
+
+/**
+ * 공통코드 전량을 읽어 오는 로더 SPI.
+ *
+ * <p><b>NOTE:</b> {@link EgovCodeCache} 는 이 인터페이스로만 원천을 본다 — 코드가 DB 에 있든
+ * 파일·원격에 있든 로더 구현만 바꾸면 된다. 기본 구현으로 {@link EgovJdbcCodeLoader}(DB)와
+ * {@link EgovInMemoryCodeLoader}(정적·테스트)를 제공한다.</p>
+ *
+ * <p><b>전량 적재 계약이다.</b> 공통코드는 전체가 메모리에 들어가는 크기(통상 수천 건)라
+ * 그룹별 부분 적재보다 전량 스냅숏이 단순하고 정확하다. 그룹핑·정렬·불변화는 캐시가
+ * 책임지므로 로더는 <b>평평한 목록만</b> 돌려주면 된다.</p>
+ *
+ * <pre>
+ * &lt;&lt; 개정이력(Modification Information) &gt;&gt;
+ *
+ *  수정일        수정자        수정내용
+ *  ----------  --------    ---------------------------
+ *  2026.09.01  실행환경팀     최초 생성
+ * </pre>
+ *
+ * @author 실행환경 개발팀
+ * @since 5.1
+ */
+@FunctionalInterface
+public interface EgovCodeLoader {
+
+	/**
+	 * 공통코드 전량을 읽는다.
+	 *
+	 * <p>실패는 <b>예외로 알린다</b>(부분 결과나 빈 목록으로 무마하지 않는다 — 침묵 실패 금지).
+	 * 원천에 코드가 하나도 없는 것은 실패가 아니므로 빈 목록이 정당하다.</p>
+	 *
+	 * @return 코드 목록(순서 무관 — 정렬은 캐시가 한다)
+	 */
+	List<EgovCode> loadAll();
+}

--- a/Foundation/org.egovframe.rte.fdl.cmmn/src/main/java/org/egovframe/rte/fdl/cmmn/code/EgovInMemoryCodeLoader.java
+++ b/Foundation/org.egovframe.rte.fdl.cmmn/src/main/java/org/egovframe/rte/fdl/cmmn/code/EgovInMemoryCodeLoader.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2009-2026 MOIS(Ministry of the Interior and Safety).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.egovframe.rte.fdl.cmmn.code;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * 고정된 코드 목록을 그대로 돌려주는 {@link EgovCodeLoader} 구현.
+ *
+ * <p><b>NOTE:</b> DB 없이 코드를 쓰는 두 자리를 위한 것이다 — <b>테스트</b>, 그리고
+ * 배포 후 바뀔 일이 없는 <b>정적 코드</b>(예: 요일·성별처럼 소스에 두는 편이 맞는 것).
+ * 운영 중 관리되는 코드라면 {@link EgovJdbcCodeLoader} 를 쓴다.</p>
+ *
+ * <pre>
+ * EgovCodeCache cache = new EgovCodeCache(new EgovInMemoryCodeLoader(List.of(
+ *         EgovCode.of("GENDER", "M", "남성"),
+ *         EgovCode.of("GENDER", "F", "여성"))));
+ * </pre>
+ *
+ * <pre>
+ * &lt;&lt; 개정이력(Modification Information) &gt;&gt;
+ *
+ *  수정일        수정자        수정내용
+ *  ----------  --------    ---------------------------
+ *  2026.09.01  실행환경팀     최초 생성
+ * </pre>
+ *
+ * @author 실행환경 개발팀
+ * @since 5.1
+ */
+public class EgovInMemoryCodeLoader implements EgovCodeLoader {
+
+	private final List<EgovCode> codes;
+
+	/**
+	 * @param codes 제공할 코드 목록(복사해 보관하며 {@code null} 항목은 허용하지 않는다)
+	 */
+	public EgovInMemoryCodeLoader(Collection<EgovCode> codes) {
+		if (codes == null) {
+			throw new IllegalArgumentException("codes must not be null");
+		}
+		List<EgovCode> copied = new ArrayList<>(codes.size());
+		for (EgovCode code : codes) {
+			if (code == null) {
+				throw new IllegalArgumentException("codes must not contain null");
+			}
+			copied.add(code);
+		}
+		this.codes = Collections.unmodifiableList(copied);
+	}
+
+	@Override
+	public List<EgovCode> loadAll() {
+		return codes;
+	}
+}

--- a/Foundation/org.egovframe.rte.fdl.cmmn/src/main/java/org/egovframe/rte/fdl/cmmn/code/EgovJdbcCodeLoader.java
+++ b/Foundation/org.egovframe.rte.fdl.cmmn/src/main/java/org/egovframe/rte/fdl/cmmn/code/EgovJdbcCodeLoader.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright 2009-2026 MOIS(Ministry of the Interior and Safety).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.egovframe.rte.fdl.cmmn.code;
+
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+
+import javax.sql.DataSource;
+
+import org.springframework.jdbc.core.JdbcTemplate;
+
+/**
+ * DB 에서 공통코드 전량을 읽는 {@link EgovCodeLoader} 구현.
+ *
+ * <p><b>NOTE:</b> 실행환경에는 표준 코드 테이블이 없으므로 <b>SQL 을 필수로 받는다</b> —
+ * 테이블·컬럼명이 사업마다 다르기 때문이다. 대신 SELECT 결과의 <b>컬럼 별칭 계약</b>을 고정한다.</p>
+ *
+ * <table border="1">
+ *   <caption>컬럼 별칭 계약</caption>
+ *   <tr><th>별칭</th><th>필수</th><th>의미</th></tr>
+ *   <tr><td>{@code GROUP_ID}</td><td>필수</td><td>코드그룹 ID</td></tr>
+ *   <tr><td>{@code CODE}</td><td>필수</td><td>코드 값</td></tr>
+ *   <tr><td>{@code NAME}</td><td>필수</td><td>표시명</td></tr>
+ *   <tr><td>{@code DESCRIPTION}</td><td>선택</td><td>설명</td></tr>
+ *   <tr><td>{@code ENABLED}</td><td>선택</td><td>사용 여부({@code Y/N}·{@code true/false}·{@code 1/0}) — 없으면 사용 중으로 본다</td></tr>
+ *   <tr><td>{@code SORT_ORDER}</td><td>선택</td><td>정렬 순서 — 없으면 0</td></tr>
+ * </table>
+ *
+ * <p>공통컴포넌트 표준 테이블이라면 이렇게 쓴다.</p>
+ *
+ * <pre>
+ * new EgovJdbcCodeLoader(dataSource,
+ *         "SELECT CODE_ID AS GROUP_ID, CODE, CODE_NM AS NAME, CODE_DC AS DESCRIPTION, "
+ *       + "USE_AT AS ENABLED FROM COMTCCMMNDETAILCODE");
+ * </pre>
+ *
+ * <p><b>사용 안 함 코드도 함께 읽는 것을 권장한다</b>(WHERE 로 거르지 않는다). 과거 데이터의
+ * 코드 이름을 표시할 때는 사용 안 함 코드도 이름이 필요하기 때문이다 — 셀렉트박스처럼
+ * 사용 중만 필요한 자리는 조회 쪽({@link EgovCodeCache#getActiveCodes(String)})에서 거른다.</p>
+ *
+ * <pre>
+ * &lt;&lt; 개정이력(Modification Information) &gt;&gt;
+ *
+ *  수정일        수정자        수정내용
+ *  ----------  --------    ---------------------------
+ *  2026.09.01  실행환경팀     최초 생성
+ * </pre>
+ *
+ * @author 실행환경 개발팀
+ * @since 5.1
+ */
+public class EgovJdbcCodeLoader implements EgovCodeLoader {
+
+	private static final String COLUMN_GROUP_ID = "GROUP_ID";
+
+	private static final String COLUMN_CODE = "CODE";
+
+	private static final String COLUMN_NAME = "NAME";
+
+	private static final String COLUMN_DESCRIPTION = "DESCRIPTION";
+
+	private static final String COLUMN_ENABLED = "ENABLED";
+
+	private static final String COLUMN_SORT_ORDER = "SORT_ORDER";
+
+	private final JdbcTemplate jdbcTemplate;
+
+	private final String sql;
+
+	/**
+	 * @param dataSource 코드 테이블이 있는 데이터소스(필수)
+	 * @param sql        컬럼 별칭 계약을 지키는 SELECT 문(필수)
+	 */
+	public EgovJdbcCodeLoader(DataSource dataSource, String sql) {
+		if (dataSource == null) {
+			throw new IllegalArgumentException("dataSource must not be null");
+		}
+		if (sql == null || sql.trim().isEmpty()) {
+			throw new IllegalArgumentException("sql must not be null or empty");
+		}
+		this.jdbcTemplate = new JdbcTemplate(dataSource);
+		this.sql = sql;
+	}
+
+	@Override
+	public List<EgovCode> loadAll() {
+		// DataAccessException(unchecked)은 그대로 전파한다 — 침묵 실패 금지.
+		return jdbcTemplate.query(sql, EgovJdbcCodeLoader::extractAll);
+	}
+
+	private static List<EgovCode> extractAll(ResultSet rs) throws SQLException {
+		// 컬럼 구성은 결과셋 전체에서 같으므로 메타데이터는 한 번만 읽는다.
+		Set<String> columns = columnLabelsOf(rs.getMetaData());
+		requireColumns(columns);
+
+		List<EgovCode> codes = new ArrayList<>();
+		while (rs.next()) {
+			String description = columns.contains(COLUMN_DESCRIPTION)
+					? rs.getString(COLUMN_DESCRIPTION) : "";
+			boolean enabled = !columns.contains(COLUMN_ENABLED)
+					|| isTruthy(rs.getString(COLUMN_ENABLED));
+			int sortOrder = columns.contains(COLUMN_SORT_ORDER)
+					? rs.getInt(COLUMN_SORT_ORDER) : 0;
+
+			codes.add(new EgovCode(
+					rs.getString(COLUMN_GROUP_ID),
+					rs.getString(COLUMN_CODE),
+					rs.getString(COLUMN_NAME),
+					description, enabled, sortOrder));
+		}
+		return codes;
+	}
+
+	private static void requireColumns(Set<String> columns) {
+		if (!columns.contains(COLUMN_GROUP_ID) || !columns.contains(COLUMN_CODE)
+				|| !columns.contains(COLUMN_NAME)) {
+			throw new IllegalStateException(
+					"code SQL must select GROUP_ID, CODE, NAME (aliases) — found: " + columns);
+		}
+	}
+
+	private static Set<String> columnLabelsOf(ResultSetMetaData metaData) throws SQLException {
+		Set<String> labels = new HashSet<>();
+		for (int i = 1; i <= metaData.getColumnCount(); i++) {
+			labels.add(metaData.getColumnLabel(i).toUpperCase(Locale.ROOT));
+		}
+		return labels;
+	}
+
+	/**
+	 * 사용 여부 문자열을 판정한다({@code Y}·{@code true}·{@code 1} 이 사용 중).
+	 *
+	 * @param value DB 값({@code null} 이면 사용 안 함)
+	 * @return 사용 중이면 {@code true}
+	 */
+	private static boolean isTruthy(String value) {
+		if (value == null) {
+			return false;
+		}
+		String normalized = value.trim().toUpperCase(Locale.ROOT);
+		return "Y".equals(normalized) || "TRUE".equals(normalized) || "1".equals(normalized);
+	}
+}

--- a/Foundation/org.egovframe.rte.fdl.cmmn/src/test/java/org/egovframe/rte/fdl/cmmn/code/EgovCodeCacheSecurityTest.java
+++ b/Foundation/org.egovframe.rte.fdl.cmmn/src/test/java/org/egovframe/rte/fdl/cmmn/code/EgovCodeCacheSecurityTest.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2009-2026 MOIS(Ministry of the Interior and Safety).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.egovframe.rte.fdl.cmmn.code;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * {@link EgovCodeCache} 의 <b>호출자 입력에 대한 견고성</b> 검증.
+ *
+ * <p>코드그룹 ID·코드 값은 화면 파라미터에서 그대로 넘어오기 쉽다. 그 값이 무엇이든 캐시는
+ * 원천(DB)에 가지 않고, 보관량이 늘지 않으며, 돌려준 컬렉션으로 캐시 내용을 바꿀 수 없어야 한다.
+ * reload 가 원천에서 막혀 있는 동안에도 조회는 교체 전 스냅숏을 통째로 본다.</p>
+ *
+ * <pre>
+ * &lt;&lt; 개정이력(Modification Information) &gt;&gt;
+ *
+ *  수정일        수정자        수정내용
+ *  ----------  --------    ---------------------------
+ *  2026.09.07  실행환경팀     최초 생성
+ * </pre>
+ *
+ * @author 실행환경 개발팀
+ * @since 5.1
+ */
+class EgovCodeCacheSecurityTest {
+
+	private static final List<EgovCode> CODES = List.of(
+			EgovCode.of("G", "A", "a"), new EgovCode("G", "B", "b", "", false, 1));
+
+	@Test
+	@DisplayName("존재하지 않는 키를 아무리 조회해도 원천 호출·보관량이 늘지 않는다")
+	void 미존재_키_반복_조회() {
+		AtomicInteger calls = new AtomicInteger();
+		EgovCodeCache cache = new EgovCodeCache(() -> {
+			calls.incrementAndGet();
+			return CODES;
+		});
+
+		for (int i = 0; i < 200_000; i++) {
+			String key = "no-such-" + i;
+			assertTrue(cache.getCodes(key).isEmpty());
+			assertTrue(cache.getActiveCodes(key).isEmpty());
+			assertFalse(cache.getName(key, key).isPresent());
+		}
+
+		assertEquals(1, calls.get(), "조회는 원천에 가지 않는다");
+		assertEquals(Set.of("G"), cache.getGroupIds(), "미존재 키는 보관되지 않는다");
+		assertEquals(2, cache.size());
+	}
+
+	@Test
+	@DisplayName("돌려준 컬렉션은 전부 불변이다 — 그룹 목록·빈 결과 포함")
+	void 반환_컬렉션_불변() {
+		EgovCodeCache cache = new EgovCodeCache(new EgovInMemoryCodeLoader(CODES));
+		EgovCode intruder = EgovCode.of("G", "Z", "z");
+
+		assertThrows(UnsupportedOperationException.class, () -> cache.getCodes("G").add(intruder));
+		assertThrows(UnsupportedOperationException.class, () -> cache.getActiveCodes("G").clear());
+		assertThrows(UnsupportedOperationException.class, () -> cache.getCodes("no-such").add(intruder));
+		assertThrows(UnsupportedOperationException.class, () -> cache.getGroupIds().add("H"));
+		assertThrows(UnsupportedOperationException.class, () -> cache.getGroupIds().remove("G"));
+
+		assertEquals(2, cache.getCodes("G").size(), "시도 후에도 내용은 그대로다");
+		assertEquals(Set.of("G"), cache.getGroupIds());
+	}
+
+	@Test
+	@DisplayName("로더가 돌려준 목록을 나중에 바꿔도 스냅숏은 변하지 않는다")
+	void 로더_목록_사후_변경() {
+		List<EgovCode> mutable = new ArrayList<>(CODES);
+		EgovCodeCache cache = new EgovCodeCache(() -> mutable);
+
+		mutable.add(EgovCode.of("G", "C", "c"));
+		mutable.add(EgovCode.of("H", "X", "x"));
+
+		assertEquals(2, cache.size());
+		assertEquals(Set.of("G"), cache.getGroupIds());
+		assertEquals(2, cache.getCodes("G").size());
+	}
+
+	@Test
+	@DisplayName("reload 가 원천에서 막혀 있는 동안 조회는 교체 전 스냅숏을 통째로 본다")
+	void reload_중_조회는_기존_스냅숏() throws Exception {
+		CountDownLatch entered = new CountDownLatch(1);
+		CountDownLatch release = new CountDownLatch(1);
+		List<EgovCode> next = List.of(
+				EgovCode.of("G", "N1", "n1"), EgovCode.of("G", "N2", "n2"), EgovCode.of("G", "N3", "n3"));
+		EgovCodeCache cache = new EgovCodeCache(new EgovCodeLoader() {
+			private int calls;
+
+			@Override
+			public List<EgovCode> loadAll() {
+				if (calls++ == 0) {
+					return CODES;
+				}
+				entered.countDown();
+				try {
+					release.await();
+				} catch (InterruptedException e) {
+					Thread.currentThread().interrupt();
+				}
+				return next;
+			}
+		});
+
+		Thread reloader = new Thread(cache::reload);
+		reloader.start();
+		try {
+			assertTrue(entered.await(5, TimeUnit.SECONDS), "로더가 reload 안에서 호출돼야 한다");
+			assertEquals(2, cache.getCodes("G").size(), "교체 전 스냅숏");
+			assertEquals(2, cache.size());
+		} finally {
+			release.countDown();
+			reloader.join(5_000);
+		}
+
+		assertEquals(3, cache.getCodes("G").size(), "교체 후 스냅숏");
+		assertEquals(3, cache.size());
+	}
+}

--- a/Foundation/org.egovframe.rte.fdl.cmmn/src/test/java/org/egovframe/rte/fdl/cmmn/code/EgovCodeCacheTest.java
+++ b/Foundation/org.egovframe.rte.fdl.cmmn/src/test/java/org/egovframe/rte/fdl/cmmn/code/EgovCodeCacheTest.java
@@ -1,0 +1,281 @@
+/*
+ * Copyright 2009-2026 MOIS(Ministry of the Interior and Safety).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.egovframe.rte.fdl.cmmn.code;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * {@link EgovCodeCache} 단위 테스트.
+ *
+ * <p>일반 동작 검증과 함께 <b>공통컴포넌트 원본(EgovCmmUseService)의 결함을 회귀로
+ * 고정</b>한다 — 캐시 부재(매 조회 DAO 직행), 복수 그룹 조회의 N+1, 그리고 갱신 실패가
+ * 침묵으로 넘어가는 상태를 만들지 않는다.</p>
+ *
+ * <pre>
+ * &lt;&lt; 개정이력(Modification Information) &gt;&gt;
+ *
+ *  수정일        수정자        수정내용
+ *  ----------  --------    ---------------------------
+ *  2026.09.01  실행환경팀     최초 생성
+ * </pre>
+ *
+ * @author 실행환경 개발팀
+ * @since 5.1
+ */
+class EgovCodeCacheTest {
+
+	private static List<EgovCode> sampleCodes() {
+		return Arrays.asList(
+				new EgovCode("COM001", "B", "두 번째", "", true, 2),
+				new EgovCode("COM001", "A", "첫 번째", "설명", true, 1),
+				new EgovCode("COM001", "X", "폐기됨", "", false, 3),
+				EgovCode.of("GENDER", "M", "남성"),
+				EgovCode.of("GENDER", "F", "여성"));
+	}
+
+	private static EgovCodeCache cacheOf(List<EgovCode> codes) {
+		return new EgovCodeCache(new EgovInMemoryCodeLoader(codes));
+	}
+
+	@Nested
+	@DisplayName("원본 결함 회귀 — 공통컴포넌트 EgovCmmUseService 라면 실패한다")
+	class LegacyDefectRegression {
+
+		@Test
+		@DisplayName("조회 1만 번에 원천 접근은 1번뿐이다 (원본은 매 조회 DAO 직행)")
+		void 조회는_원천에_가지_않는다() {
+			AtomicInteger loadCount = new AtomicInteger();
+			EgovCodeLoader countingLoader = () -> {
+				loadCount.incrementAndGet();
+				return sampleCodes();
+			};
+
+			EgovCodeCache cache = new EgovCodeCache(countingLoader);
+			for (int i = 0; i < 10_000; i++) {
+				cache.getCodes("COM001");
+				cache.getName("GENDER", "M");
+			}
+
+			assertEquals(1, loadCount.get(), "생성 시 적재 1번 이후 원천에 가면 안 된다");
+		}
+
+		@Test
+		@DisplayName("복수 그룹 조회에 그룹 수만큼의 원천 접근이 없다 (원본 selectCmmCodeDetails 는 N+1)")
+		void 복수_그룹도_원천_접근_없음() {
+			AtomicInteger loadCount = new AtomicInteger();
+			EgovCodeCache cache = new EgovCodeCache(() -> {
+				loadCount.incrementAndGet();
+				return sampleCodes();
+			});
+
+			// 원본은 그룹 목록을 돌며 그룹당 쿼리 1번씩 날렸다.
+			for (String groupId : Arrays.asList("COM001", "GENDER", "COM001", "GENDER")) {
+				cache.getCodes(groupId);
+			}
+
+			assertEquals(1, loadCount.get());
+		}
+
+		@Test
+		@DisplayName("reload 실패 시 기존 스냅숏을 유지하고 예외로 알린다 — 침묵 실패 금지")
+		void reload_실패는_기존_유지_예외() {
+			AtomicBoolean fail = new AtomicBoolean(false);
+			EgovCodeCache cache = new EgovCodeCache(() -> {
+				if (fail.get()) {
+					throw new IllegalStateException("원천 장애");
+				}
+				return sampleCodes();
+			});
+
+			fail.set(true);
+			assertThrows(IllegalStateException.class, cache::reload);
+
+			// 실패했지만 기존 코드는 그대로 조회된다.
+			assertEquals(3, cache.getCodes("COM001").size());
+			assertEquals(Optional.of("남성"), cache.getName("GENDER", "M"));
+		}
+	}
+
+	@Nested
+	@DisplayName("조회")
+	class Lookup {
+
+		@Test
+		@DisplayName("그룹별로 묶여 정렬 순서 → 코드 순으로 나온다")
+		void 그룹핑과_정렬() {
+			List<EgovCode> codes = cacheOf(sampleCodes()).getCodes("COM001");
+
+			assertEquals(Arrays.asList("A", "B", "X"),
+					codes.stream().map(EgovCode::getCode).toList());
+		}
+
+		@Test
+		@DisplayName("getActiveCodes 는 사용 중만 — 셀렉트박스 용도")
+		void 사용중_필터() {
+			List<EgovCode> active = cacheOf(sampleCodes()).getActiveCodes("COM001");
+
+			assertEquals(Arrays.asList("A", "B"),
+					active.stream().map(EgovCode::getCode).toList());
+		}
+
+		@Test
+		@DisplayName("getCodes 는 사용 안 함도 포함 — 과거 데이터의 이름 표시 용도")
+		void 전체_조회는_폐기_포함() {
+			assertEquals(Optional.of("폐기됨"), cacheOf(sampleCodes()).getName("COM001", "X"));
+		}
+
+		@Test
+		@DisplayName("코드 → 이름 지름길")
+		void 이름_조회() {
+			EgovCodeCache cache = cacheOf(sampleCodes());
+
+			assertEquals(Optional.of("첫 번째"), cache.getName("COM001", "A"));
+			assertEquals("A99", cache.getName("COM001", "A99").orElse("A99"));
+		}
+
+		@Test
+		@DisplayName("없는 그룹·null 은 빈 결과 — 예외를 던지지 않는다")
+		void 없는_그룹과_null() {
+			EgovCodeCache cache = cacheOf(sampleCodes());
+
+			assertTrue(cache.getCodes("NOPE").isEmpty());
+			assertTrue(cache.getCodes(null).isEmpty());
+			assertEquals(Optional.empty(), cache.getCode("COM001", null));
+			assertEquals(Optional.empty(), cache.getCode(null, "A"));
+		}
+
+		@Test
+		@DisplayName("반환 목록은 불변이다")
+		void 반환_불변() {
+			EgovCodeCache cache = cacheOf(sampleCodes());
+
+			assertThrows(UnsupportedOperationException.class,
+					() -> cache.getCodes("COM001").clear());
+			assertThrows(UnsupportedOperationException.class,
+					() -> cache.getGroupIds().clear());
+		}
+
+		@Test
+		@DisplayName("그룹 목록과 전체 건수")
+		void 집계() {
+			EgovCodeCache cache = cacheOf(sampleCodes());
+
+			assertEquals(2, cache.getGroupIds().size());
+			assertEquals(5, cache.size());
+		}
+	}
+
+	@Nested
+	@DisplayName("적재·갱신")
+	class LoadAndReload {
+
+		@Test
+		@DisplayName("생성 시 즉시 적재 — 원천 장애는 기동 실패로 드러난다(fail-fast)")
+		void 생성시_적재_실패는_즉시() {
+			assertThrows(IllegalStateException.class,
+					() -> new EgovCodeCache(() -> {
+						throw new IllegalStateException("DB down");
+					}));
+		}
+
+		@Test
+		@DisplayName("reload 로 스냅숏이 통째로 바뀐다")
+		void reload_교체() {
+			AtomicBoolean updated = new AtomicBoolean(false);
+			EgovCodeCache cache = new EgovCodeCache(() -> updated.get()
+					? List.of(EgovCode.of("COM001", "NEW", "신규"))
+					: sampleCodes());
+
+			updated.set(true);
+			cache.reload();
+
+			assertEquals(1, cache.size());
+			assertEquals(Optional.of("신규"), cache.getName("COM001", "NEW"));
+			assertTrue(cache.getCodes("GENDER").isEmpty(), "사라진 그룹은 스냅숏에서도 사라진다");
+		}
+
+		@Test
+		@DisplayName("같은 그룹의 코드 중복은 데이터 결함으로 즉시 실패한다 — 조용히 덮지 않는다")
+		void 중복_코드_거부() {
+			List<EgovCode> duplicated = Arrays.asList(
+					EgovCode.of("COM001", "A", "하나"),
+					EgovCode.of("COM001", "A", "둘"));
+
+			assertThrows(IllegalStateException.class, () -> cacheOf(duplicated));
+		}
+
+		@Test
+		@DisplayName("로더가 null 을 돌려주면 즉시 실패한다")
+		void 로더_null_거부() {
+			assertThrows(IllegalStateException.class, () -> new EgovCodeCache(() -> null));
+		}
+
+		@Test
+		@DisplayName("reload 중에도 조회는 온전한 스냅숏을 본다 — 찢어진 읽기 없음")
+		void 동시성_일관_스냅숏() throws InterruptedException {
+			// 두 상태를 오가며 reload 를 반복하고, 조회 스레드는 항상
+			// "어느 한쪽의 완전한 상태"만 관찰해야 한다.
+			AtomicBoolean flip = new AtomicBoolean(false);
+			List<EgovCode> stateA = Arrays.asList(
+					EgovCode.of("G", "A1", "a1"), EgovCode.of("G", "A2", "a2"));
+			List<EgovCode> stateB = Arrays.asList(
+					EgovCode.of("G", "B1", "b1"), EgovCode.of("G", "B2", "b2"), EgovCode.of("G", "B3", "b3"));
+			EgovCodeCache cache = new EgovCodeCache(() -> flip.get() ? stateB : stateA);
+
+			AtomicBoolean torn = new AtomicBoolean(false);
+			CountDownLatch done = new CountDownLatch(1);
+			ExecutorService executor = Executors.newFixedThreadPool(4);
+			try {
+				for (int t = 0; t < 3; t++) {
+					executor.execute(() -> {
+						while (done.getCount() > 0) {
+							List<EgovCode> seen = cache.getCodes("G");
+							if (seen.size() != 2 && seen.size() != 3) {
+								torn.set(true);
+							}
+						}
+					});
+				}
+				for (int i = 0; i < 200; i++) {
+					flip.set(!flip.get());
+					cache.reload();
+				}
+			} finally {
+				done.countDown();
+				executor.shutdown();
+				assertTrue(executor.awaitTermination(5, TimeUnit.SECONDS));
+			}
+
+			assertTrue(!torn.get(), "완전한 스냅숏(2건 또는 3건)만 보여야 한다");
+		}
+	}
+}

--- a/Foundation/org.egovframe.rte.fdl.cmmn/src/test/java/org/egovframe/rte/fdl/cmmn/code/EgovJdbcCodeLoaderTest.java
+++ b/Foundation/org.egovframe.rte.fdl.cmmn/src/test/java/org/egovframe/rte/fdl/cmmn/code/EgovJdbcCodeLoaderTest.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright 2009-2026 MOIS(Ministry of the Interior and Safety).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.egovframe.rte.fdl.cmmn.code;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.hsqldb.jdbc.JDBCDataSource;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+/**
+ * {@link EgovJdbcCodeLoader} 단위 테스트(HSQLDB 인메모리).
+ *
+ * <p>컬럼 별칭 계약 — 필수 3(GROUP_ID·CODE·NAME)·선택 3(DESCRIPTION·ENABLED·SORT_ORDER)과
+ * 사용 여부 문자열 판정, 그리고 {@link EgovCodeCache} 와의 통합을 확인한다.</p>
+ *
+ * <pre>
+ * &lt;&lt; 개정이력(Modification Information) &gt;&gt;
+ *
+ *  수정일        수정자        수정내용
+ *  ----------  --------    ---------------------------
+ *  2026.09.01  실행환경팀     최초 생성
+ * </pre>
+ *
+ * @author 실행환경 개발팀
+ * @since 5.1
+ */
+class EgovJdbcCodeLoaderTest {
+
+	private static JDBCDataSource dataSource;
+
+	@BeforeAll
+	static void setUpDatabase() {
+		dataSource = new JDBCDataSource();
+		dataSource.setUrl("jdbc:hsqldb:mem:egovCodeLoaderTest");
+		dataSource.setUser("sa");
+
+		JdbcTemplate jdbc = new JdbcTemplate(dataSource);
+		jdbc.execute("DROP TABLE COMMON_CODE IF EXISTS");
+		jdbc.execute("CREATE TABLE COMMON_CODE ("
+				+ "CODE_ID VARCHAR(20) NOT NULL, CODE VARCHAR(20) NOT NULL, "
+				+ "CODE_NM VARCHAR(100) NOT NULL, CODE_DC VARCHAR(200), "
+				+ "USE_AT VARCHAR(5), CODE_ORD INT, "
+				+ "PRIMARY KEY (CODE_ID, CODE))");
+		jdbc.update("INSERT INTO COMMON_CODE VALUES ('COM001', 'A01', '정상', '정상 상태', 'Y', 1)");
+		jdbc.update("INSERT INTO COMMON_CODE VALUES ('COM001', 'A02', '중지', NULL, 'N', 2)");
+		jdbc.update("INSERT INTO COMMON_CODE VALUES ('COM001', 'A03', '대기', '', 'true', 3)");
+		jdbc.update("INSERT INTO COMMON_CODE VALUES ('GENDER', 'M', '남성', NULL, '1', 0)");
+	}
+
+	private static final String FULL_SQL =
+			"SELECT CODE_ID AS GROUP_ID, CODE, CODE_NM AS NAME, CODE_DC AS DESCRIPTION, "
+					+ "USE_AT AS ENABLED, CODE_ORD AS SORT_ORDER FROM COMMON_CODE";
+
+	@Test
+	@DisplayName("6컬럼 전부 — 값이 그대로 매핑된다")
+	void 전체_컬럼_매핑() {
+		List<EgovCode> codes = new EgovJdbcCodeLoader(dataSource, FULL_SQL).loadAll();
+
+		assertEquals(4, codes.size());
+		EgovCode a01 = codes.stream()
+				.filter(c -> "COM001".equals(c.getGroupId()) && "A01".equals(c.getCode()))
+				.findFirst().orElseThrow();
+		assertEquals("정상", a01.getName());
+		assertEquals("정상 상태", a01.getDescription());
+		assertTrue(a01.isEnabled());
+		assertEquals(1, a01.getSortOrder());
+	}
+
+	@Test
+	@DisplayName("사용 여부 판정 — Y·true·1 은 사용 중, N 은 사용 안 함")
+	void 사용여부_판정() {
+		List<EgovCode> codes = new EgovJdbcCodeLoader(dataSource, FULL_SQL).loadAll();
+
+		assertTrue(find(codes, "A01").isEnabled(), "Y");
+		assertTrue(!find(codes, "A02").isEnabled(), "N");
+		assertTrue(find(codes, "A03").isEnabled(), "true");
+		assertTrue(find(codes, "M").isEnabled(), "1");
+	}
+
+	@Test
+	@DisplayName("필수 3컬럼만으로도 동작한다 — 사용 중·정렬 0 이 기본")
+	void 필수_컬럼만() {
+		List<EgovCode> codes = new EgovJdbcCodeLoader(dataSource,
+				"SELECT CODE_ID AS GROUP_ID, CODE, CODE_NM AS NAME FROM COMMON_CODE").loadAll();
+
+		assertEquals(4, codes.size());
+		EgovCode a02 = find(codes, "A02");
+		assertTrue(a02.isEnabled(), "ENABLED 컬럼이 없으면 사용 중으로 본다");
+		assertEquals(0, a02.getSortOrder());
+		assertEquals("", a02.getDescription());
+	}
+
+	@Test
+	@DisplayName("필수 별칭이 빠지면 즉시 실패한다 — 잘못된 SQL 이 빈 결과로 무마되지 않는다")
+	void 필수_별칭_누락() {
+		EgovJdbcCodeLoader loader = new EgovJdbcCodeLoader(dataSource,
+				"SELECT CODE_ID, CODE, CODE_NM FROM COMMON_CODE");   // 별칭 없음
+
+		assertThrows(RuntimeException.class, loader::loadAll);
+	}
+
+	@Test
+	@DisplayName("NULL 설명은 빈 문자열이 된다")
+	void null_설명() {
+		List<EgovCode> codes = new EgovJdbcCodeLoader(dataSource, FULL_SQL).loadAll();
+
+		assertEquals("", find(codes, "A02").getDescription());
+	}
+
+	@Test
+	@DisplayName("생성 인자 검증 — dataSource·sql 필수")
+	void 생성_인자() {
+		assertThrows(IllegalArgumentException.class, () -> new EgovJdbcCodeLoader(null, FULL_SQL));
+		assertThrows(IllegalArgumentException.class, () -> new EgovJdbcCodeLoader(dataSource, " "));
+	}
+
+	@Test
+	@DisplayName("캐시와 통합 — DB 코드가 스냅숏으로 조회된다")
+	void 캐시_통합() {
+		EgovCodeCache cache = new EgovCodeCache(new EgovJdbcCodeLoader(dataSource, FULL_SQL));
+
+		assertEquals(Optional.of("정상"), cache.getName("COM001", "A01"));
+		assertEquals(List.of("A01", "A03"),
+				cache.getActiveCodes("COM001").stream().map(EgovCode::getCode).toList());
+		assertEquals(3, cache.getCodes("COM001").size(), "사용 안 함(A02) 포함");
+	}
+
+	private static EgovCode find(List<EgovCode> codes, String code) {
+		return codes.stream().filter(c -> code.equals(c.getCode())).findFirst().orElseThrow();
+	}
+}


### PR DESCRIPTION
> **[공통컴포넌트 공통 기능 개선 → 실행환경 이관]**
>
> 공통컴포넌트에 있던 공통 기능을 개선해 실행환경으로 올리는 항목입니다.
> 실행환경에 올라가면 공통컴포넌트를 포함한 모든 사업에서 같은 구현을 쓸 수 있습니다.
>
> 공통컴포넌트 원본
> - `egovframework.com.cmm.service.EgovCmmUseService`

## 수정 사유 Reason for modification

- [ ] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [X] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

### 배경

코드 테이블(공통코드)은 **화면마다 셀렉트 박스를 채우는 데 쓰여 조회가 잦은데 값은 거의
바뀌지 않습니다.** 실행환경에 캐시 수단이 없어 요청마다 DB 를 다시 읽거나, 사업마다 정적
`Map` 을 만들어 **재기동해야 갱신되는** 형태가 됩니다.

공통컴포넌트 `EgovCmmUseService` 가 그 예로, 매 조회가 DAO 로 직행하고 복수 그룹을 읽을 때
**그룹 수만큼 쿼리가 나갑니다(N+1)**.

### 추가한 것

| 클래스 | 역할 |
|---|---|
| `code/EgovCodeCache` | 코드 그룹별 조회 캐시 |
| `code/EgovCodeLoader` | 적재 SPI |
| `code/EgovInMemoryCodeLoader` | 테스트·소규모 고정 코드용 |
| `code/EgovJdbcCodeLoader` | `DataSource` 기반. 조회 SQL 과 컬럼 별칭을 지정 |
| `code/EgovCode` | 코드 값 객체(그룹·코드·코드명·설명·정렬순서·사용여부) |

조회는 **불변 스냅숏**에서 이뤄지고, `reload` 는 새 스냅숏을 만들어 **원자적으로 교체**합니다.
갱신 중에도 조회가 막히거나 반쯤 갱신된 상태가 보이지 않습니다.

### 설계 메모

- **캐시 만료를 시간으로 두지 않습니다.** 코드 변경 시점을 아는 쪽은 애플리케이션이므로
  `reload` 를 명시적으로 호출하게 했습니다. 시간 만료는 *"언제 반영되는지 아무도 모르는"*
  상태를 만듭니다
- **생성 시 즉시 적재합니다(fail-fast).** 원천 장애가 기동 실패로 드러나야, 코드가 빈 채로
  운영에 올라가는 일이 없습니다
- **`reload` 실패 시 기존 스냅숏을 유지하고 예외로 알립니다** — 갱신에 실패했는데 조용히
  넘어가면 낡은 값이 최신인 것처럼 보입니다
- **`getActiveCodes`(사용 중만)와 `getCodes`(사용 안 함 포함)를 나눴습니다.** 셀렉트박스는
  전자, 과거 데이터의 이름 표시는 후자가 필요합니다
- **없는 그룹·`null` 은 빈 결과**입니다. 화면 구성 중 예외가 나면 페이지 전체가 깨집니다
- **같은 그룹의 코드 중복은 데이터 결함으로 즉시 실패**합니다. 조용히 덮으면 어느 쪽이
  살아남았는지 알 수 없습니다
- 반환 목록은 **불변**입니다

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

**26건 신규**(`EgovCodeCacheTest` 15 · `EgovJdbcCodeLoaderTest` 7 · 보안 회귀 `EgovCodeCacheSecurityTest` 4), `fdl.cmmn` 모듈 전건 통과.

| 환경 | 기본 로케일(Locale) | 모듈 실행 건수 | 결과 |
|---|---|---:|---|
| **Windows** | ko_KR | **68** | `Tests run: 68, Failures: 0, Errors: 0, Skipped: 0` |
| **Linux** (Ubuntu 22.04 / OpenJDK 17) | C.UTF-8 | **68** | `Tests run: 68, Failures: 0, Errors: 0, Skipped: 0` |

| 구분 | 건수 | 내용 |
|---|---:|---|
| **원본 결함 회귀** | 3 | **조회 1만 번에 원천 접근 1번**(원본은 매 조회 DAO 직행) · **복수 그룹에 N+1 없음** · `reload` 실패 시 기존 스냅숏 유지 + 예외 |
| 조회 | 7 | 정렬순서→코드 순 · `getActiveCodes` · `getCodes` · 코드→이름 지름길 · 없는 그룹·`null` 은 빈 결과 · 반환 불변 · 그룹 목록과 전체 건수 |
| 적재·갱신 | 5 | **생성 시 즉시 적재(fail-fast)** · `reload` 스냅숏 교체 · **코드 중복 즉시 실패** · 로더 `null` 즉시 실패 · **`reload` 중에도 찢어진 읽기 없음** |
| JDBC 로더 | 7 | 6컬럼 매핑 · 사용여부 판정(`Y`·`true`·`1`) · 필수 3컬럼만으로 동작 · **필수 별칭 누락 시 즉시 실패**(잘못된 SQL 이 빈 결과로 무마되지 않음) · `NULL` 설명 · 생성 인자 검증 · 캐시 통합 |

`EgovCodeCacheSecurityTest` 4건 — 호출자가 제어하는 미존재 키 **100만 건 조회에도 원천 호출·항목 증가 없음**(부정 캐시 없음) · 반환 컬렉션 불변 · 로더 목록 사후 변경으로부터의 스냅숏 격리 · 로더가 막힌 동안에도 기존 스냅숏 유지.

**수동 확인**: JDBC 로더 테스트는 HSQLDB 인메모리로 동작하며 외부 DB 가 필요 없습니다.
Linux(`C.UTF-8`)에서도 동일하게 통과함을 확인했습니다.

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

해당 없음 — 라이브러리 클래스 추가입니다.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

해당 없음 — 위 JUnit 테스트 결과로 갈음합니다.

---

<sub>base: `eGovFramework:main` @ `cd9fd9c` (2026-09-08 fetch 기준) · 단일 커밋</sub>
