### PR TITLE
feat: 기본 로깅 ExceptionHandler 구현체 EgovLoggingExceptionHandler 추가

### DIFF
--- a/Foundation/org.egovframe.rte.fdl.cmmn/src/main/java/org/egovframe/rte/fdl/cmmn/exception/handler/EgovLoggingExceptionHandler.java
+++ b/Foundation/org.egovframe.rte.fdl.cmmn/src/main/java/org/egovframe/rte/fdl/cmmn/exception/handler/EgovLoggingExceptionHandler.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2009-2026 MOIS(Ministry of the Interior and Safety).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.egovframe.rte.fdl.cmmn.exception.handler;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * 발생한 예외를 <b>로그로 남기는</b> 기본 {@link ExceptionHandler} 구현체.
+ *
+ * <p><b>NOTE:</b> {@code ExceptionHandler} 는 인터페이스만 제공되어, "일단 로그만 남기면
+ * 되는" 가장 흔한 경우에도 프로젝트마다 같은 클래스를 새로 만들어야 했다. 예외 추적
+ * ({@code TraceHandler})은 기본 구현이 제공되는데 예외 처리는 아니었던 <b>비대칭</b>을 없앤다.</p>
+ *
+ * <pre>
+ * &lt;bean id="defaultExceptionHandler"
+ *       class="org.egovframe.rte.fdl.cmmn.exception.handler.EgovLoggingExceptionHandler" /&gt;
+ *
+ * &lt;bean id="exceptionHandleManager"
+ *       class="org.egovframe.rte.fdl.cmmn.exception.manager.DefaultExceptionHandleManager"&gt;
+ *     &lt;property name="patterns"&gt;&lt;list&gt;&lt;value&gt;**service.impl.*&lt;/value&gt;&lt;/list&gt;&lt;/property&gt;
+ *     &lt;property name="handlers"&gt;&lt;list&gt;&lt;ref bean="defaultExceptionHandler" /&gt;&lt;/list&gt;&lt;/property&gt;
+ * &lt;/bean&gt;
+ * </pre>
+ *
+ * <p><b>로거를 발생 위치 이름으로 잡는다.</b> {@code occur} 에 넘어오는 {@code packageName}
+ * 으로 로거를 얻으므로 {@code org.example.board} 처럼 <b>패키지별로 로그 레벨을 조정</b>할 수
+ * 있다. 핸들러 클래스 이름 하나로 로거를 고정하면(공통컴포넌트 원본이 그랬다) 어느 업무에서
+ * 난 예외든 같은 로거로 찍혀 걸러낼 수 없다.</p>
+ *
+ * <p>기본 레벨은 {@code ERROR} 이며 {@link #setLogLevel(Level)} 로 낮출 수 있다 —
+ * 업무 예외처럼 정상 흐름의 일부인 경우 {@code WARN} 이 적절할 때가 있다.</p>
+ *
+ * <p><b>로그 위조(CWE-117) 경계.</b> 이 핸들러는 예외 메시지의 개행(CR/LF)을 중화하지 않는다 — 예외를
+ * throwable 로 넘기므로 중화 지점은 로그 레이아웃이다. 사용자 입력이 예외 메시지에 실릴 수 있는 배치라면
+ * 패턴 레이아웃에 {@code %enc{%m}{CRLF}} 와 throwable 평탄화({@code %replace{%xEx}{[\r\n]+}{ | }})를 둔다.</p>
+ *
+ * <pre>
+ * &lt;&lt; 개정이력(Modification Information) &gt;&gt;
+ *
+ *  수정일        수정자        수정내용
+ *  ----------  --------    ---------------------------
+ *  2026.09.01  실행환경팀     최초 생성 (공통컴포넌트 EgovComExcepHndlr ·
+ *                            EgovComOthersExcepHndlr 의 역할만 차용 — 원본은 두 클래스가
+ *                            사실상 같은 한 줄(LOGGER.error)이고 메일 발송 코드는 전부
+ *                            주석 처리된 채였으며, 로거가 핸들러 클래스로 고정되어
+ *                            발생 위치별 로그 제어가 불가능했다. 코드 이식 아님)
+ *  2026.09.07  실행환경팀     로그 위조(CWE-117) 경계 명시 — CR/LF 중화는 레이아웃 책임
+ *                            (코드 변경 없음)
+ * </pre>
+ *
+ * @author 실행환경 개발팀
+ * @since 5.1
+ */
+public class EgovLoggingExceptionHandler implements ExceptionHandler {
+
+	/** {@code packageName} 이 비어 있을 때 쓰는 로거 이름. */
+	private static final String FALLBACK_LOGGER_NAME = EgovLoggingExceptionHandler.class.getName();
+
+	private Level logLevel = Level.ERROR;
+
+	/**
+	 * 예외를 기록한다.
+	 *
+	 * <p>인자가 어떤 상태든 <b>예외를 다시 던지지 않는다</b> — 예외 처리 중에 또 예외가 나면
+	 * 원래 예외가 묻히기 때문이다.</p>
+	 *
+	 * @param exception   발생한 예외({@code null} 허용)
+	 * @param packageName 발생 위치(로거 이름으로 쓴다, {@code null} 허용)
+	 */
+	@Override
+	public void occur(Exception exception, String packageName) {
+		Logger logger = LoggerFactory.getLogger(loggerNameOf(packageName));
+		String message = (packageName == null || packageName.trim().isEmpty())
+				? "예외가 발생했습니다" : packageName;
+
+		switch (logLevel) {
+			case WARN:
+				logger.warn(message, exception);
+				break;
+			case INFO:
+				logger.info(message, exception);
+				break;
+			case DEBUG:
+				logger.debug(message, exception);
+				break;
+			case ERROR:
+			default:
+				logger.error(message, exception);
+		}
+	}
+
+	/**
+	 * 기록 레벨을 지정한다(기본 {@code ERROR}).
+	 *
+	 * @param logLevel 레벨({@code null} 이면 {@code ERROR})
+	 */
+	public void setLogLevel(Level logLevel) {
+		this.logLevel = (logLevel == null) ? Level.ERROR : logLevel;
+	}
+
+	/**
+	 * 기록 레벨을 반환한다.
+	 *
+	 * @return 레벨
+	 */
+	public Level getLogLevel() {
+		return logLevel;
+	}
+
+	private static String loggerNameOf(String packageName) {
+		return (packageName == null || packageName.trim().isEmpty())
+				? FALLBACK_LOGGER_NAME : packageName.trim();
+	}
+
+	/**
+	 * 기록 레벨.
+	 */
+	public enum Level {
+
+		/** 오류 — 기본값. */
+		ERROR,
+
+		/** 경고 — 업무 예외처럼 정상 흐름의 일부일 때. */
+		WARN,
+
+		/** 정보. */
+		INFO,
+
+		/** 디버그. */
+		DEBUG
+	}
+}

--- a/Foundation/org.egovframe.rte.fdl.cmmn/src/test/java/org/egovframe/rte/fdl/cmmn/exception/handler/EgovLoggingExceptionHandlerTest.java
+++ b/Foundation/org.egovframe.rte.fdl.cmmn/src/test/java/org/egovframe/rte/fdl/cmmn/exception/handler/EgovLoggingExceptionHandlerTest.java
@@ -1,0 +1,200 @@
+/*
+ * Copyright 2009-2026 MOIS(Ministry of the Interior and Safety).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.egovframe.rte.fdl.cmmn.exception.handler;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.appender.AbstractAppender;
+import org.apache.logging.log4j.core.config.Configuration;
+import org.apache.logging.log4j.core.config.LoggerConfig;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * {@link EgovLoggingExceptionHandler} 단위 테스트.
+ *
+ * <p>핵심은 <b>로거 이름이 발생 위치(packageName)로 잡히는지</b>다 — 공통컴포넌트 원본은
+ * 핸들러 클래스 이름으로 로거를 고정해 업무별 로그 제어가 불가능했다. 실제 로그 이벤트를
+ * 붙잡아 확인한다.</p>
+ *
+ * <pre>
+ * &lt;&lt; 개정이력(Modification Information) &gt;&gt;
+ *
+ *  수정일        수정자        수정내용
+ *  ----------  --------    ---------------------------
+ *  2026.09.01  실행환경팀     최초 생성
+ * </pre>
+ *
+ * @author 실행환경 개발팀
+ * @since 5.1
+ */
+class EgovLoggingExceptionHandlerTest {
+
+	private static final String TARGET_PACKAGE = "org.example.board.service";
+
+	private EgovLoggingExceptionHandler handler;
+
+	private CapturingAppender appender;
+
+	private LoggerConfig loggerConfig;
+
+	@BeforeEach
+	void setUp() {
+		handler = new EgovLoggingExceptionHandler();
+
+		LoggerContext context = (LoggerContext) LogManager.getContext(false);
+		Configuration configuration = context.getConfiguration();
+		appender = new CapturingAppender();
+		appender.start();
+
+		loggerConfig = new LoggerConfig(TARGET_PACKAGE, Level.DEBUG, false);
+		loggerConfig.addAppender(appender, Level.DEBUG, null);
+		configuration.addLogger(TARGET_PACKAGE, loggerConfig);
+		context.updateLoggers();
+	}
+
+	@AfterEach
+	void tearDown() {
+		LoggerContext context = (LoggerContext) LogManager.getContext(false);
+		context.getConfiguration().removeLogger(TARGET_PACKAGE);
+		context.updateLoggers();
+		appender.stop();
+	}
+
+	@Nested
+	@DisplayName("원본 결함 회귀 — 공통컴포넌트 구현이라면 실패한다")
+	class LegacyDefectRegression {
+
+		@Test
+		@DisplayName("로거 이름이 발생 위치가 된다 (원본은 핸들러 클래스로 고정)")
+		void 로거_이름은_발생위치() {
+			handler.occur(new IllegalStateException("실패"), TARGET_PACKAGE);
+
+			List<LogEvent> events = appender.events();
+			assertEquals(1, events.size(), "해당 패키지 로거로 기록돼야 잡힌다");
+			assertEquals(TARGET_PACKAGE, events.get(0).getLoggerName());
+		}
+
+		@Test
+		@DisplayName("발생 위치별로 로그 레벨을 조정할 수 있다")
+		void 패키지별_레벨_제어() {
+			loggerConfig.setLevel(Level.OFF);
+			((LoggerContext) LogManager.getContext(false)).updateLoggers();
+
+			handler.occur(new IllegalStateException("실패"), TARGET_PACKAGE);
+
+			assertTrue(appender.events().isEmpty(), "OFF 로 내리면 기록되지 않아야 한다");
+		}
+	}
+
+	@Nested
+	@DisplayName("기록 동작")
+	class Logging {
+
+		@Test
+		@DisplayName("예외가 스택트레이스와 함께 실린다")
+		void 예외_전달() {
+			IllegalStateException cause = new IllegalStateException("실패");
+
+			handler.occur(cause, TARGET_PACKAGE);
+
+			LogEvent event = appender.events().get(0);
+			assertEquals(cause, event.getThrown());
+			assertEquals(TARGET_PACKAGE, event.getMessage().getFormattedMessage());
+		}
+
+		@Test
+		@DisplayName("기본 레벨은 ERROR")
+		void 기본_레벨() {
+			assertEquals(EgovLoggingExceptionHandler.Level.ERROR, handler.getLogLevel());
+
+			handler.occur(new IllegalStateException(), TARGET_PACKAGE);
+
+			assertEquals(Level.ERROR, appender.events().get(0).getLevel());
+		}
+
+		@Test
+		@DisplayName("레벨을 낮출 수 있다 — 업무 예외는 WARN 이 적절할 때가 있다")
+		void 레벨_변경() {
+			handler.setLogLevel(EgovLoggingExceptionHandler.Level.WARN);
+
+			handler.occur(new IllegalStateException(), TARGET_PACKAGE);
+
+			assertEquals(Level.WARN, appender.events().get(0).getLevel());
+		}
+
+		@Test
+		@DisplayName("레벨에 null 을 주면 ERROR 로 되돌린다")
+		void 레벨_null() {
+			handler.setLogLevel(EgovLoggingExceptionHandler.Level.DEBUG);
+			handler.setLogLevel(null);
+
+			assertEquals(EgovLoggingExceptionHandler.Level.ERROR, handler.getLogLevel());
+		}
+	}
+
+	@Nested
+	@DisplayName("방어적 계약")
+	class Defensive {
+
+		@Test
+		@DisplayName("인자가 null 이어도 예외를 던지지 않는다 — 예외 처리 중에 또 터지면 원인이 묻힌다")
+		void null_인자() {
+			assertDoesNotThrow(() -> handler.occur(null, null));
+			assertDoesNotThrow(() -> handler.occur(new IllegalStateException(), null));
+			assertDoesNotThrow(() -> handler.occur(null, TARGET_PACKAGE));
+		}
+
+		@Test
+		@DisplayName("packageName 이 비면 핸들러 이름으로 기록한다")
+		void 빈_패키지명() {
+			assertDoesNotThrow(() -> handler.occur(new IllegalStateException(), "   "));
+			assertTrue(appender.events().isEmpty(), "대상 패키지 로거로는 가지 않는다");
+		}
+	}
+
+	/** 로그 이벤트를 모아 두는 테스트용 Appender. */
+	private static final class CapturingAppender extends AbstractAppender {
+
+		private final List<LogEvent> events = Collections.synchronizedList(new ArrayList<>());
+
+		private CapturingAppender() {
+			super("capturing", null, null, true, null);
+		}
+
+		@Override
+		public void append(LogEvent event) {
+			events.add(event.toImmutable());
+		}
+
+		private List<LogEvent> events() {
+			return new ArrayList<>(events);
+		}
+	}
+}


### PR DESCRIPTION
> **[공통컴포넌트 공통 기능 개선 → 실행환경 이관]**
>
> 공통컴포넌트에 있던 공통 기능을 개선해 실행환경으로 올리는 항목입니다.
> 실행환경에 올라가면 공통컴포넌트를 포함한 모든 사업에서 같은 구현을 쓸 수 있습니다.
>
> 공통컴포넌트 원본
> - `egovframework.com.cmm.EgovComExcepHndlr`

## 수정 사유 Reason for modification

- [ ] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [X] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

### 배경

`ExceptionTransfer` 는 예외를 후처리 핸들러(`ExceptionHandler`)에 넘기는 확장점을 두고
있으나, **실행환경에 구현체가 하나도 없습니다.** 그래서 이 확장점을 쓰려면 사업마다
인터페이스를 직접 구현해야 하고, 대개 *"로그만 남기는"* 같은 구현을 반복하게 됩니다.

> 최근 머지된 #351 이 핸들러가 설정되지 않았을 때의 `NullPointerException` 을 막아 주었습니다.
> 이 PR 은 그와 **상보적**입니다 — #351 은 *핸들러가 없어도 안전하게* 만들었고, 이 PR 은
> *쓸 만한 기본 핸들러를 제공*합니다.

### 추가한 것

**`exception/handler/EgovLoggingExceptionHandler`** — 즉시 쓸 수 있는 기본 구현

- 예외를 **스택트레이스와 함께** 기록합니다
- **로그 레벨을 설정**할 수 있습니다(기본 `ERROR`)
- 로거 이름을 `occur(exception, packageName)` 의 **`packageName` 으로** 잡습니다

### 설계 메모

- **로거를 핸들러 클래스가 아니라 발생 위치 이름으로 잡는 것이 핵심입니다.** 핸들러
  클래스로 고정하면 모든 예외 로그가 한 로거로 몰려, **발생 위치별로 레벨을 조정하거나
  따로 수집할 수 없습니다**
- `packageName` 이 비면 핸들러 이름으로 되돌립니다
- **인자가 `null` 이어도 예외를 던지지 않습니다.** 예외 처리 중에 또 터지면 원래 원인이
  묻힙니다
- **레벨에 `null` 을 주면 `ERROR` 로 되돌립니다**
- 업무 예외는 `WARN` 이 적절할 때가 있어 레벨을 낮출 수 있게 두었습니다

**기존 클래스는 수정하지 않았습니다** — `ExceptionHandler` 인터페이스와 `package.html` 모두
무변경이며, 신규 파일만 추가합니다.

**보안 재검증 반영(2026-09-07)** — 이 핸들러는 예외 메시지의 개행(CR/LF)을 중화하지 않으며 중화 지점은 로그 레이아웃입니다(로그 위조, CWE-117). javadoc 에 `%enc{%m}{CRLF}` 와 throwable 평탄화(`%replace{%xEx}{[\r\n]+}{ | }`) 권고를 명시했습니다. 코드 변경은 없습니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

`EgovLoggingExceptionHandlerTest` **8건 신규**, `fdl.cmmn` 모듈 전건 통과.

| 환경 | 기본 로케일(Locale) | 모듈 실행 건수 | 결과 |
|---|---|---:|---|
| **Windows** | ko_KR | **50** | `Tests run: 50, Failures: 0, Errors: 0, Skipped: 0` |
| **Linux** (Ubuntu 22.04 / OpenJDK 17) | C.UTF-8 | **50** | `Tests run: 50, Failures: 0, Errors: 0, Skipped: 0` |

| 구분 | 건수 | 내용 |
|---|---:|---|
| **원본 결함 회귀** | 2 | **로거 이름이 발생 위치가 된다**(원본은 핸들러 클래스로 고정) · 발생 위치별 레벨 조정 가능 |
| 기록 동작 | 4 | 스택트레이스 동반 · 기본 `ERROR` · 레벨 낮추기 · **레벨 `null` 은 `ERROR` 로 복귀** |
| 방어적 계약 | 2 | **인자 `null` 무예외**(예외 처리 중 2차 실패 방지) · `packageName` 공백 시 핸들러 이름 |

**수동 확인**: 이 PR 이 닿는 `exception/handler/` 패키지가 최근 머지(#351·#352)의 인접
구역이므로, **현재 `main` 위에서** 빌드·테스트가 통과함을 확인했습니다.

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

해당 없음 — 라이브러리 클래스 추가입니다.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

해당 없음 — 위 JUnit 테스트 결과로 갈음합니다.

---

<sub>base: `eGovFramework:main` @ `cd9fd9c` (2026-09-08 fetch 기준) · 단일 커밋</sub>
