### PR TITLE
feat: 세션 만료시각 쿠키 필터와 안전 쿠키 빌더 추가

### DIFF
--- a/Presentation/org.egovframe.rte.ptl.mvc/src/main/java/org/egovframe/rte/ptl/mvc/cookie/EgovCookies.java
+++ b/Presentation/org.egovframe.rte.ptl.mvc/src/main/java/org/egovframe/rte/ptl/mvc/cookie/EgovCookies.java
@@ -1,0 +1,383 @@
+/*
+ * Copyright 2009-2026 MOIS(Ministry of the Interior and Safety).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.egovframe.rte.ptl.mvc.cookie;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import java.net.URLDecoder;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * 안전 기본값이 붙는 쿠키 빌더 + 읽기·삭제 헬퍼.
+ *
+ * <p>Servlet 6 {@link Cookie} 도 Spring {@code ResponseCookie} 도 기본값이 비어 있어(SameSite 없음·
+ * HttpOnly false·Secure false) 개발자가 빠뜨리면 그대로 나간다. 이 빌더는 <b>빠뜨릴 수 없는
+ * 기본값</b>을 강제하고, 브라우저가 폐기하는 조합과 주입 가능한 값을 <b>생성 시점에 거부</b>한다.</p>
+ *
+ * <table border="1">
+ *   <caption>기본값</caption>
+ *   <tr><th>속성</th><th>기본</th><th>비고</th></tr>
+ *   <tr><td>HttpOnly</td><td>true</td><td>{@link Builder#httpOnly(boolean)} 로 명시 해제</td></tr>
+ *   <tr><td>SameSite</td><td>Lax</td><td>Strict·None 선택 가능, 빈 값이면 미설정</td></tr>
+ *   <tr><td>Secure</td><td>요청이 보안 채널이면 자동</td><td>{@link Builder#secure(boolean)} 명시가 우선</td></tr>
+ *   <tr><td>Path</td><td>컨텍스트 루트</td><td>요청 경로에 따라 달라지는 Servlet 기본값을 쓰지 않는다</td></tr>
+ * </table>
+ *
+ * <pre>
+ * EgovCookies.builder("theme", "dark").maxAge(Duration.ofDays(30)).addTo(request, response);
+ * EgovCookies.builder("name", "홍길동").encodeValue().addTo(request, response);   // 비 ASCII 는 인코딩 선택
+ * Optional&lt;String&gt; theme = EgovCookies.value(request, "theme");
+ * EgovCookies.expire("theme").addTo(request, response);                        // 같은 Path 로 삭제
+ * </pre>
+ *
+ * <p><b>거부 규칙(IAE)</b>: {@code SameSite=None} 인데 Secure 가 아님(브라우저가 폐기) · 이름이 RFC 6265
+ * token 이 아님 · 이름·값에 제어 문자·CR/LF·{@code ;} 포함(헤더 주입) · 값이 cookie-octet 밖
+ * 문자(공백·{@code "}·{@code ,}·{@code \}·비 ASCII)를 포함하는데 {@link Builder#encodeValue()} 를
+ * 선택하지 않음. 원본(공통컴포넌트 {@code EgovSessionCookieUtil})처럼 CRLF 를 조용히 지우는
+ * 정제는 하지 않는다 — 잘못된 입력은 실패가 맞다(설계 원칙 4).</p>
+ *
+ * <p><b>Secure 자동 판정과 프록시</b>: HTTPS 종단이 리버스 프록시에 있으면 컨테이너가 보는
+ * {@code request.isSecure()} 는 false 다. 표준 경로는 forward 헤더 신뢰 설정(Boot
+ * {@code server.forward-headers-strategy}, Tomcat {@code RemoteIpValve})이고, 그것이 없으면
+ * {@code secure(true)} 를 명시한다. 원본처럼 무조건 true 로 두면 HTTP 개발환경에서 쿠키가
+ * 저장되지 않는 침묵 미동작이 생기므로 자동이 기본이다.</p>
+ *
+ * <pre>
+ * &lt;&lt; 개정이력(Modification Information) &gt;&gt;
+ *
+ *  수정일        수정자        수정내용
+ *  ----------  --------    ---------------------------
+ *  2026.09.02  실행환경팀     최초 생성 (안전 기본값 쿠키 빌더 — 원본 EgovSessionCookieUtil 은
+ *                            SameSite 전무·Secure 하드코딩·CRLF 정제 편측·path 미설정·부재 이원화
+ *                            결함에 소비처 0건이라 계약(set·get·delete)만 참고, 코드 이식 없음)
+ * </pre>
+ *
+ * @author 실행환경 개발팀
+ * @since 5.1
+ */
+public final class EgovCookies {
+
+	/** SameSite=Lax — 기본값. 외부 링크 진입(top-level GET)에는 쿠키가 실리고 교차 사이트 POST 에는 실리지 않는다. */
+	public static final String SAME_SITE_LAX = "Lax";
+
+	/** SameSite=Strict — 외부 링크 진입에도 쿠키가 실리지 않는다(로그인 유지가 끊기는 흔한 함정). */
+	public static final String SAME_SITE_STRICT = "Strict";
+
+	/** SameSite=None — 교차 사이트 허용. 반드시 Secure 여야 한다(아니면 생성 거부). */
+	public static final String SAME_SITE_NONE = "None";
+
+	private static final String ATTR_SAME_SITE = "SameSite";
+	private static final String ATTR_PARTITIONED = "Partitioned";
+
+	private EgovCookies() {
+	}
+
+	/**
+	 * 발급 빌더를 연다.
+	 *
+	 * @param name  쿠키 이름(RFC 6265 token)
+	 * @param value 쿠키 값(cookie-octet — 비 ASCII·공백 등은 {@link Builder#encodeValue()} 필요)
+	 * @throws IllegalArgumentException 이름이 token 이 아니거나 값에 제어 문자·CR/LF·{@code ;} 가 있는 경우
+	 */
+	public static Builder builder(String name, String value) {
+		return new Builder(name, value, false);
+	}
+
+	/**
+	 * 삭제 빌더를 연다 — 빈 값·{@code Max-Age=0}. 발급 때와 <b>같은 Path·Domain</b> 을 지정해야
+	 * 브라우저가 같은 쿠키로 본다(기본값끼리는 자동 정합).
+	 *
+	 * @param name 삭제할 쿠키 이름
+	 */
+	public static Builder expire(String name) {
+		return new Builder(name, "", true);
+	}
+
+	/**
+	 * 요청에서 쿠키 값을 읽는다. 쿠키가 전혀 없거나 이름이 없으면 <b>둘 다</b> 빈 Optional —
+	 * 원본의 {@code ""}/{@code null} 이원화를 단일 표현으로 교정.
+	 */
+	public static Optional<String> value(HttpServletRequest request, String name) {
+		Objects.requireNonNull(request, "request must not be null");
+		Objects.requireNonNull(name, "name must not be null");
+		Cookie[] cookies = request.getCookies();
+		if (cookies == null) {
+			return Optional.empty();
+		}
+		for (Cookie cookie : cookies) {
+			if (name.equals(cookie.getName())) {
+				return Optional.ofNullable(cookie.getValue());
+			}
+		}
+		return Optional.empty();
+	}
+
+	/**
+	 * {@link Builder#encodeValue()} 로 발급한 쿠키의 값을 URL 디코딩해 읽는다(발급의 대칭).
+	 * 쿠키 값은 클라이언트가 임의로 바꿀 수 있으므로, 디코딩할 수 없는 값(깨진 퍼센트 인코딩)은
+	 * 예외 대신 <b>빈 Optional</b> 로 다룬다 — 이 헬퍼가 발급한 값은 항상 디코딩된다.
+	 */
+	public static Optional<String> decodedValue(HttpServletRequest request, String name) {
+		return value(request, name).flatMap(EgovCookies::decodeOrEmpty);
+	}
+
+	private static Optional<String> decodeOrEmpty(String encoded) {
+		try {
+			return Optional.of(URLDecoder.decode(encoded, StandardCharsets.UTF_8));
+		} catch (IllegalArgumentException malformed) {
+			return Optional.empty();
+		}
+	}
+
+	/**
+	 * {@link EgovCookies} 빌더 — 미지정 속성은 안전 기본값.
+	 */
+	public static final class Builder {
+
+		private final String name;
+		private final String value;
+		private final boolean expiring;
+		private boolean httpOnly = true;
+		private String sameSite = SAME_SITE_LAX;
+		private Boolean secure;
+		private String path;
+		private String domain;
+		private int maxAge = -1;
+		private boolean partitioned;
+		private boolean encodeValue;
+
+		private Builder(String name, String value, boolean expiring) {
+			this.name = validName(name);
+			this.value = validRawValue(value);
+			this.expiring = expiring;
+			if (expiring) {
+				this.maxAge = 0;
+			}
+		}
+
+		/** HttpOnly 여부(기본 true). 화면 스크립트가 읽어야 하는 쿠키만 false 로 명시한다. */
+		public Builder httpOnly(boolean httpOnly) {
+			this.httpOnly = httpOnly;
+			return this;
+		}
+
+		/**
+		 * SameSite — {@code Lax}·{@code Strict}·{@code None}(대소문자 무시, 표준 표기로 정규화).
+		 * null 이나 빈 값이면 속성을 붙이지 않는다(명시 해제).
+		 *
+		 * @throws IllegalArgumentException 세 값 외의 문자열
+		 */
+		public Builder sameSite(String sameSite) {
+			if (sameSite == null || sameSite.trim().isEmpty()) {
+				this.sameSite = null;
+				return this;
+			}
+			String canonical = canonicalSameSite(sameSite.trim());
+			if (canonical == null) {
+				throw new IllegalArgumentException("sameSite must be Lax, Strict or None: " + sameSite);
+			}
+			this.sameSite = canonical;
+			return this;
+		}
+
+		/** Secure 명시 — 지정하면 요청 채널 자동 판정보다 우선한다. */
+		public Builder secure(boolean secure) {
+			this.secure = secure;
+			return this;
+		}
+
+		/** Path(기본 컨텍스트 루트). 삭제 시 발급과 같은 값을 써야 한다. */
+		public Builder path(String path) {
+			this.path = validAttribute("path", path);
+			return this;
+		}
+
+		/** Domain(기본 미설정 = 발급 호스트). */
+		public Builder domain(String domain) {
+			this.domain = validAttribute("domain", domain);
+			return this;
+		}
+
+		/** Max-Age(초). -1 이면 세션 쿠키(기본). 삭제 빌더는 0 고정. */
+		public Builder maxAge(int seconds) {
+			if (expiring) {
+				throw new IllegalStateException("expire() cookie has Max-Age fixed to 0");
+			}
+			if (seconds < -1) {
+				throw new IllegalArgumentException("maxAge must be >= -1: " + seconds);
+			}
+			this.maxAge = seconds;
+			return this;
+		}
+
+		/** Max-Age 를 기간으로 지정한다(초 단위로 내림, 최대 int 범위). */
+		public Builder maxAge(Duration duration) {
+			Objects.requireNonNull(duration, "duration must not be null");
+			long seconds = duration.getSeconds();
+			if (seconds > Integer.MAX_VALUE) {
+				throw new IllegalArgumentException("maxAge too large: " + duration);
+			}
+			return maxAge((int) seconds);
+		}
+
+		/** Partitioned(CHIPS) 속성을 붙인다. Secure 가 전제라 None 과 같은 규칙으로 검증된다. */
+		public Builder partitioned() {
+			this.partitioned = true;
+			return this;
+		}
+
+		/**
+		 * 값을 URL 인코딩해 발급한다(UTF-8). 비 ASCII·공백·따옴표 등 cookie-octet 밖 문자가 있을 때
+		 * 선택한다. 읽을 때는 {@link EgovCookies#decodedValue(HttpServletRequest, String)}.
+		 */
+		public Builder encodeValue() {
+			this.encodeValue = true;
+			return this;
+		}
+
+		/**
+		 * 쿠키를 만든다. Secure 미지정 시 {@code request.isSecure()} 로, Path 미지정 시 컨텍스트 루트로
+		 * 채운다.
+		 *
+		 * @param request 발급 요청(자동 판정용 — null 이면 Secure=false·Path="/")
+		 * @throws IllegalArgumentException None/Partitioned 인데 Secure 가 아님, 값이 cookie-octet 밖인데
+		 *                                  인코딩 미선택
+		 */
+		public Cookie build(HttpServletRequest request) {
+			String cookieValue = encodeValue
+					? URLEncoder.encode(value, StandardCharsets.UTF_8)
+					: requireCookieOctets(value);
+			boolean effectiveSecure = (secure != null) ? secure : (request != null && request.isSecure());
+			if (!effectiveSecure && SAME_SITE_NONE.equals(sameSite)) {
+				throw new IllegalArgumentException("SameSite=None requires Secure — browsers reject it otherwise"
+						+ " (cookie '" + name + "')");
+			}
+			if (!effectiveSecure && partitioned) {
+				throw new IllegalArgumentException("Partitioned requires Secure (cookie '" + name + "')");
+			}
+			Cookie cookie = new Cookie(name, cookieValue);
+			cookie.setHttpOnly(httpOnly);
+			cookie.setSecure(effectiveSecure);
+			cookie.setPath((path != null) ? path : contextRoot(request));
+			if (domain != null) {
+				cookie.setDomain(domain);
+			}
+			cookie.setMaxAge(maxAge);
+			if (sameSite != null) {
+				cookie.setAttribute(ATTR_SAME_SITE, sameSite);
+			}
+			if (partitioned) {
+				cookie.setAttribute(ATTR_PARTITIONED, "");
+			}
+			return cookie;
+		}
+
+		/** {@link #build(HttpServletRequest)} 후 응답에 추가한다. */
+		public Cookie addTo(HttpServletRequest request, HttpServletResponse response) {
+			Objects.requireNonNull(response, "response must not be null");
+			Cookie cookie = build(request);
+			response.addCookie(cookie);
+			return cookie;
+		}
+
+		private static String contextRoot(HttpServletRequest request) {
+			if (request == null) {
+				return "/";
+			}
+			String contextPath = request.getContextPath();
+			return (contextPath == null || contextPath.isEmpty()) ? "/" : contextPath;
+		}
+
+		private static String canonicalSameSite(String value) {
+			switch (value.toLowerCase(Locale.ROOT)) {
+				case "lax":
+					return SAME_SITE_LAX;
+				case "strict":
+					return SAME_SITE_STRICT;
+				case "none":
+					return SAME_SITE_NONE;
+				default:
+					return null;
+			}
+		}
+
+	}
+
+	// ---------------------------------------------------------------- 검증
+
+	/** RFC 6265 token — 제어 문자·구분자(`()<>@,;:\"/[]?={} 공백 탭`) 제외. */
+	private static String validName(String name) {
+		Objects.requireNonNull(name, "name must not be null");
+		if (name.isEmpty()) {
+			throw new IllegalArgumentException("cookie name must not be empty");
+		}
+		for (int i = 0; i < name.length(); i++) {
+			char c = name.charAt(i);
+			if (c <= 0x20 || c >= 0x7F || "()<>@,;:\\\"/[]?={}".indexOf(c) >= 0) {
+				throw new IllegalArgumentException("cookie name is not an RFC 6265 token: '" + name + "'");
+			}
+		}
+		return name;
+	}
+
+	/** 인코딩 여부와 무관하게 절대 허용하지 않는 문자 — 제어 문자·CR/LF·{@code ;}. */
+	private static String validRawValue(String value) {
+		Objects.requireNonNull(value, "value must not be null");
+		for (int i = 0; i < value.length(); i++) {
+			char c = value.charAt(i);
+			if (c < 0x20 || c == 0x7F || c == ';') {
+				throw new IllegalArgumentException("cookie value contains a control character or ';' (header injection)");
+			}
+		}
+		return value;
+	}
+
+	/** RFC 6265 cookie-octet: %x21 / %x23-2B / %x2D-3A / %x3C-5B / %x5D-7E. */
+	private static String requireCookieOctets(String value) {
+		for (int i = 0; i < value.length(); i++) {
+			char c = value.charAt(i);
+			boolean ok = c == 0x21 || (c >= 0x23 && c <= 0x2B) || (c >= 0x2D && c <= 0x3A)
+					|| (c >= 0x3C && c <= 0x5B) || (c >= 0x5D && c <= 0x7E);
+			if (!ok) {
+				throw new IllegalArgumentException("cookie value contains a character outside RFC 6265 cookie-octet"
+						+ " (space, quote, comma, backslash or non-ASCII) — call encodeValue() to URL-encode it");
+			}
+		}
+		return value;
+	}
+
+	private static String validAttribute(String attribute, String value) {
+		Objects.requireNonNull(value, attribute + " must not be null");
+		if (value.trim().isEmpty()) {
+			throw new IllegalArgumentException(attribute + " must not be blank");
+		}
+		for (int i = 0; i < value.length(); i++) {
+			char c = value.charAt(i);
+			if (c < 0x20 || c == 0x7F || c == ';') {
+				throw new IllegalArgumentException(attribute + " contains a control character or ';'");
+			}
+		}
+		return value.trim();
+	}
+
+}

--- a/Presentation/org.egovframe.rte.ptl.mvc/src/main/java/org/egovframe/rte/ptl/mvc/session/EgovSessionExpiry.java
+++ b/Presentation/org.egovframe.rte.ptl.mvc/src/main/java/org/egovframe/rte/ptl/mvc/session/EgovSessionExpiry.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright 2009-2026 MOIS(Ministry of the Interior and Safety).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.egovframe.rte.ptl.mvc.session;
+
+import java.util.Optional;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
+
+/**
+ * 세션 만료 시각 정보 — 서버 시각과 만료 예정 시각을 함께 담는 값 객체.
+ *
+ * <p>세션 잔여 시간을 화면에 표시하려면 <b>서버 시각도 함께</b> 필요하다. 클라이언트 시계는
+ * 서버와 어긋나 있을 수 있으므로, 남은 시간은 "만료 시각 − <b>서버</b> 시각"으로 계산한 뒤
+ * 그 시점부터 브라우저에서 흘려보내야 한다.</p>
+ *
+ * <p><b>쿠키를 거치지 않고 바로 쓸 수 있다.</b> {@link EgovSessionExpiryCookieFilter} 가
+ * 쿠키로도 실어 보내지만, 쿠키는 <b>다음 요청부터</b> 브라우저가 되돌려 주므로 최초 진입
+ * 화면에서는 값이 비어 있다. 컨트롤러에서 이 클래스로 값을 직접 얻어 모델에 담으면
+ * 그 문제가 없다.</p>
+ *
+ * <pre>
+ * EgovSessionExpiry.from(request)
+ *         .ifPresent(expiry -&gt; model.addAttribute("sessionExpiry", expiry));
+ * </pre>
+ *
+ * <p><b>무제한 세션</b>({@code maxInactiveInterval} 이 0 이하)이면 {@link #getExpiryTime()} 이
+ * {@link #UNLIMITED}(-1)를 반환한다. 화면은 이 값을 보고 카운트다운을 하지 않으면 된다.</p>
+ *
+ * <pre>
+ * &lt;&lt; 개정이력(Modification Information) &gt;&gt;
+ *
+ *  수정일        수정자        수정내용
+ *  ----------  --------    ---------------------------
+ *  2026.09.01  실행환경팀     최초 생성 (공통컴포넌트 SessionTimeoutCookieFilter 가
+ *                            필터 안에 계산을 묻어 두어 쿠키를 거쳐야만 값을 얻을 수 있던
+ *                            구조를, 서버에서 바로 조회 가능한 값 객체로 분리)
+ * </pre>
+ *
+ * @author 실행환경 개발팀
+ * @since 5.1
+ * @see EgovSessionExpiryCookieFilter
+ */
+public final class EgovSessionExpiry {
+
+	/** 무제한 세션임을 나타내는 만료 시각 값. */
+	public static final long UNLIMITED = -1L;
+
+	private final long serverTime;
+
+	private final long expiryTime;
+
+	private final int maxInactiveIntervalSeconds;
+
+	private EgovSessionExpiry(long serverTime, long expiryTime, int maxInactiveIntervalSeconds) {
+		this.serverTime = serverTime;
+		this.expiryTime = expiryTime;
+		this.maxInactiveIntervalSeconds = maxInactiveIntervalSeconds;
+	}
+
+	/**
+	 * 현재 요청의 세션에서 만료 정보를 얻는다.
+	 *
+	 * <p><b>세션을 새로 만들지 않는다</b>({@code getSession(false)}) — 정적 자원 요청처럼
+	 * 세션이 필요 없는 요청 때문에 세션이 생기면 서버 자원이 낭비된다.</p>
+	 *
+	 * @param request 현재 요청 (null 불가)
+	 * @return 만료 정보. <b>세션이 없으면 빈 Optional</b>
+	 * @throws IllegalArgumentException request 가 null 인 경우
+	 */
+	public static Optional<EgovSessionExpiry> from(HttpServletRequest request) {
+		if (request == null) {
+			throw new IllegalArgumentException("request must not be null");
+		}
+		HttpSession session = request.getSession(false);
+		if (session == null) {
+			return Optional.empty();
+		}
+		return Optional.of(of(session, System.currentTimeMillis()));
+	}
+
+	/**
+	 * 지정한 세션과 기준 시각으로 만료 정보를 만든다.
+	 *
+	 * @param session    대상 세션 (null 불가)
+	 * @param serverTime 기준 서버 시각(epoch millis)
+	 * @return 만료 정보
+	 * @throws IllegalArgumentException session 이 null 인 경우
+	 */
+	public static EgovSessionExpiry of(HttpSession session, long serverTime) {
+		if (session == null) {
+			throw new IllegalArgumentException("session must not be null");
+		}
+		int interval = session.getMaxInactiveInterval();
+		// interval 이 0 이하이면 만료 없음(서블릿 규약). 곱셈은 long 으로 — int 연산은
+		// 약 24.8일을 넘기면 넘침이 생기고, 음수일 때는 과거 시각이 되어 즉시 만료로 오판된다.
+		long expiry = (interval <= 0) ? UNLIMITED : serverTime + (long) interval * 1000L;
+		return new EgovSessionExpiry(serverTime, expiry, interval);
+	}
+
+	/**
+	 * 기준 서버 시각(epoch millis)을 반환한다.
+	 *
+	 * @return 서버 시각
+	 */
+	public long getServerTime() {
+		return serverTime;
+	}
+
+	/**
+	 * 세션 만료 예정 시각(epoch millis)을 반환한다.
+	 *
+	 * @return 만료 시각, 무제한 세션이면 {@link #UNLIMITED}
+	 */
+	public long getExpiryTime() {
+		return expiryTime;
+	}
+
+	/**
+	 * 세션 비활성 유지 시간(초)을 반환한다.
+	 *
+	 * @return {@code HttpSession.getMaxInactiveInterval()} 값
+	 */
+	public int getMaxInactiveIntervalSeconds() {
+		return maxInactiveIntervalSeconds;
+	}
+
+	/**
+	 * 만료가 없는 세션인지 여부.
+	 *
+	 * @return 무제한이면 true
+	 */
+	public boolean isUnlimited() {
+		return expiryTime == UNLIMITED;
+	}
+
+	/**
+	 * 기준 서버 시각으로부터의 잔여 시간(ms)을 반환한다.
+	 *
+	 * @return 잔여 밀리초. 무제한이면 {@link #UNLIMITED}
+	 */
+	public long getRemainingMillis() {
+		return isUnlimited() ? UNLIMITED : expiryTime - serverTime;
+	}
+
+	/**
+	 * 지정 시각 기준으로 이미 만료됐는지 판단한다.
+	 *
+	 * @param currentTime 판단 기준 시각(epoch millis)
+	 * @return 만료됐으면 true. 무제한 세션은 항상 false
+	 */
+	public boolean isExpiredAt(long currentTime) {
+		return !isUnlimited() && currentTime >= expiryTime;
+	}
+
+	@Override
+	public String toString() {
+		return "EgovSessionExpiry[serverTime=" + serverTime + ", expiryTime=" + expiryTime
+				+ ", maxInactiveIntervalSeconds=" + maxInactiveIntervalSeconds + "]";
+	}
+
+}

--- a/Presentation/org.egovframe.rte.ptl.mvc/src/main/java/org/egovframe/rte/ptl/mvc/session/EgovSessionExpiryCookieFilter.java
+++ b/Presentation/org.egovframe.rte.ptl.mvc/src/main/java/org/egovframe/rte/ptl/mvc/session/EgovSessionExpiryCookieFilter.java
@@ -1,0 +1,276 @@
+/*
+ * Copyright 2009-2026 MOIS(Ministry of the Interior and Safety).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.egovframe.rte.ptl.mvc.session;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.util.AntPathMatcher;
+import org.springframework.util.PathMatcher;
+
+import jakarta.servlet.Filter;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.FilterConfig;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import org.egovframe.rte.ptl.mvc.cookie.EgovCookies;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+/**
+ * 세션 만료 시각을 쿠키로 내려 주는 필터 — 화면이 세션 잔여 시간을 표시할 수 있게 한다.
+ *
+ * <p>매 요청마다 두 쿠키를 갱신한다. 요청이 오면 세션 유효 기간이 연장되므로, 갱신된 값을
+ * 그때그때 내려 줘야 화면 카운트다운이 실제 세션과 어긋나지 않는다.</p>
+ *
+ * <table border="1">
+ * <caption>발행 쿠키</caption>
+ * <tr><th>쿠키</th><th>값</th></tr>
+ * <tr><td>{@value #DEFAULT_SERVER_TIME_COOKIE}</td><td>서버 현재 시각(epoch millis)</td></tr>
+ * <tr><td>{@value #DEFAULT_EXPIRY_TIME_COOKIE}</td>
+ *     <td>세션 만료 예정 시각(epoch millis). 무제한 세션이면 {@code -1}</td></tr>
+ * </table>
+ *
+ * <p><b>세션을 새로 만들지 않는다.</b> 세션이 없는 요청(정적 자원·비로그인 최초 진입)에는
+ * 쿠키를 발행하지 않고 지나간다.</p>
+ *
+ * <p><b>{@code httpOnly} 기본값이 {@code false} 인 이유</b> — 이 쿠키는 <b>브라우저
+ * 스크립트가 읽어서</b> 잔여 시간을 표시하라고 있는 것이다. {@code httpOnly=true} 로 두면
+ * 스크립트가 읽지 못해 목적을 잃는다(그 경우 서버에서 값을 심어 주는 우회가 필요해진다).
+ * 담기는 값은 세션 식별자가 아니라 시각 두 개뿐이라 노출 위험이 낮다. 그래도 막고 싶으면
+ * {@code httpOnly} 초기화 파라미터로 켤 수 있다.</p>
+ *
+ * <p><b>최초 진입 화면</b>은 쿠키가 아직 브라우저에 없다(응답에 실린 쿠키는 <b>다음</b>
+ * 요청부터 되돌아온다). 그 화면에서도 값이 필요하면 컨트롤러에서
+ * {@link EgovSessionExpiry#from(HttpServletRequest)} 로 직접 얻어 모델에 담는다.</p>
+ *
+ * <p><b>web.xml 설정 예</b></p>
+ * <pre>
+ * &lt;filter&gt;
+ *     &lt;filter-name&gt;sessionExpiryCookieFilter&lt;/filter-name&gt;
+ *     &lt;filter-class&gt;org.egovframe.rte.ptl.mvc.session.EgovSessionExpiryCookieFilter&lt;/filter-class&gt;
+ *     &lt;init-param&gt;
+ *         &lt;param-name&gt;excludePathPatterns&lt;/param-name&gt;
+ *         &lt;param-value&gt;/css/**,/js/**,/images/**&lt;/param-value&gt;
+ *     &lt;/init-param&gt;
+ * &lt;/filter&gt;
+ * </pre>
+ *
+ * <p>지원하는 초기화 파라미터: {@code serverTimeCookieName} · {@code expiryTimeCookieName} ·
+ * {@code cookiePath} · {@code httpOnly} · {@code sameSite} · {@code excludePathPatterns}</p>
+ *
+ * <pre>
+ * &lt;&lt; 개정이력(Modification Information) &gt;&gt;
+ *
+ *  수정일        수정자        수정내용
+ *  ----------  --------    ---------------------------
+ *  2026.09.01  실행환경팀     최초 생성 (공통컴포넌트 SessionTimeoutCookieFilter 의
+ *                            설계를 차용하되 세션 강제 생성·httpOnly 목적 모순·무제한 세션
+ *                            음수 계산·경로 제외 부재를 재구성 — 코드 이식 아님)
+ *  2026.09.02  실행환경팀     쿠키 조립을 EgovCookies 빌더에 위임 (동작·초기화 파라미터 불변)
+ * </pre>
+ *
+ * @author 실행환경 개발팀
+ * @since 5.1
+ * @see EgovSessionExpiry
+ */
+public class EgovSessionExpiryCookieFilter implements Filter {
+
+	/** 서버 시각 쿠키의 기본 이름 — 공통컴포넌트와 동일하게 두어 화면 코드를 그대로 쓸 수 있다. */
+	public static final String DEFAULT_SERVER_TIME_COOKIE = "egovLatestServerTime";
+
+	/** 만료 시각 쿠키의 기본 이름 — 공통컴포넌트와 동일. */
+	public static final String DEFAULT_EXPIRY_TIME_COOKIE = "egovExpireSessionTime";
+
+	private final PathMatcher pathMatcher = new AntPathMatcher();
+
+	private String serverTimeCookieName = DEFAULT_SERVER_TIME_COOKIE;
+
+	private String expiryTimeCookieName = DEFAULT_EXPIRY_TIME_COOKIE;
+
+	private String cookiePath = "/";
+
+	private boolean httpOnly;
+
+	private String sameSite = "Lax";
+
+	private List<String> excludePathPatterns = Collections.emptyList();
+
+	/**
+	 * 초기화 파라미터를 읽는다. 지정하지 않은 항목은 기본값을 유지한다.
+	 *
+	 * @param filterConfig 필터 설정 (null 허용 — 전부 기본값)
+	 */
+	@Override
+	public void init(FilterConfig filterConfig) {
+		if (filterConfig == null) {
+			return;
+		}
+		serverTimeCookieName = value(filterConfig, "serverTimeCookieName", serverTimeCookieName);
+		expiryTimeCookieName = value(filterConfig, "expiryTimeCookieName", expiryTimeCookieName);
+		cookiePath = value(filterConfig, "cookiePath", cookiePath);
+		sameSite = value(filterConfig, "sameSite", sameSite);
+		httpOnly = Boolean.parseBoolean(value(filterConfig, "httpOnly", String.valueOf(httpOnly)));
+		// 이름·경로·SameSite 의 설정 오류는 첫 요청이 아니라 기동 시점에 드러나야 한다 — 빌더 검증을 미리 거친다
+		EgovCookies.builder(serverTimeCookieName, "0").path(cookiePath).sameSite(sameSite);
+		EgovCookies.builder(expiryTimeCookieName, "0").path(cookiePath).sameSite(sameSite);
+
+		String patterns = filterConfig.getInitParameter("excludePathPatterns");
+		if (patterns != null && !patterns.trim().isEmpty()) {
+			List<String> parsed = new ArrayList<>();
+			for (String pattern : patterns.split(",")) {
+				String trimmed = pattern.trim();
+				if (!trimmed.isEmpty()) {
+					parsed.add(trimmed);
+				}
+			}
+			excludePathPatterns = Collections.unmodifiableList(parsed);
+		}
+	}
+
+	/**
+	 * 세션이 있으면 만료 시각 쿠키를 갱신한 뒤 다음 필터로 넘긴다.
+	 *
+	 * @param request  요청
+	 * @param response 응답
+	 * @param chain    필터 체인
+	 * @throws IOException      체인 처리 중 IO 오류
+	 * @throws ServletException 체인 처리 중 서블릿 오류
+	 */
+	@Override
+	public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+			throws IOException, ServletException {
+
+		if (request instanceof HttpServletRequest && response instanceof HttpServletResponse) {
+			HttpServletRequest httpRequest = (HttpServletRequest) request;
+			if (!isExcluded(httpRequest)) {
+				// 세션이 없으면 빈 Optional — 쿠키를 발행하지 않고, 세션도 만들지 않는다
+				Optional<EgovSessionExpiry> expiry = EgovSessionExpiry.from(httpRequest);
+				if (expiry.isPresent()) {
+					writeCookies(httpRequest, (HttpServletResponse) response, expiry.get());
+				}
+			}
+		}
+
+		chain.doFilter(request, response);
+	}
+
+	/**
+	 * 요청 경로가 제외 대상인지 판단한다.
+	 *
+	 * @param request 요청
+	 * @return 제외 대상이면 true
+	 */
+	protected boolean isExcluded(HttpServletRequest request) {
+		if (excludePathPatterns.isEmpty()) {
+			return false;
+		}
+		String path = request.getRequestURI();
+		String contextPath = request.getContextPath();
+		if (contextPath != null && !contextPath.isEmpty() && path.startsWith(contextPath)) {
+			path = path.substring(contextPath.length());
+		}
+		for (String pattern : excludePathPatterns) {
+			if (pathMatcher.match(pattern, path)) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	private void writeCookies(HttpServletRequest request, HttpServletResponse response, EgovSessionExpiry expiry) {
+		cookie(serverTimeCookieName, Long.toString(expiry.getServerTime())).addTo(request, response);
+		cookie(expiryTimeCookieName, Long.toString(expiry.getExpiryTime())).addTo(request, response);
+	}
+
+	/**
+	 * 쿠키 조립을 {@link EgovCookies} 에 위임한다(같은 조리법 두 벌 방지). Secure 는 빌더가
+	 * {@code request.isSecure()} 로 자동 판정하고, {@code sameSite} 초기화 파라미터가 빈 값이면
+	 * 속성을 붙이지 않는 종전 의미를 그대로 유지한다.
+	 */
+	private EgovCookies.Builder cookie(String name, String value) {
+		return EgovCookies.builder(name, value)
+				.path(cookiePath)
+				.httpOnly(httpOnly)
+				.sameSite(sameSite);
+	}
+
+	private static String value(FilterConfig config, String name, String defaultValue) {
+		String parameter = config.getInitParameter(name);
+		return (parameter == null || parameter.trim().isEmpty()) ? defaultValue : parameter.trim();
+	}
+
+	/**
+	 * 서버 시각 쿠키 이름을 지정한다(Java Config 등록 시).
+	 *
+	 * @param serverTimeCookieName 쿠키 이름
+	 */
+	public void setServerTimeCookieName(String serverTimeCookieName) {
+		this.serverTimeCookieName = serverTimeCookieName;
+	}
+
+	/**
+	 * 만료 시각 쿠키 이름을 지정한다(Java Config 등록 시).
+	 *
+	 * @param expiryTimeCookieName 쿠키 이름
+	 */
+	public void setExpiryTimeCookieName(String expiryTimeCookieName) {
+		this.expiryTimeCookieName = expiryTimeCookieName;
+	}
+
+	/**
+	 * 쿠키 경로를 지정한다.
+	 *
+	 * @param cookiePath 경로 (기본 "/")
+	 */
+	public void setCookiePath(String cookiePath) {
+		this.cookiePath = cookiePath;
+	}
+
+	/**
+	 * {@code HttpOnly} 사용 여부를 지정한다.
+	 *
+	 * @param httpOnly true 면 스크립트에서 읽을 수 없다(기본 false — 클래스 설명 참조)
+	 */
+	public void setHttpOnly(boolean httpOnly) {
+		this.httpOnly = httpOnly;
+	}
+
+	/**
+	 * {@code SameSite} 속성을 지정한다.
+	 *
+	 * @param sameSite Lax·Strict·None 등 (기본 "Lax", 빈 값이면 미설정)
+	 */
+	public void setSameSite(String sameSite) {
+		this.sameSite = sameSite;
+	}
+
+	/**
+	 * 쿠키를 발행하지 않을 경로 패턴을 지정한다(Ant 패턴).
+	 *
+	 * @param excludePathPatterns 패턴 목록 (null 이면 제외 없음)
+	 */
+	public void setExcludePathPatterns(List<String> excludePathPatterns) {
+		this.excludePathPatterns = (excludePathPatterns == null)
+				? Collections.emptyList()
+				: Collections.unmodifiableList(new ArrayList<>(excludePathPatterns));
+	}
+
+}

--- a/Presentation/org.egovframe.rte.ptl.mvc/src/test/java/org/egovframe/rte/ptl/mvc/cookie/EgovCookiesSecurityTest.java
+++ b/Presentation/org.egovframe.rte.ptl.mvc/src/test/java/org/egovframe/rte/ptl/mvc/cookie/EgovCookiesSecurityTest.java
@@ -1,0 +1,127 @@
+package org.egovframe.rte.ptl.mvc.cookie;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import jakarta.servlet.http.Cookie;
+
+/**
+ * {@link EgovCookies} 의 <b>헤더 주입(CWE-113)·안전 기본값</b> 회귀 검증.
+ *
+ * <p>기능 테스트({@link EgovCookiesTest})와 별도로, Set-Cookie 헤더를 깨뜨리거나 속성을 끼워 넣는 데
+ * 실제로 쓰이는 입력을 표로 모아 두고 <b>하나라도 쿠키가 만들어지면 실패</b>하게 한다. 컨테이너
+ * (Tomcat 의 RFC 6265 처리기)도 같은 문자를 거부하지만 이 빌더는 컨테이너에 기대지 않고 생성
+ * 시점에 거부한다 — 테스트 응답 객체는 검증을 하지 않으므로 여기서 그 계약을 고정한다.</p>
+ */
+class EgovCookiesSecurityTest {
+
+	private static final String CR = "\r";
+	private static final String LF = "\n";
+	private static final String NUL = String.valueOf((char) 0);
+
+	/** 헤더 경계·속성 경계를 무너뜨리는 입력 — 이름·값·Path·Domain 어디에 넣어도 거부돼야 한다. */
+	private static final List<String> INJECTIONS = List.of(
+			"x" + CR + LF + "Set-Cookie: admin=true",
+			"x" + LF + "Set-Cookie: admin=true",
+			"x" + CR + "Set-Cookie: admin=true",
+			"x; HttpOnly=false",
+			"x; Path=/",
+			"x;Secure",
+			"x" + NUL + "y",
+			"x" + (char) 0x7F,
+			"x\t; Domain=evil.example");
+
+	private static MockHttpServletRequest request() {
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.setContextPath("/app");
+		return request;
+	}
+
+	private static boolean isCookieOctet(char c) {
+		return c == 0x21 || (c >= 0x23 && c <= 0x2B) || (c >= 0x2D && c <= 0x3A)
+				|| (c >= 0x3C && c <= 0x5B) || (c >= 0x5D && c <= 0x7E);
+	}
+
+	private static String label(String s) {
+		return s.replace(CR, "<CR>").replace(LF, "<LF>").replace(NUL, "<NUL>");
+	}
+
+	@Test
+	@DisplayName("CR·LF·세미콜론·제어 문자는 이름·값·Path·Domain 어디에 있어도 생성 시점에 거부된다")
+	void 주입_문자는_어느_자리에서도_거부() {
+		for (String bad : INJECTIONS) {
+			assertThrows(IllegalArgumentException.class, () -> EgovCookies.builder(bad, "v"), "이름: " + label(bad));
+			assertThrows(IllegalArgumentException.class, () -> EgovCookies.builder("n", bad), "값: " + label(bad));
+			assertThrows(IllegalArgumentException.class, () -> EgovCookies.builder("n", "v").path(bad), "Path: " + label(bad));
+			assertThrows(IllegalArgumentException.class, () -> EgovCookies.builder("n", "v").domain(bad), "Domain: " + label(bad));
+		}
+	}
+
+	@Test
+	@DisplayName("세미콜론·제어 문자는 encodeValue 를 선택해도 발급되지 않는다 — 속성 경계는 인코딩으로 우회할 수 없다")
+	void 세미콜론은_인코딩으로도_우회_불가() {
+		// 빌더 생성 자체가 거부되므로 encodeValue() 에 도달할 수 없다
+		assertThrows(IllegalArgumentException.class, () -> EgovCookies.builder("n", "a; Secure"));
+		assertThrows(IllegalArgumentException.class, () -> EgovCookies.builder("n", "a" + CR + LF + "Set-Cookie: b=1"));
+	}
+
+	@Test
+	@DisplayName("encodeValue 로 발급한 값은 cookie-octet 밖의 문자가 하나도 없고 decodedValue 로 원본이 복원된다")
+	void 인코딩_발급_값은_cookie_octet_뿐() {
+		for (String raw : List.of("v w", "\"quoted\"", "a,b", "back" + "\\" + "slash", "한글 이름", "100%", "a+b=c&d",
+				"x".repeat(4096), "line" + (char) 0x2028 + "sep", "emoji😀")) {
+			MockHttpServletResponse response = new MockHttpServletResponse();
+			Cookie cookie = EgovCookies.builder("n", raw).encodeValue().addTo(request(), response);
+
+			for (char c : cookie.getValue().toCharArray()) {
+				assertTrue(isCookieOctet(c), "cookie-octet 밖 문자 U+" + Integer.toHexString(c) + " in " + raw);
+			}
+			String header = response.getHeader("Set-Cookie");
+			assertFalse(header.contains(CR) || header.contains(LF), header);
+
+			MockHttpServletRequest next = new MockHttpServletRequest();
+			next.setCookies(new Cookie("n", cookie.getValue()));
+			assertEquals(Optional.of(raw), EgovCookies.decodedValue(next, "n"));
+		}
+	}
+
+	@Test
+	@DisplayName("SameSite=None·Partitioned 는 Secure 없이 만들 수 없고, SameSite 값에 다른 속성을 끼워 넣을 수 없다")
+	void SameSite_규칙과_속성_주입() {
+		MockHttpServletRequest plain = request();
+		assertThrows(IllegalArgumentException.class, () -> EgovCookies.builder("n", "v").sameSite("None").build(plain));
+		assertThrows(IllegalArgumentException.class, () -> EgovCookies.builder("n", "v").partitioned().build(plain));
+		for (String bad : List.of("None; Secure", "Lax" + CR + LF + "Set-Cookie: a=b", "Strict; Domain=evil.example", "Foo")) {
+			assertThrows(IllegalArgumentException.class, () -> EgovCookies.builder("n", "v").sameSite(bad), label(bad));
+		}
+
+		MockHttpServletRequest secure = request();
+		secure.setSecure(true);
+		Cookie cookie = EgovCookies.builder("n", "v").sameSite("none").build(secure);
+		assertTrue(cookie.getSecure());
+		assertEquals("None", cookie.getAttribute("SameSite"));
+	}
+
+	@Test
+	@DisplayName("클라이언트가 변조한 퍼센트 인코딩은 decodedValue 가 예외 대신 빈 Optional 로 다룬다")
+	void 변조된_인코딩은_예외가_아니라_빈값() {
+		// 쿠키 값은 클라이언트가 임의로 바꿀 수 있다 — 읽기 헬퍼가 그 값 때문에 예외를 내면 요청 처리가 500 으로 끝난다
+		for (String tampered : List.of("%", "%zz", "%E0%A4%A", "abc%", "%%")) {
+			MockHttpServletRequest request = new MockHttpServletRequest();
+			request.setCookies(new Cookie("n", tampered));
+			assertEquals(Optional.empty(), EgovCookies.decodedValue(request, "n"), tampered);
+			assertEquals(Optional.of(tampered), EgovCookies.value(request, "n"), "원시 값 읽기는 그대로: " + tampered);
+		}
+	}
+
+}

--- a/Presentation/org.egovframe.rte.ptl.mvc/src/test/java/org/egovframe/rte/ptl/mvc/cookie/EgovCookiesTest.java
+++ b/Presentation/org.egovframe.rte.ptl.mvc/src/test/java/org/egovframe/rte/ptl/mvc/cookie/EgovCookiesTest.java
@@ -1,0 +1,161 @@
+package org.egovframe.rte.ptl.mvc.cookie;
+
+import jakarta.servlet.http.Cookie;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import java.time.Duration;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * EgovCookies(안전 쿠키 빌더) 검증.
+ */
+class EgovCookiesTest {
+
+	private static MockHttpServletRequest request(boolean secure, String contextPath) {
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.setSecure(secure);
+		request.setContextPath(contextPath);
+		return request;
+	}
+
+	@Test
+	@DisplayName("이름과 값만 주면 HttpOnly·Lax·Secure(보안 채널)·Path=컨텍스트 루트가 붙는다")
+	void 기본값() {
+		MockHttpServletResponse response = new MockHttpServletResponse();
+
+		Cookie cookie = EgovCookies.builder("theme", "dark").addTo(request(true, "/app"), response);
+
+		assertTrue(cookie.isHttpOnly());
+		assertTrue(cookie.getSecure());
+		assertEquals("Lax", cookie.getAttribute("SameSite"));
+		assertEquals("/app", cookie.getPath());
+		assertEquals(-1, cookie.getMaxAge(), "기본은 세션 쿠키");
+		assertNotNull(response.getCookie("theme"), "응답에 실린다");
+	}
+
+	@Test
+	@DisplayName("평문 채널이면 Secure 가 자동으로 꺼져 브라우저가 저장한다 — 원본 Secure 하드코딩의 침묵 미동작 교정")
+	void 평문_채널_Secure_자동() {
+		Cookie cookie = EgovCookies.builder("theme", "dark").build(request(false, ""));
+
+		assertFalse(cookie.getSecure());
+		assertEquals("/", cookie.getPath(), "컨텍스트 루트가 비면 /");
+	}
+
+	@Test
+	@DisplayName("secure(true) 명시는 채널 자동 판정보다 우선한다(프록시 뒤 HTTPS 종단)")
+	void Secure_명시_우선() {
+		Cookie cookie = EgovCookies.builder("theme", "dark").secure(true).build(request(false, ""));
+
+		assertTrue(cookie.getSecure());
+	}
+
+	@Test
+	@DisplayName("SameSite=None 인데 Secure 가 아니면 생성 시점에 거부된다 — 종전 구현이면 브라우저가 폐기하는 쿠키를 발급하던 입력")
+	void None_비Secure_거부() {
+		EgovCookies.Builder builder = EgovCookies.builder("sso", "x").sameSite("None");
+
+		assertThrows(IllegalArgumentException.class, () -> builder.build(request(false, "")));
+		assertEquals("None", builder.build(request(true, "")).getAttribute("SameSite"), "Secure 면 허용");
+		assertThrows(IllegalArgumentException.class,
+				() -> EgovCookies.builder("p", "x").partitioned().build(request(false, "")), "Partitioned 도 Secure 전제");
+	}
+
+	@Test
+	@DisplayName("CRLF·세미콜론이 섞인 값과 token 이 아닌 이름은 거부된다 — 정제가 아니라 실패")
+	void 주입_문자_거부() {
+		assertThrows(IllegalArgumentException.class, () -> EgovCookies.builder("a", "x\r\nSet-Cookie: evil=1"));
+		assertThrows(IllegalArgumentException.class, () -> EgovCookies.builder("a", "x; Path=/"));
+		assertThrows(IllegalArgumentException.class, () -> EgovCookies.builder("bad name", "x"));
+		assertThrows(IllegalArgumentException.class, () -> EgovCookies.builder("a=b", "x"));
+		assertThrows(IllegalArgumentException.class, () -> EgovCookies.builder("", "x"));
+		assertThrows(IllegalArgumentException.class, () -> EgovCookies.builder("a", "x").path("/p;q"));
+	}
+
+	@Test
+	@DisplayName("한글·공백 값은 기본 거부, encodeValue() 를 선택하면 URL 인코딩 발급 + decodedValue 대칭")
+	void 인코딩_옵션() {
+		assertThrows(IllegalArgumentException.class, () -> EgovCookies.builder("name", "홍길동").build(request(true, "")));
+		assertThrows(IllegalArgumentException.class, () -> EgovCookies.builder("name", "a b").build(request(true, "")));
+
+		Cookie cookie = EgovCookies.builder("name", "홍길동 님").encodeValue().build(request(true, ""));
+		assertFalse(cookie.getValue().contains("홍"), "인코딩된 값: " + cookie.getValue());
+
+		MockHttpServletRequest next = request(true, "");
+		next.setCookies(cookie);
+		assertEquals(Optional.of("홍길동 님"), EgovCookies.decodedValue(next, "name"));
+		assertEquals(Optional.of(cookie.getValue()), EgovCookies.value(next, "name"), "value() 는 원시 값");
+	}
+
+	@Test
+	@DisplayName("삭제는 발급과 같은 Path·Domain 으로 Max-Age=0 을 낸다 — 원본은 path 미설정이라 다른 경로에서 안 지워졌다")
+	void 삭제_정합() {
+		MockHttpServletResponse response = new MockHttpServletResponse();
+		EgovCookies.builder("theme", "dark").path("/app").domain("example.go.kr").addTo(request(true, "/app"), response);
+
+		Cookie expired = EgovCookies.expire("theme").path("/app").domain("example.go.kr").addTo(request(true, "/app"), response);
+
+		assertEquals(0, expired.getMaxAge());
+		assertEquals("", expired.getValue());
+		assertEquals("/app", expired.getPath());
+		assertEquals("example.go.kr", expired.getDomain());
+		assertThrows(IllegalStateException.class, () -> EgovCookies.expire("theme").maxAge(10), "삭제 빌더의 Max-Age 는 0 고정");
+		// 기본값끼리는 자동 정합 — 발급 Path(컨텍스트 루트) == 삭제 Path
+		assertEquals(EgovCookies.builder("t", "v").build(request(true, "/app")).getPath(),
+				EgovCookies.expire("t").build(request(true, "/app")).getPath());
+	}
+
+	@Test
+	@DisplayName("읽기 부재는 쿠키 배열이 null 이든 이름이 없든 빈 Optional 하나다 — 원본의 \"\"/null 이원화 교정")
+	void 읽기_부재_단일_표현() {
+		MockHttpServletRequest none = request(true, "");
+		assertNull(none.getCookies(), "전제: 쿠키 배열 null");
+		assertEquals(Optional.empty(), EgovCookies.value(none, "theme"));
+
+		MockHttpServletRequest other = request(true, "");
+		other.setCookies(new Cookie("other", "1"));
+		assertEquals(Optional.empty(), EgovCookies.value(other, "theme"));
+
+		other.setCookies(new Cookie("theme", "dark"));
+		assertEquals(Optional.of("dark"), EgovCookies.value(other, "theme"));
+	}
+
+	@Test
+	@DisplayName("속성 지정 — maxAge(Duration)·domain·partitioned·sameSite 정규화·명시 해제")
+	void 속성_반영() {
+		Cookie cookie = EgovCookies.builder("theme", "dark")
+				.maxAge(Duration.ofDays(30)).domain("example.go.kr").partitioned().sameSite("strict")
+				.build(request(true, "/app"));
+
+		assertEquals(30 * 24 * 3600, cookie.getMaxAge());
+		assertEquals("example.go.kr", cookie.getDomain());
+		assertEquals("Strict", cookie.getAttribute("SameSite"), "대소문자 무시 후 표준 표기로 정규화");
+		assertNotNull(cookie.getAttribute("Partitioned"));
+
+		Cookie unset = EgovCookies.builder("theme", "dark").sameSite("").httpOnly(false).build(request(true, ""));
+		assertNull(unset.getAttribute("SameSite"), "빈 값이면 속성을 붙이지 않는다(만료시각 필터의 의미)");
+		assertFalse(unset.isHttpOnly());
+		assertThrows(IllegalArgumentException.class, () -> EgovCookies.builder("t", "v").sameSite("Foo"));
+		assertThrows(IllegalArgumentException.class, () -> EgovCookies.builder("t", "v").maxAge(-2));
+	}
+
+	@Test
+	@DisplayName("request 없이 build 하면 Secure=false·Path=/ 로 판정한다(비 웹 컨텍스트)")
+	void request_null() {
+		Cookie cookie = EgovCookies.builder("theme", "dark").build(null);
+
+		assertFalse(cookie.getSecure());
+		assertEquals("/", cookie.getPath());
+	}
+
+}

--- a/Presentation/org.egovframe.rte.ptl.mvc/src/test/java/org/egovframe/rte/ptl/mvc/session/EgovSessionExpiryCookieFilterSecurityTest.java
+++ b/Presentation/org.egovframe.rte.ptl.mvc/src/test/java/org/egovframe/rte/ptl/mvc/session/EgovSessionExpiryCookieFilterSecurityTest.java
@@ -1,0 +1,82 @@
+package org.egovframe.rte.ptl.mvc.session;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockFilterConfig;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.mock.web.MockHttpSession;
+import org.springframework.mock.web.MockServletContext;
+
+import jakarta.servlet.http.Cookie;
+
+/**
+ * {@link EgovSessionExpiryCookieFilter} 의 <b>노출 범위·설정 오류</b> 회귀 검증.
+ *
+ * <p>이 필터의 쿠키는 스크립트가 읽어야 하므로 {@code HttpOnly} 가 아니다. 그래서 담기는 값이
+ * <b>시각 두 개뿐</b>이라는 점(세션 식별자 미노출)이 안전성의 근거이며, 여기서 그것을 고정한다.
+ * 초기화 파라미터에 주입 문자가 섞인 경우에는 쿠키를 내지 않고 실패해야 한다.</p>
+ */
+class EgovSessionExpiryCookieFilterSecurityTest {
+
+	@Test
+	@DisplayName("쿠키에는 시각 두 개(숫자)만 실리고 세션 식별자는 어디에도 실리지 않는다")
+	void 세션_식별자_미노출() throws Exception {
+		MockServletContext context = new MockServletContext();
+		MockHttpSession session = new MockHttpSession(context, "SID-0123456789abcdef0123456789abcdef");
+		session.setMaxInactiveInterval(1800);
+		MockHttpServletRequest request = new MockHttpServletRequest(context, "GET", "/app/page");
+		request.setContextPath("/app");
+		request.setSession(session);
+		MockHttpServletResponse response = new MockHttpServletResponse();
+
+		EgovSessionExpiryCookieFilter filter = new EgovSessionExpiryCookieFilter();
+		filter.init(new MockFilterConfig());
+		filter.doFilter(request, response, new MockFilterChain());
+
+		List<Cookie> cookies = Arrays.asList(response.getCookies());
+		assertEquals(2, cookies.size());
+		for (Cookie cookie : cookies) {
+			assertTrue(cookie.getValue().matches("-?[0-9]+"), cookie.getName() + "=" + cookie.getValue());
+		}
+		for (String header : response.getHeaders("Set-Cookie")) {
+			assertFalse(header.contains(session.getId()), header);
+			assertFalse(header.contains("\r") || header.contains("\n"), header);
+		}
+	}
+
+	@Test
+	@DisplayName("주입 문자가 든 경로·미지원 SameSite·token 아닌 이름 설정은 쿠키를 내지 않고 실패로 닫힌다")
+	void 잘못된_설정은_실패로_닫힌다() {
+		List<String[]> badParams = List.of(
+				new String[] {"cookiePath", "/app\r\nSet-Cookie: admin=true"},
+				new String[] {"cookiePath", "/app; HttpOnly=false"},
+				new String[] {"sameSite", "None; Secure"},
+				new String[] {"serverTimeCookieName", "bad name"});
+		for (String[] param : badParams) {
+			MockFilterConfig config = new MockFilterConfig();
+			config.addInitParameter(param[0], param[1]);
+			MockHttpServletRequest request = new MockHttpServletRequest("GET", "/app/page");
+			request.setContextPath("/app");
+			request.getSession(true).setMaxInactiveInterval(1800);
+			MockHttpServletResponse response = new MockHttpServletResponse();
+			EgovSessionExpiryCookieFilter filter = new EgovSessionExpiryCookieFilter();
+
+			assertThrows(IllegalArgumentException.class, () -> {
+				filter.init(config);
+				filter.doFilter(request, response, new MockFilterChain());
+			}, param[0] + "=" + param[1]);
+			assertEquals(0, response.getHeaders("Set-Cookie").size(), param[0] + "=" + param[1]);
+		}
+	}
+
+}

--- a/Presentation/org.egovframe.rte.ptl.mvc/src/test/java/org/egovframe/rte/ptl/mvc/session/EgovSessionExpiryCookieFilterTest.java
+++ b/Presentation/org.egovframe.rte.ptl.mvc/src/test/java/org/egovframe/rte/ptl/mvc/session/EgovSessionExpiryCookieFilterTest.java
@@ -1,0 +1,309 @@
+package org.egovframe.rte.ptl.mvc.session;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockFilterConfig;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.mock.web.MockHttpSession;
+
+import jakarta.servlet.http.Cookie;
+
+/**
+ * {@link EgovSessionExpiryCookieFilter}·{@link EgovSessionExpiry} 단위 테스트.
+ *
+ * <p>기본 발행 계약과 함께, 원본(공통컴포넌트 SessionTimeoutCookieFilter)의
+ * <b>세션 강제 생성</b>·<b>무제한 세션 음수 계산</b>·<b>httpOnly 목적 모순</b>을 회귀 검증한다.</p>
+ */
+class EgovSessionExpiryCookieFilterTest {
+
+	private EgovSessionExpiryCookieFilter filter() throws Exception {
+		EgovSessionExpiryCookieFilter filter = new EgovSessionExpiryCookieFilter();
+		filter.init(new MockFilterConfig());
+		return filter;
+	}
+
+	private MockHttpServletRequest requestWithSession(int maxInactiveSeconds) {
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		MockHttpSession session = new MockHttpSession();
+		session.setMaxInactiveInterval(maxInactiveSeconds);
+		request.setSession(session);
+		return request;
+	}
+
+	private Cookie cookie(MockHttpServletResponse response, String name) {
+		return response.getCookie(name);
+	}
+
+	// ─────────────────────────────── 기본 발행 ───────────────────────────────
+
+	@Test
+	@DisplayName("세션이 있으면 서버 시각·만료 시각 쿠키를 발행한다")
+	void 쿠키_발행() throws Exception {
+		MockHttpServletRequest request = requestWithSession(1800);
+		MockHttpServletResponse response = new MockHttpServletResponse();
+
+		filter().doFilter(request, response, new MockFilterChain());
+
+		Cookie serverTime = cookie(response, EgovSessionExpiryCookieFilter.DEFAULT_SERVER_TIME_COOKIE);
+		Cookie expiryTime = cookie(response, EgovSessionExpiryCookieFilter.DEFAULT_EXPIRY_TIME_COOKIE);
+		assertNotNull(serverTime);
+		assertNotNull(expiryTime);
+
+		long server = Long.parseLong(serverTime.getValue());
+		long expiry = Long.parseLong(expiryTime.getValue());
+		assertEquals(1800L * 1000L, expiry - server, "만료 시각은 서버 시각 + 세션 유지 시간이어야 한다");
+	}
+
+	@Test
+	@DisplayName("쿠키 경로는 / 이고 SameSite 는 Lax 가 기본이다")
+	void 쿠키_속성_기본값() throws Exception {
+		MockHttpServletResponse response = new MockHttpServletResponse();
+		filter().doFilter(requestWithSession(600), response, new MockFilterChain());
+
+		Cookie serverTime = cookie(response, EgovSessionExpiryCookieFilter.DEFAULT_SERVER_TIME_COOKIE);
+		assertEquals("/", serverTime.getPath());
+		assertEquals("Lax", serverTime.getAttribute("SameSite"));
+	}
+
+	@Test
+	@DisplayName("필터는 항상 체인을 이어서 호출한다")
+	void 체인_호출() throws Exception {
+		MockFilterChain chain = new MockFilterChain();
+		filter().doFilter(new MockHttpServletRequest(), new MockHttpServletResponse(), chain);
+
+		assertNotNull(chain.getRequest(), "세션이 없어도 체인은 진행돼야 한다");
+	}
+
+	// ─────────────────────── 원본 결함 ① 세션 강제 생성 ───────────────────────
+
+	@Test
+	@DisplayName("세션이 없으면 쿠키를 발행하지 않고, 세션을 새로 만들지도 않는다")
+	void 세션_생성하지_않음() throws Exception {
+		MockHttpServletRequest request = new MockHttpServletRequest();   // 세션 없음
+		MockHttpServletResponse response = new MockHttpServletResponse();
+
+		filter().doFilter(request, response, new MockFilterChain());
+
+		assertEquals(0, response.getCookies().length, "세션이 없으면 쿠키를 내리지 않는다");
+		assertNull(request.getSession(false),
+				"필터가 세션을 생성하면 정적 자원 요청까지 세션이 만들어진다");
+	}
+
+	// ─────────────────── 원본 결함 ② 무제한 세션 음수 계산 ───────────────────
+
+	@Test
+	@DisplayName("무제한 세션(maxInactiveInterval<=0)은 만료 시각이 -1 이다 — 과거 시각이 되면 안 된다")
+	void 무제한_세션() throws Exception {
+		MockHttpServletResponse response = new MockHttpServletResponse();
+		filter().doFilter(requestWithSession(-1), response, new MockFilterChain());
+
+		Cookie expiryTime = cookie(response, EgovSessionExpiryCookieFilter.DEFAULT_EXPIRY_TIME_COOKIE);
+		long expiry = Long.parseLong(expiryTime.getValue());
+
+		assertEquals(EgovSessionExpiry.UNLIMITED, expiry);
+		long server = Long.parseLong(
+				cookie(response, EgovSessionExpiryCookieFilter.DEFAULT_SERVER_TIME_COOKIE).getValue());
+		assertFalse(expiry > 0 && expiry < server,
+				"만료 시각이 서버 시각보다 과거이면 화면이 즉시 만료로 오판한다");
+	}
+
+	@Test
+	@DisplayName("큰 세션 유지 시간도 넘침 없이 계산된다(int 곱셈 한계 초과)")
+	void 오버플로_방지() {
+		// int 로 계산하면 2,147,484초를 넘길 때 넘침이 발생한다
+		int hugeSeconds = 3_000_000;
+		EgovSessionExpiry expiry = EgovSessionExpiry.of(sessionOf(hugeSeconds), 1_000_000L);
+
+		assertEquals(1_000_000L + 3_000_000L * 1000L, expiry.getExpiryTime());
+		assertTrue(expiry.getExpiryTime() > 0, "넘침이 나면 음수가 된다");
+	}
+
+	private MockHttpSession sessionOf(int seconds) {
+		MockHttpSession session = new MockHttpSession();
+		session.setMaxInactiveInterval(seconds);
+		return session;
+	}
+
+	// ─────────────────── 원본 결함 ③ httpOnly 목적 모순 ───────────────────
+
+	@Test
+	@DisplayName("기본값은 httpOnly=false — 화면 스크립트가 읽어야 하는 쿠키다")
+	void httpOnly_기본_false() throws Exception {
+		MockHttpServletResponse response = new MockHttpServletResponse();
+		filter().doFilter(requestWithSession(600), response, new MockFilterChain());
+
+		assertFalse(cookie(response, EgovSessionExpiryCookieFilter.DEFAULT_SERVER_TIME_COOKIE).isHttpOnly());
+		assertFalse(cookie(response, EgovSessionExpiryCookieFilter.DEFAULT_EXPIRY_TIME_COOKIE).isHttpOnly());
+	}
+
+	@Test
+	@DisplayName("httpOnly 를 켤 수도 있다")
+	void httpOnly_설정() throws Exception {
+		MockFilterConfig config = new MockFilterConfig();
+		config.addInitParameter("httpOnly", "true");
+		EgovSessionExpiryCookieFilter filter = new EgovSessionExpiryCookieFilter();
+		filter.init(config);
+
+		MockHttpServletResponse response = new MockHttpServletResponse();
+		filter.doFilter(requestWithSession(600), response, new MockFilterChain());
+
+		assertTrue(cookie(response, EgovSessionExpiryCookieFilter.DEFAULT_SERVER_TIME_COOKIE).isHttpOnly());
+	}
+
+	// ─────────────────────────────── 설정 ───────────────────────────────
+
+	@Test
+	@DisplayName("HTTPS 요청이면 Secure 가 붙는다")
+	void secure_요청() throws Exception {
+		MockHttpServletRequest request = requestWithSession(600);
+		request.setSecure(true);
+		MockHttpServletResponse response = new MockHttpServletResponse();
+
+		filter().doFilter(request, response, new MockFilterChain());
+
+		assertTrue(cookie(response, EgovSessionExpiryCookieFilter.DEFAULT_SERVER_TIME_COOKIE).getSecure());
+	}
+
+	@Test
+	@DisplayName("쿠키 이름·경로·SameSite 를 초기화 파라미터로 바꿀 수 있다")
+	void 설정_변경() throws Exception {
+		MockFilterConfig config = new MockFilterConfig();
+		config.addInitParameter("serverTimeCookieName", "svrTime");
+		config.addInitParameter("expiryTimeCookieName", "expTime");
+		config.addInitParameter("cookiePath", "/app");
+		config.addInitParameter("sameSite", "Strict");
+		EgovSessionExpiryCookieFilter filter = new EgovSessionExpiryCookieFilter();
+		filter.init(config);
+
+		MockHttpServletResponse response = new MockHttpServletResponse();
+		filter.doFilter(requestWithSession(600), response, new MockFilterChain());
+
+		Cookie custom = cookie(response, "svrTime");
+		assertNotNull(custom);
+		assertNotNull(cookie(response, "expTime"));
+		assertEquals("/app", custom.getPath());
+		assertEquals("Strict", custom.getAttribute("SameSite"));
+	}
+
+	@Test
+	@DisplayName("제외 경로에는 쿠키를 발행하지 않는다(정적 자원)")
+	void 제외_경로() throws Exception {
+		MockFilterConfig config = new MockFilterConfig();
+		config.addInitParameter("excludePathPatterns", "/css/**, /js/**");
+		EgovSessionExpiryCookieFilter filter = new EgovSessionExpiryCookieFilter();
+		filter.init(config);
+
+		MockHttpServletRequest request = requestWithSession(600);
+		request.setRequestURI("/css/egov.css");
+		MockHttpServletResponse response = new MockHttpServletResponse();
+		filter.doFilter(request, response, new MockFilterChain());
+
+		assertEquals(0, response.getCookies().length);
+	}
+
+	@Test
+	@DisplayName("제외 경로 판정은 컨텍스트 경로를 제거하고 수행한다")
+	void 제외_경로_컨텍스트() throws Exception {
+		MockFilterConfig config = new MockFilterConfig();
+		config.addInitParameter("excludePathPatterns", "/images/**");
+		EgovSessionExpiryCookieFilter filter = new EgovSessionExpiryCookieFilter();
+		filter.init(config);
+
+		MockHttpServletRequest request = requestWithSession(600);
+		request.setContextPath("/egov");
+		request.setRequestURI("/egov/images/logo.png");
+		MockHttpServletResponse response = new MockHttpServletResponse();
+		filter.doFilter(request, response, new MockFilterChain());
+
+		assertEquals(0, response.getCookies().length);
+	}
+
+	@Test
+	@DisplayName("제외 대상이 아닌 경로는 정상 발행된다")
+	void 제외_비대상() throws Exception {
+		MockFilterConfig config = new MockFilterConfig();
+		config.addInitParameter("excludePathPatterns", "/css/**");
+		EgovSessionExpiryCookieFilter filter = new EgovSessionExpiryCookieFilter();
+		filter.init(config);
+
+		MockHttpServletRequest request = requestWithSession(600);
+		request.setRequestURI("/board/list.do");
+		MockHttpServletResponse response = new MockHttpServletResponse();
+		filter.doFilter(request, response, new MockFilterChain());
+
+		assertEquals(2, response.getCookies().length);
+	}
+
+	// ─────────────────────────── EgovSessionExpiry ───────────────────────────
+
+	@Test
+	@DisplayName("세션이 없으면 빈 Optional 을 반환하고 세션을 만들지 않는다")
+	void 값객체_세션_없음() {
+		MockHttpServletRequest request = new MockHttpServletRequest();
+
+		assertTrue(EgovSessionExpiry.from(request).isEmpty());
+		assertNull(request.getSession(false));
+	}
+
+	@Test
+	@DisplayName("잔여 시간·만료 판정을 제공한다")
+	void 값객체_계산() {
+		EgovSessionExpiry expiry = EgovSessionExpiry.of(sessionOf(600), 1_000L);
+
+		assertEquals(600_000L, expiry.getRemainingMillis());
+		assertEquals(601_000L, expiry.getExpiryTime());
+		assertEquals(600, expiry.getMaxInactiveIntervalSeconds());
+		assertFalse(expiry.isUnlimited());
+		assertFalse(expiry.isExpiredAt(600_999L));
+		assertTrue(expiry.isExpiredAt(601_000L), "만료 시각에 도달하면 만료다");
+	}
+
+	@Test
+	@DisplayName("무제한 세션은 잔여 시간 -1 이며 만료되지 않는다")
+	void 값객체_무제한() {
+		EgovSessionExpiry expiry = EgovSessionExpiry.of(sessionOf(0), 1_000L);
+
+		assertTrue(expiry.isUnlimited());
+		assertEquals(EgovSessionExpiry.UNLIMITED, expiry.getRemainingMillis());
+		assertFalse(expiry.isExpiredAt(Long.MAX_VALUE));
+	}
+
+	@Test
+	@DisplayName("null 인자는 명시 예외")
+	void 값객체_null_예외() {
+		assertThrows(IllegalArgumentException.class, () -> EgovSessionExpiry.from(null));
+		assertThrows(IllegalArgumentException.class, () -> EgovSessionExpiry.of(null, 0L));
+	}
+
+	@Test
+	@DisplayName("setter 로 등록해도 초기화 파라미터와 같게 동작한다(Java Config)")
+	void 자바_설정() throws Exception {
+		EgovSessionExpiryCookieFilter filter = new EgovSessionExpiryCookieFilter();
+		filter.setServerTimeCookieName("st");
+		filter.setExpiryTimeCookieName("et");
+		filter.setExcludePathPatterns(Arrays.asList("/static/**"));
+
+		MockHttpServletRequest excluded = requestWithSession(600);
+		excluded.setRequestURI("/static/a.png");
+		MockHttpServletResponse response1 = new MockHttpServletResponse();
+		filter.doFilter(excluded, response1, new MockFilterChain());
+		assertEquals(0, response1.getCookies().length);
+
+		MockHttpServletResponse response2 = new MockHttpServletResponse();
+		filter.doFilter(requestWithSession(600), response2, new MockFilterChain());
+		assertNotNull(cookie(response2, "st"));
+		assertNotNull(cookie(response2, "et"));
+	}
+
+}


### PR DESCRIPTION
> **[공통컴포넌트 공통 기능 개선 → 실행환경 이관]**
>
> 공통컴포넌트에 있던 공통 기능을 개선해 실행환경으로 올리는 항목입니다.
> 실행환경에 올라가면 공통컴포넌트를 포함한 모든 사업에서 같은 구현을 쓸 수 있습니다.
>
> 공통컴포넌트 원본
> - `egovframework.com.utl.cas.service.EgovSessionCookieUtil`

## 수정 사유 Reason for modification

- [ ] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [X] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

### 배경

화면에 **"세션이 N분 후 만료됩니다"** 를 띄우려면 서버 시각과 만료 시각을 스크립트가 읽을 수
있어야 합니다. 실행환경에 수단이 없어 사업마다 필터를 직접 만들고, 그 과정에서 **쿠키 속성을
손으로 조립하다 같은 실수를 반복**합니다.

공통컴포넌트 `EgovSessionCookieUtil` 이 그 예로, `Secure` 를 하드코딩해 평문 채널에서는
**브라우저가 쿠키를 저장하지 않는데 그 사실이 드러나지 않고**, 삭제 시 `path` 를 지정하지 않아
**다른 경로에서 지워지지 않습니다.**

### 추가한 것

**`cookie/EgovCookies`** — 안전 기본값이 붙는 빌더 + 읽기·삭제 헬퍼

```java
EgovCookies.builder("theme", "dark").maxAge(Duration.ofDays(30)).addTo(request, response);
Optional<String> theme = EgovCookies.value(request, "theme");
EgovCookies.expire("theme").addTo(request, response);   // 같은 Path 로 삭제
```

- 이름과 값만 주면 **HttpOnly · SameSite=Lax · Path=컨텍스트 루트** 가 붙고,
  **`Secure` 는 요청 채널을 보고 자동 판정**합니다(프록시 뒤 HTTPS 종단은 `secure(true)` 로 우선 지정)
- **`SameSite=None` 인데 `Secure` 가 아니면 생성 시점에 거부**합니다 — 브라우저가 폐기할 쿠키를
  발급하지 않습니다
- **CRLF·세미콜론이 섞인 값과 token 이 아닌 이름은 거부**합니다(정제가 아니라 실패)
- **한글·공백 값은 기본 거부**하고, `encodeValue()` 를 선택하면 URL 인코딩해 발급하며
  `decodedValue()` 로 대칭 복원합니다
- **삭제는 발급과 같은 Path·Domain 으로 `Max-Age=0`** 을 냅니다

**`session/EgovSessionExpiryCookieFilter`** — 서버 시각·만료 시각 쿠키 발행

- **세션이 없으면 발행하지 않고 세션을 새로 만들지도 않습니다**
- **무제한 세션(`maxInactiveInterval<=0`)은 만료 시각을 `-1`** 로 둡니다(과거 시각이 되면 안 됩니다)
- 쿠키 이름·경로·SameSite·httpOnly·**제외 경로**를 초기화 파라미터로 바꿉니다

**`session/EgovSessionExpiry`** — 만료 정보 값 객체(서버 시각·만료 시각·잔여·무제한 여부)

### 설계 메모

- 이 쿠키는 **화면 스크립트가 읽어야 하므로 필터 기본값만 `httpOnly=false`** 입니다. 다른
  용도로 쓸 때를 위해 켤 수 있게 두었습니다
- 세션 유지 시간이 큰 경우 **`int` 곱셈이 넘치므로 `long` 으로 계산**합니다
- 정적 자원 요청마다 쿠키를 다시 내리지 않도록 **제외 경로**를 둡니다

**보안 재검증 반영(2026-09-07)** — `decodedValue()` 가 변조된 퍼센트 인코딩(`%`, `%zz`)에 `IllegalArgumentException` 을 전파해 자기 쿠키를 바꾼 요청이 미처리 예외가 되던 것을 **빈 Optional** 로 닫았습니다(원시 값은 `value()` 로 그대로). 필터 초기화 파라미터 오류는 첫 요청이 아니라 `init()` 에서 실패하도록 앞당겼습니다(fail-closed 는 동일).

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

**35건 신규**(`EgovCookiesTest` 10 · `EgovSessionExpiryCookieFilterTest` 18 · 보안 회귀 `EgovCookiesSecurityTest` 5 · `EgovSessionExpiryCookieFilterSecurityTest` 2), 모듈 전건 통과.

| 환경 | 기본 로케일(Locale) | 모듈 실행 건수 | 결과 |
|---|---|---:|---|
| **Windows** | ko_KR | **77** | `Tests run: 77, Failures: 0, Errors: 0, Skipped: 0` |
| **Linux** (Ubuntu 22.04 / OpenJDK 17) | C.UTF-8 | **77** | `Tests run: 77, Failures: 0, Errors: 0, Skipped: 0` |

| 구분 | 건수 | 내용 |
|---|---:|---|
| 쿠키 빌더 — 기본값·채널 | 3 | HttpOnly·Lax·Secure·Path 기본값 · **평문 채널이면 Secure 자동 해제**(원본 하드코딩의 침묵 미동작 교정) · `secure(true)` 명시 우선 |
| 쿠키 빌더 — 거부 계약 | 2 | **`SameSite=None` + 비Secure 는 생성 거부** · CRLF·세미콜론·비token 이름 거부 |
| 쿠키 빌더 — 인코딩·삭제 | 2 | `encodeValue()` ↔ `decodedValue()` 대칭 · **삭제가 발급과 같은 Path·Domain** |
| 필터 — 발행 | 5 | 서버·만료 시각 발행 · 속성 기본값 · 체인 항상 호출 · **세션 없으면 미발행·미생성** · 제외 경로 |
| 필터 — 계산 | 2 | **무제한 세션은 `-1`** · **`int` 넘침 방지** |
| 필터 — 설정 | 4 | `httpOnly` 기본 `false` · 켜기 · HTTPS 요청 · 이름·경로·SameSite 변경 |

보안 회귀 7건 — 이름·값·Path·Domain 에 CR/LF·`;`·공백·비 ASCII 를 넣는 **주입 배터리는 전부 생성 시점 거부** · 세미콜론은 인코딩으로도 우회 불가 · `encodeValue` 발급은 cookie-octet 만 쓰고 `decodedValue` 로 왕복 · SameSite 표준 3값 외·평문 채널의 `None`/`Partitioned` 거부 · 변조된 퍼센트 인코딩은 빈값 · 세션 만료 쿠키는 **숫자 값만**(세션 식별자 미노출) · 오설정은 fail-closed.

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

해당 없음 — 서버 측 필터·유틸 추가이며, 검증은 위 JUnit(`MockHttpServletRequest`/`Response`)으로
수행했습니다.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

해당 없음 — 위 JUnit 테스트 결과로 갈음합니다.

---

<sub>base: `eGovFramework:main` @ `cd9fd9c` (2026-09-08 fetch 기준) · 단일 커밋</sub>
