### PR TITLE
feat: 중복 제출 방지 토큰 EgovSubmitTokens 추가

### DIFF
--- a/Presentation/org.egovframe.rte.ptl.mvc/src/main/java/org/egovframe/rte/ptl/mvc/tags/ui/SubmitTokenTag.java
+++ b/Presentation/org.egovframe.rte.ptl.mvc/src/main/java/org/egovframe/rte/ptl/mvc/tags/ui/SubmitTokenTag.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2009-2026 MOIS(Ministry of the Interior and Safety).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.egovframe.rte.ptl.mvc.tags.ui;
+
+import java.io.IOException;
+
+import org.egovframe.rte.ptl.mvc.token.EgovSubmitTokens;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.jsp.JspException;
+import jakarta.servlet.jsp.JspTagException;
+import jakarta.servlet.jsp.tagext.TagSupport;
+
+/**
+ * 중복 제출 방지 토큰을 hidden input 으로 출력하는 JSP 태그.
+ *
+ * <pre>
+ * &lt;%@ taglib prefix="ui" uri="http://egovframework.gov/ctl/ui" %&gt;
+ * &lt;form action="/orders" method="post"&gt;
+ *     &lt;ui:submitToken/&gt;                        &lt;!-- 기본 키 --&gt;
+ *     &lt;ui:submitToken tokenKey="orderForm"/&gt;    &lt;!-- 폼별 키 --&gt;
+ * &lt;/form&gt;
+ * </pre>
+ *
+ * <p>토큰 발급·검증 로직은 {@link EgovSubmitTokens} 가 갖고 있으며 이 태그는 출력만 담당한다.
+ * <b>JSP 가 아닌 뷰</b>(Thymeleaf·SPA 등)는 태그 없이 컨트롤러에서
+ * {@code EgovSubmitTokens.issue(request)} 로 토큰을 얻어 모델·응답에 담으면 된다.</p>
+ *
+ * <pre>
+ * &lt;&lt; 개정이력(Modification Information) &gt;&gt;
+ *
+ *  수정일        수정자        수정내용
+ *  ----------  --------    ---------------------------
+ *  2026.09.01  실행환경팀     최초 생성 (공통컴포넌트 DoubleSubmitTag 가 발급 로직까지
+ *                            품고 있어 JSP 없이는 쓸 수 없던 구조를, 출력 전용 얇은 태그로 분리)
+ * </pre>
+ *
+ * @author 실행환경 개발팀
+ * @since 5.1
+ * @see EgovSubmitTokens
+ */
+public class SubmitTokenTag extends TagSupport {
+
+	private static final long serialVersionUID = 1L;
+
+	private String tokenKey = EgovSubmitTokens.DEFAULT_TOKEN_KEY;
+
+	/**
+	 * 토큰 키를 반환한다.
+	 *
+	 * @return 토큰 키
+	 */
+	public String getTokenKey() {
+		return tokenKey;
+	}
+
+	/**
+	 * 토큰 키를 지정한다. 한 세션에서 여러 폼을 동시에 열 때 폼마다 다른 키를 주면
+	 * 서로 간섭하지 않는다.
+	 *
+	 * @param tokenKey 토큰 키
+	 */
+	public void setTokenKey(String tokenKey) {
+		this.tokenKey = tokenKey;
+	}
+
+	/**
+	 * 토큰을 발급해 hidden input 으로 출력한다.
+	 *
+	 * @return {@link #SKIP_BODY}
+	 * @throws JspException 출력 중 IO 오류가 발생한 경우
+	 */
+	@Override
+	public int doStartTag() throws JspException {
+		HttpServletRequest request = (HttpServletRequest) pageContext.getRequest();
+		String token = EgovSubmitTokens.issue(request, tokenKey);
+
+		String html = "<input type=\"hidden\" name=\"" + EgovSubmitTokens.PARAMETER_NAME
+				+ "\" value=\"" + token + "\"/>";
+		try {
+			pageContext.getOut().print(html);
+		} catch (IOException e) {
+			throw new JspTagException("제출 토큰 출력 중 오류가 발생했습니다.", e);
+		}
+		return SKIP_BODY;
+	}
+
+}

--- a/Presentation/org.egovframe.rte.ptl.mvc/src/main/java/org/egovframe/rte/ptl/mvc/token/EgovSubmitTokenException.java
+++ b/Presentation/org.egovframe.rte.ptl.mvc/src/main/java/org/egovframe/rte/ptl/mvc/token/EgovSubmitTokenException.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2009-2026 MOIS(Ministry of the Interior and Safety).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.egovframe.rte.ptl.mvc.token;
+
+/**
+ * 중복 제출 방지 토큰 검증 실패를 알리는 unchecked 예외.
+ *
+ * <p>{@link EgovSubmitTokens#validateOrThrow(jakarta.servlet.http.HttpServletRequest)} 계열이
+ * 던진다. 실패 사유는 {@link Reason} 으로 구분되므로, 화면에서 "중복 제출입니다"와
+ * "세션이 만료됐습니다"를 다르게 안내할 수 있다.</p>
+ *
+ * <pre>
+ * &lt;&lt; 개정이력(Modification Information) &gt;&gt;
+ *
+ *  수정일        수정자        수정내용
+ *  ----------  --------    ---------------------------
+ *  2026.09.01  실행환경팀     최초 생성 (공통컴포넌트 EgovDoubleSubmitHelper 의
+ *                            raw RuntimeException 을 사유 구분 가능한 명시 예외로 재구성)
+ * </pre>
+ *
+ * @author 실행환경 개발팀
+ * @since 5.1
+ * @see EgovSubmitTokens
+ */
+public class EgovSubmitTokenException extends RuntimeException {
+
+	private static final long serialVersionUID = 1L;
+
+	/**
+	 * 검증 실패 사유.
+	 */
+	public enum Reason {
+
+		/** 세션이 없거나 만료됐다 — 발급 이력 자체가 사라진 상태. */
+		NO_SESSION("세션이 없거나 만료되어 제출 토큰을 확인할 수 없습니다."),
+
+		/** 요청에 토큰 파라미터가 없다 — 화면에 토큰을 심지 않았을 가능성이 크다. */
+		NO_PARAMETER("요청에 제출 토큰 파라미터가 없습니다. 화면에 토큰을 출력했는지 확인하십시오."),
+
+		/** 토큰이 발급되지 않았거나 이미 소비됐다 — <b>중복 제출의 전형</b>. */
+		TOKEN_NOT_ISSUED("발급되지 않았거나 이미 사용된 제출 토큰입니다."),
+
+		/** 세션 토큰과 요청 토큰이 다르다. */
+		TOKEN_MISMATCH("제출 토큰이 일치하지 않습니다.");
+
+		private final String defaultMessage;
+
+		Reason(String defaultMessage) {
+			this.defaultMessage = defaultMessage;
+		}
+
+		/**
+		 * 사유별 기본 메시지를 반환한다.
+		 *
+		 * @return 기본 메시지
+		 */
+		public String getDefaultMessage() {
+			return defaultMessage;
+		}
+	}
+
+	private final transient Reason reason;
+
+	private final transient String tokenKey;
+
+	/**
+	 * 검증 실패 예외를 생성한다.
+	 *
+	 * @param reason   실패 사유 (null 불가)
+	 * @param tokenKey 검증 대상 토큰 키
+	 */
+	public EgovSubmitTokenException(Reason reason, String tokenKey) {
+		super(reason.getDefaultMessage() + " (tokenKey=" + tokenKey + ")");
+		this.reason = reason;
+		this.tokenKey = tokenKey;
+	}
+
+	/**
+	 * 실패 사유를 반환한다.
+	 *
+	 * @return 실패 사유
+	 */
+	public Reason getReason() {
+		return reason;
+	}
+
+	/**
+	 * 검증 대상이던 토큰 키를 반환한다.
+	 *
+	 * @return 토큰 키
+	 */
+	public String getTokenKey() {
+		return tokenKey;
+	}
+
+	/**
+	 * 중복 제출로 판단되는 사유인지 여부.
+	 *
+	 * <p>{@link Reason#TOKEN_NOT_ISSUED} · {@link Reason#TOKEN_MISMATCH} 는 이미 처리된
+	 * 요청의 재전송으로 보는 것이 타당하다. 반면 {@link Reason#NO_SESSION} 은 세션 만료,
+	 * {@link Reason#NO_PARAMETER} 는 화면 구성 누락에 가깝다.</p>
+	 *
+	 * @return 중복 제출로 판단되면 true
+	 */
+	public boolean isDuplicateSubmit() {
+		return reason == Reason.TOKEN_NOT_ISSUED || reason == Reason.TOKEN_MISMATCH;
+	}
+
+}

--- a/Presentation/org.egovframe.rte.ptl.mvc/src/main/java/org/egovframe/rte/ptl/mvc/token/EgovSubmitTokenStore.java
+++ b/Presentation/org.egovframe.rte.ptl.mvc/src/main/java/org/egovframe/rte/ptl/mvc/token/EgovSubmitTokenStore.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2009-2026 MOIS(Ministry of the Interior and Safety).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.egovframe.rte.ptl.mvc.token;
+
+import java.io.Serializable;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * 세션에 보관되는 중복 제출 방지 토큰 저장소.
+ *
+ * <p><b>이 클래스의 존재 이유는 원자성이다.</b> 토큰 검증은 "값이 같은지 확인하고 지운다"는
+ * 복합 연산이라, 확인과 삭제 사이에 다른 요청이 끼어들면 <b>둘 다 통과</b>한다 —
+ * 바로 이 기능이 막으려던 상황이다. 따라서 모든 상태 변경은 이 객체를 모니터로 삼아
+ * {@code synchronized} 안에서 수행한다.</p>
+ *
+ * <p>세션당 토큰 수는 {@link #maxTokens} 로 제한한다. 화면마다 다른 토큰 키를 쓰는 앱에서
+ * 토큰이 무한정 쌓여 세션이 비대해지는 것을 막기 위함이며, 초과 시 <b>가장 오래 전에 발급된
+ * 토큰부터</b> 제거한다({@link LinkedHashMap} 삽입 순서).</p>
+ *
+ * <p>세션 직렬화·복제(클러스터) 환경을 고려해 {@link Serializable} 이다.</p>
+ *
+ * <pre>
+ * &lt;&lt; 개정이력(Modification Information) &gt;&gt;
+ *
+ *  수정일        수정자        수정내용
+ *  ----------  --------    ---------------------------
+ *  2026.09.01  실행환경팀     최초 생성 (원본의 비동기화 HashMap + check-then-act 를
+ *                            원자 연산으로 재구성, 세션당 토큰 수 상한 도입)
+ * </pre>
+ *
+ * @author 실행환경 개발팀
+ * @since 5.1
+ * @see EgovSubmitTokens
+ */
+public class EgovSubmitTokenStore implements Serializable {
+
+	private static final long serialVersionUID = 1L;
+
+	private final Map<String, String> tokens = new LinkedHashMap<>();
+
+	private final int maxTokens;
+
+	/**
+	 * 저장소를 생성한다.
+	 *
+	 * @param maxTokens 세션당 보관할 최대 토큰 수 (1 이상)
+	 * @throws IllegalArgumentException maxTokens 가 1 미만인 경우
+	 */
+	public EgovSubmitTokenStore(int maxTokens) {
+		if (maxTokens < 1) {
+			throw new IllegalArgumentException("maxTokens must be >= 1, but was " + maxTokens);
+		}
+		this.maxTokens = maxTokens;
+	}
+
+	/**
+	 * 토큰을 발급해 보관하고 반환한다. 같은 키에 이미 토큰이 있으면 <b>새 값으로 교체</b>한다
+	 * (화면을 다시 열면 이전 화면의 토큰은 무효가 된다).
+	 *
+	 * @param tokenKey 토큰 키
+	 * @param token    발급할 토큰 값
+	 * @return 보관된 토큰 값(= 인자 token)
+	 */
+	public synchronized String put(String tokenKey, String token) {
+		tokens.remove(tokenKey);
+		tokens.put(tokenKey, token);
+		while (tokens.size() > maxTokens) {
+			// LinkedHashMap 은 삽입 순서를 유지하므로 첫 항목이 가장 오래된 토큰이다
+			String oldest = tokens.keySet().iterator().next();
+			tokens.remove(oldest);
+		}
+		return token;
+	}
+
+	/**
+	 * 토큰이 일치하면 <b>제거하고</b> true 를 반환한다 — 확인과 제거가 한 임계 구역에서
+	 * 일어나므로 동시 요청 중 <b>정확히 하나만</b> true 를 받는다.
+	 *
+	 * @param tokenKey 토큰 키
+	 * @param token    요청이 제시한 토큰 값
+	 * @return 일치해 소비했으면 true, 미발급이거나 불일치면 false
+	 */
+	public synchronized boolean consume(String tokenKey, String token) {
+		String issued = tokens.get(tokenKey);
+		if (issued != null && issued.equals(token)) {
+			tokens.remove(tokenKey);
+			return true;
+		}
+		return false;
+	}
+
+	/**
+	 * 해당 키에 발급된 토큰이 있는지 확인한다(소비하지 않는다).
+	 *
+	 * @param tokenKey 토큰 키
+	 * @return 발급돼 있으면 true
+	 */
+	public synchronized boolean isIssued(String tokenKey) {
+		return tokens.containsKey(tokenKey);
+	}
+
+	/**
+	 * 보관 중인 토큰을 모두 제거한다.
+	 */
+	public synchronized void clear() {
+		tokens.clear();
+	}
+
+	/**
+	 * 보관 중인 토큰 수를 반환한다.
+	 *
+	 * @return 토큰 수
+	 */
+	public synchronized int size() {
+		return tokens.size();
+	}
+
+}

--- a/Presentation/org.egovframe.rte.ptl.mvc/src/main/java/org/egovframe/rte/ptl/mvc/token/EgovSubmitTokens.java
+++ b/Presentation/org.egovframe.rte.ptl.mvc/src/main/java/org/egovframe/rte/ptl/mvc/token/EgovSubmitTokens.java
@@ -1,0 +1,253 @@
+/*
+ * Copyright 2009-2026 MOIS(Ministry of the Interior and Safety).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.egovframe.rte.ptl.mvc.token;
+
+import java.util.UUID;
+
+import org.egovframe.rte.ptl.mvc.token.EgovSubmitTokenException.Reason;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
+
+/**
+ * <b>중복 제출 방지 토큰</b>(멱등성 토큰) 유틸 — 같은 요청이 두 번 처리되는 것을 막는다.
+ *
+ * <p><b>CSRF 토큰과 다르다.</b> CSRF 토큰은 "제3자 사이트가 보낸 요청인가"를 가리고
+ * 세션 동안 재사용되지만, 제출 토큰은 <b>"이미 처리한 요청인가"</b>를 가리며
+ * <b>1회 사용 후 소비</b>된다. 새로고침·따닥 클릭·뒤로가기 후 재전송으로 생기는
+ * 이중 등록·이중 결제를 막는 용도이며, CSRF 방어(Spring Security)를 대체하지 않는다.</p>
+ *
+ * <p><b>사용 흐름</b> — 화면을 그릴 때 발급하고, 처리 직전에 검증한다.</p>
+ * <pre>
+ * // ① 폼 화면
+ * model.addAttribute("submitToken", EgovSubmitTokens.issue(request));
+ *
+ * // ② 처리 컨트롤러 — 실패 시 사유가 담긴 예외
+ * EgovSubmitTokens.validateOrThrow(request);
+ * orderService.register(vo);
+ * return "redirect:/orders";   // PRG 로 새로고침 재전송까지 차단
+ * </pre>
+ *
+ * <p>JSP 는 {@code <ui:submitToken/>} 태그로 hidden input 을 바로 출력할 수 있고,
+ * Thymeleaf 등 다른 뷰는 위처럼 모델에 담아 쓰면 된다 — <b>이 클래스는 뷰 기술에
+ * 의존하지 않는다.</b></p>
+ *
+ * <p><b>토큰 키</b>는 화면(폼)을 구분한다. 한 세션에서 여러 폼을 동시에 열 수 있으므로
+ * 폼마다 다른 키를 주면 서로 간섭하지 않는다. 지정하지 않으면 {@link #DEFAULT_TOKEN_KEY}.</p>
+ *
+ * <pre>
+ * &lt;&lt; 개정이력(Modification Information) &gt;&gt;
+ *
+ *  수정일        수정자        수정내용
+ *  ----------  --------    ---------------------------
+ *  2026.09.01  실행환경팀     최초 생성 (공통컴포넌트 EgovDoubleSubmitHelper·
+ *                            DoubleSubmitTag 의 설계를 차용하되 원자적 검증·뷰 비종속·
+ *                            명시 예외·토큰 상한으로 재구성 — 코드 이식 아님)
+ * </pre>
+ *
+ * @author 실행환경 개발팀
+ * @since 5.1
+ * @see EgovSubmitTokenException
+ * @see EgovSubmitTokenStore
+ */
+public final class EgovSubmitTokens {
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(EgovSubmitTokens.class);
+
+	/** 토큰을 담는 요청 파라미터(및 hidden input) 이름. */
+	public static final String PARAMETER_NAME = "egovSubmitToken";
+
+	/** 토큰 저장소를 보관하는 세션 속성 이름. */
+	public static final String SESSION_ATTRIBUTE_NAME =
+			"org.egovframe.rte.ptl.mvc.token.EgovSubmitTokens.STORE";
+
+	/** 토큰 키를 지정하지 않았을 때 쓰는 기본 키. */
+	public static final String DEFAULT_TOKEN_KEY = "DEFAULT";
+
+	/** 세션당 보관하는 최대 토큰 수 — 초과 시 가장 오래된 토큰부터 제거된다. */
+	public static final int MAX_TOKENS_PER_SESSION = 32;
+
+	private EgovSubmitTokens() {
+	}
+
+	/**
+	 * 기본 키로 토큰을 발급한다. 세션이 없으면 생성한다.
+	 *
+	 * @param request 현재 요청 (null 불가)
+	 * @return 발급된 토큰 값
+	 */
+	public static String issue(HttpServletRequest request) {
+		return issue(request, DEFAULT_TOKEN_KEY);
+	}
+
+	/**
+	 * 지정한 키로 토큰을 발급한다. 세션이 없으면 생성하며, 같은 키에 이미 토큰이 있으면
+	 * 새 값으로 교체한다.
+	 *
+	 * @param request  현재 요청 (null 불가)
+	 * @param tokenKey 토큰 키 (null·공백이면 {@link #DEFAULT_TOKEN_KEY})
+	 * @return 발급된 토큰 값
+	 * @throws IllegalArgumentException request 가 null 인 경우
+	 */
+	public static String issue(HttpServletRequest request, String tokenKey) {
+		assertRequest(request);
+		String key = normalizeKey(tokenKey);
+		String token = UUID.randomUUID().toString();
+
+		HttpSession session = request.getSession();
+		// 저장소 최초 생성이 요청 간에 겹칠 수 있으므로 세션을 모니터로 잡는다.
+		// 이후 토큰 조작은 저장소 자신이 동기화한다.
+		EgovSubmitTokenStore store;
+		synchronized (session) {
+			Object attribute = session.getAttribute(SESSION_ATTRIBUTE_NAME);
+			if (attribute instanceof EgovSubmitTokenStore) {
+				store = (EgovSubmitTokenStore) attribute;
+			} else {
+				store = new EgovSubmitTokenStore(MAX_TOKENS_PER_SESSION);
+				session.setAttribute(SESSION_ATTRIBUTE_NAME, store);
+			}
+		}
+
+		store.put(key, token);
+		LOGGER.debug("제출 토큰 발급 — tokenKey={}", key);
+		return token;
+	}
+
+	/**
+	 * 기본 키로 토큰을 검증한다. 성공하면 토큰은 <b>소비되어 재사용할 수 없다</b>.
+	 *
+	 * @param request 현재 요청 (null 불가)
+	 * @return 유효한 요청이면 true, 중복 제출·미발급·세션 부재면 false
+	 */
+	public static boolean validate(HttpServletRequest request) {
+		return validate(request, DEFAULT_TOKEN_KEY);
+	}
+
+	/**
+	 * 지정한 키로 토큰을 검증한다. 성공하면 토큰은 <b>소비되어 재사용할 수 없다</b>.
+	 *
+	 * <p>확인과 소비가 한 임계 구역에서 일어나므로, 같은 토큰으로 <b>동시에</b> 들어온
+	 * 요청 중 정확히 하나만 true 를 받는다.</p>
+	 *
+	 * @param request  현재 요청 (null 불가)
+	 * @param tokenKey 토큰 키 (null·공백이면 {@link #DEFAULT_TOKEN_KEY})
+	 * @return 유효한 요청이면 true
+	 * @throws IllegalArgumentException request 가 null 인 경우
+	 */
+	public static boolean validate(HttpServletRequest request, String tokenKey) {
+		return resolveFailure(request, tokenKey) == null;
+	}
+
+	/**
+	 * 기본 키로 토큰을 검증하고, 실패하면 사유가 담긴 예외를 던진다.
+	 *
+	 * @param request 현재 요청 (null 불가)
+	 * @throws EgovSubmitTokenException 검증에 실패한 경우
+	 */
+	public static void validateOrThrow(HttpServletRequest request) {
+		validateOrThrow(request, DEFAULT_TOKEN_KEY);
+	}
+
+	/**
+	 * 지정한 키로 토큰을 검증하고, 실패하면 사유가 담긴 예외를 던진다.
+	 *
+	 * @param request  현재 요청 (null 불가)
+	 * @param tokenKey 토큰 키 (null·공백이면 {@link #DEFAULT_TOKEN_KEY})
+	 * @throws EgovSubmitTokenException 검증에 실패한 경우
+	 * @throws IllegalArgumentException request 가 null 인 경우
+	 */
+	public static void validateOrThrow(HttpServletRequest request, String tokenKey) {
+		Reason failure = resolveFailure(request, tokenKey);
+		if (failure != null) {
+			throw new EgovSubmitTokenException(failure, normalizeKey(tokenKey));
+		}
+	}
+
+	/**
+	 * 세션에 보관된 제출 토큰을 모두 제거한다(로그아웃·세션 정리 시).
+	 * 세션이 없으면 아무 일도 하지 않는다.
+	 *
+	 * @param request 현재 요청 (null 불가)
+	 * @throws IllegalArgumentException request 가 null 인 경우
+	 */
+	public static void reset(HttpServletRequest request) {
+		assertRequest(request);
+		EgovSubmitTokenStore store = findStore(request);
+		if (store != null) {
+			store.clear();
+		}
+	}
+
+	/**
+	 * 검증을 수행하고 실패 사유를 반환한다.
+	 *
+	 * @return 성공이면 null, 실패면 사유
+	 */
+	private static Reason resolveFailure(HttpServletRequest request, String tokenKey) {
+		assertRequest(request);
+		String key = normalizeKey(tokenKey);
+
+		EgovSubmitTokenStore store = findStore(request);
+		if (store == null) {
+			LOGGER.debug("제출 토큰 검증 실패(세션·저장소 없음) — tokenKey={}", key);
+			return Reason.NO_SESSION;
+		}
+
+		String parameter = request.getParameter(PARAMETER_NAME);
+		if (parameter == null || parameter.isEmpty()) {
+			LOGGER.debug("제출 토큰 검증 실패(파라미터 없음) — tokenKey={}", key);
+			return Reason.NO_PARAMETER;
+		}
+
+		// 확인과 소비가 원자적으로 일어난다 — 동시 요청 중 하나만 통과
+		if (store.consume(key, parameter)) {
+			LOGGER.debug("제출 토큰 검증 성공·소비 — tokenKey={}", key);
+			return null;
+		}
+
+		// 미발급(이미 소비 포함)과 불일치를 구분해 알린다
+		Reason reason = store.isIssued(key) ? Reason.TOKEN_MISMATCH : Reason.TOKEN_NOT_ISSUED;
+		LOGGER.debug("제출 토큰 검증 실패({}) — tokenKey={}", reason, key);
+		return reason;
+	}
+
+	/**
+	 * 세션에서 저장소를 찾는다. 세션을 새로 만들지 않는다.
+	 *
+	 * @return 저장소, 없으면 null
+	 */
+	private static EgovSubmitTokenStore findStore(HttpServletRequest request) {
+		HttpSession session = request.getSession(false);
+		if (session == null) {
+			return null;
+		}
+		Object attribute = session.getAttribute(SESSION_ATTRIBUTE_NAME);
+		return (attribute instanceof EgovSubmitTokenStore) ? (EgovSubmitTokenStore) attribute : null;
+	}
+
+	private static String normalizeKey(String tokenKey) {
+		return (tokenKey == null || tokenKey.trim().isEmpty()) ? DEFAULT_TOKEN_KEY : tokenKey;
+	}
+
+	private static void assertRequest(HttpServletRequest request) {
+		if (request == null) {
+			throw new IllegalArgumentException("request must not be null");
+		}
+	}
+
+}

--- a/Presentation/org.egovframe.rte.ptl.mvc/src/main/resources/META-INF/taglib.tld
+++ b/Presentation/org.egovframe.rte.ptl.mvc/src/main/resources/META-INF/taglib.tld
@@ -33,4 +33,17 @@
         </attribute>
     </tag>
 
+    <tag>
+        <name>submitToken</name>
+        <tag-class>org.egovframe.rte.ptl.mvc.tags.ui.SubmitTokenTag</tag-class>
+        <body-content>empty</body-content>
+        <description>중복 제출 방지 토큰을 hidden input 으로 출력한다. 검증은 컨트롤러에서
+            EgovSubmitTokens.validateOrThrow(request) 로 수행한다.</description>
+        <attribute>
+            <name>tokenKey</name>
+            <required>false</required>
+            <rtexprvalue>true</rtexprvalue>
+        </attribute>
+    </tag>
+
 </taglib>

--- a/Presentation/org.egovframe.rte.ptl.mvc/src/test/java/org/egovframe/rte/ptl/mvc/token/EgovSubmitTokensSecurityTest.java
+++ b/Presentation/org.egovframe.rte.ptl.mvc/src/test/java/org/egovframe/rte/ptl/mvc/token/EgovSubmitTokensSecurityTest.java
@@ -1,0 +1,148 @@
+package org.egovframe.rte.ptl.mvc.token;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+import org.egovframe.rte.ptl.mvc.tags.ui.SubmitTokenTag;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.mock.web.MockHttpSession;
+import org.springframework.mock.web.MockPageContext;
+import org.springframework.mock.web.MockServletContext;
+
+/**
+ * {@link EgovSubmitTokens} 의 <b>예측 불가성·원자성·세션 바인딩·비반사</b> 회귀 검증.
+ *
+ * <p>기능 테스트({@link EgovSubmitTokensTest})가 흐름을 다루고, 이 클래스는 공격 관점의 성질을
+ * 고정한다 — 토큰을 추측할 수 없고, 동시에 두 번 쓸 수 없고, 다른 세션에서 쓸 수 없으며,
+ * 실패 응답이 요청 값을 되비추지 않는다.</p>
+ */
+class EgovSubmitTokensSecurityTest {
+
+	private static final String UUID_V4 = "[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}";
+
+	@Test
+	@DisplayName("같은 토큰으로 64건이 동시에 들어와도 정확히 1건만 통과한다 — 확인과 소비가 원자적이다")
+	void 동시_소비는_정확히_1건() throws Exception {
+		int threads = 64;
+		ExecutorService pool = Executors.newFixedThreadPool(threads);
+		try {
+			for (int round = 0; round < 5; round++) {
+				MockHttpSession session = new MockHttpSession();
+				MockHttpServletRequest issuing = new MockHttpServletRequest();
+				issuing.setSession(session);
+				String token = EgovSubmitTokens.issue(issuing, "order");
+
+				CountDownLatch ready = new CountDownLatch(threads);
+				CountDownLatch start = new CountDownLatch(1);
+				List<Future<Boolean>> results = new ArrayList<>();
+				for (int i = 0; i < threads; i++) {
+					results.add(pool.submit(() -> {
+						MockHttpServletRequest request = new MockHttpServletRequest();
+						request.setSession(session);
+						request.setParameter(EgovSubmitTokens.PARAMETER_NAME, token);
+						ready.countDown();
+						start.await();
+						return EgovSubmitTokens.validate(request, "order");
+					}));
+				}
+				ready.await();
+				start.countDown();
+
+				int passed = 0;
+				for (Future<Boolean> result : results) {
+					if (result.get()) {
+						passed++;
+					}
+				}
+				assertEquals(1, passed, "round " + round);
+			}
+		} finally {
+			pool.shutdownNow();
+		}
+	}
+
+	@Test
+	@DisplayName("토큰은 UUID v4 형식(122비트 무작위)이라 추측할 수 없고, 문자 집합이 HTML 속성·URL 에 안전하다")
+	void 토큰_형식과_유일성() {
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		Set<String> issued = new HashSet<>();
+		for (int i = 0; i < 2000; i++) {
+			String token = EgovSubmitTokens.issue(request, "k" + (i % 8));
+			assertTrue(token.matches(UUID_V4), token);
+			issued.add(token);
+		}
+		assertEquals(2000, issued.size(), "발급값이 겹치면 안 된다");
+	}
+
+	@Test
+	@DisplayName("토큰은 발급 세션에 묶인다 — 다른 세션에서 제시하면 거부되고, 그 시도가 원래 토큰을 소비하지도 않는다")
+	void 세션_바인딩() {
+		MockHttpSession victim = new MockHttpSession();
+		MockHttpServletRequest issuing = new MockHttpServletRequest();
+		issuing.setSession(victim);
+		String token = EgovSubmitTokens.issue(issuing, "pay");
+
+		MockHttpServletRequest attacker = new MockHttpServletRequest();
+		attacker.setSession(new MockHttpSession());
+		attacker.setParameter(EgovSubmitTokens.PARAMETER_NAME, token);
+		assertFalse(EgovSubmitTokens.validate(attacker, "pay"));
+
+		MockHttpServletRequest owner = new MockHttpServletRequest();
+		owner.setSession(victim);
+		owner.setParameter(EgovSubmitTokens.PARAMETER_NAME, token);
+		assertTrue(EgovSubmitTokens.validate(owner, "pay"), "다른 세션의 시도가 원래 토큰을 소비하면 안 된다");
+	}
+
+	@Test
+	@DisplayName("검증 실패 메시지는 요청이 제시한 값을 되비추지 않는다 — 화면에 그대로 찍혀도 주입이 되지 않는다")
+	void 실패_메시지_비반사() {
+		MockHttpSession session = new MockHttpSession();
+		MockHttpServletRequest issuing = new MockHttpServletRequest();
+		issuing.setSession(session);
+		EgovSubmitTokens.issue(issuing, "form");
+
+		String hostile = "x\" onfocus=\"alert(1)\" <script>";
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.setSession(session);
+		request.setParameter(EgovSubmitTokens.PARAMETER_NAME, hostile);
+		EgovSubmitTokenException failure = org.junit.jupiter.api.Assertions.assertThrows(
+				EgovSubmitTokenException.class, () -> EgovSubmitTokens.validateOrThrow(request, "form"));
+
+		assertFalse(failure.getMessage().contains("alert"), failure.getMessage());
+		assertFalse(failure.getMessage().contains("<"), failure.getMessage());
+		assertEquals(EgovSubmitTokenException.Reason.TOKEN_MISMATCH, failure.getReason());
+	}
+
+	@Test
+	@DisplayName("태그 출력은 고정 name 과 UUID value 뿐이다 — tokenKey 속성값은 출력에 실리지 않는다")
+	void 태그_출력_고정_형식() throws Exception {
+		MockServletContext context = new MockServletContext();
+		MockHttpServletRequest request = new MockHttpServletRequest(context);
+		MockHttpServletResponse response = new MockHttpServletResponse();
+		MockPageContext pageContext = new MockPageContext(context, request, response);
+
+		SubmitTokenTag tag = new SubmitTokenTag();
+		tag.setPageContext(pageContext);
+		tag.setTokenKey("form\" onfocus=\"alert(1)");
+		tag.doStartTag();
+
+		String html = response.getContentAsString();
+		assertTrue(html.matches("<input type=\"hidden\" name=\"" + EgovSubmitTokens.PARAMETER_NAME
+				+ "\" value=\"" + UUID_V4 + "\"/>"), html);
+		assertFalse(html.contains("onfocus"), html);
+	}
+
+}

--- a/Presentation/org.egovframe.rte.ptl.mvc/src/test/java/org/egovframe/rte/ptl/mvc/token/EgovSubmitTokensTest.java
+++ b/Presentation/org.egovframe.rte.ptl.mvc/src/test/java/org/egovframe/rte/ptl/mvc/token/EgovSubmitTokensTest.java
@@ -1,0 +1,285 @@
+package org.egovframe.rte.ptl.mvc.token;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.egovframe.rte.ptl.mvc.token.EgovSubmitTokenException.Reason;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpSession;
+
+/**
+ * {@link EgovSubmitTokens} 단위 테스트 — 중복 제출 방지 토큰.
+ *
+ * <p>발급·검증의 기본 계약과 함께, 원본(공통컴포넌트 EgovDoubleSubmitHelper)이 막지 못하던
+ * <b>동시 요청 경합</b>을 중점 검증한다.</p>
+ */
+class EgovSubmitTokensTest {
+
+	private MockHttpServletRequest requestWith(MockHttpSession session, String token) {
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.setSession(session);
+		if (token != null) {
+			request.setParameter(EgovSubmitTokens.PARAMETER_NAME, token);
+		}
+		return request;
+	}
+
+	// ─────────────────────────────── 발급 ───────────────────────────────
+
+	@Test
+	@DisplayName("발급하면 토큰이 생성되고 세션에 저장소가 만들어진다")
+	void 발급_기본() {
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		String token = EgovSubmitTokens.issue(request);
+
+		assertNotNull(token);
+		assertFalse(token.isEmpty());
+		assertNotNull(request.getSession(false), "발급 시 세션이 생성돼야 한다");
+		assertNotNull(request.getSession().getAttribute(EgovSubmitTokens.SESSION_ATTRIBUTE_NAME));
+	}
+
+	@Test
+	@DisplayName("발급할 때마다 값이 다르다")
+	void 발급_유일성() {
+		MockHttpSession session = new MockHttpSession();
+		String first = EgovSubmitTokens.issue(requestWith(session, null));
+		String second = EgovSubmitTokens.issue(requestWith(session, null));
+
+		assertNotEquals(first, second);
+	}
+
+	@Test
+	@DisplayName("같은 키로 재발급하면 이전 토큰은 무효가 된다(화면을 다시 연 경우)")
+	void 재발급하면_이전_토큰_무효() {
+		MockHttpSession session = new MockHttpSession();
+		String old = EgovSubmitTokens.issue(requestWith(session, null));
+		EgovSubmitTokens.issue(requestWith(session, null));
+
+		assertFalse(EgovSubmitTokens.validate(requestWith(session, old)));
+	}
+
+	// ─────────────────────────────── 검증·소비 ───────────────────────────────
+
+	@Test
+	@DisplayName("발급한 토큰은 한 번만 통과한다 — 두 번째는 중복 제출로 거부")
+	void 일회성_소비() {
+		MockHttpSession session = new MockHttpSession();
+		String token = EgovSubmitTokens.issue(requestWith(session, null));
+
+		assertTrue(EgovSubmitTokens.validate(requestWith(session, token)), "첫 제출은 통과");
+		assertFalse(EgovSubmitTokens.validate(requestWith(session, token)), "재전송은 거부");
+	}
+
+	@Test
+	@DisplayName("발급받지 않은 토큰은 거부된다")
+	void 위조_토큰_거부() {
+		MockHttpSession session = new MockHttpSession();
+		EgovSubmitTokens.issue(requestWith(session, null));
+
+		assertFalse(EgovSubmitTokens.validate(requestWith(session, "forged-token")));
+	}
+
+	@Test
+	@DisplayName("토큰 파라미터가 없으면 거부된다")
+	void 파라미터_누락_거부() {
+		MockHttpSession session = new MockHttpSession();
+		EgovSubmitTokens.issue(requestWith(session, null));
+
+		assertFalse(EgovSubmitTokens.validate(requestWith(session, null)));
+	}
+
+	@Test
+	@DisplayName("세션이 없으면 거부되고, 검증이 세션을 새로 만들지 않는다")
+	void 세션_없음_거부() {
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.setParameter(EgovSubmitTokens.PARAMETER_NAME, "any");
+
+		assertFalse(EgovSubmitTokens.validate(request));
+		assertEquals(null, request.getSession(false), "검증이 세션을 생성하면 안 된다");
+	}
+
+	// ─────────────────────────────── 동시 요청 (원본 결함) ───────────────────────────────
+
+	@Test
+	@DisplayName("같은 토큰으로 동시에 20건이 들어와도 정확히 1건만 통과한다")
+	void 동시_요청에서_하나만_통과() throws InterruptedException {
+		final int threads = 20;
+		MockHttpSession session = new MockHttpSession();
+		final String token = EgovSubmitTokens.issue(requestWith(session, null));
+
+		ExecutorService pool = Executors.newFixedThreadPool(threads);
+		CountDownLatch ready = new CountDownLatch(threads);
+		CountDownLatch start = new CountDownLatch(1);
+		CountDownLatch done = new CountDownLatch(threads);
+		AtomicInteger passed = new AtomicInteger();
+
+		try {
+			for (int i = 0; i < threads; i++) {
+				pool.execute(() -> {
+					ready.countDown();
+					try {
+						start.await();
+						if (EgovSubmitTokens.validate(requestWith(session, token))) {
+							passed.incrementAndGet();
+						}
+					} catch (InterruptedException e) {
+						Thread.currentThread().interrupt();
+					} finally {
+						done.countDown();
+					}
+				});
+			}
+			assertTrue(ready.await(5, TimeUnit.SECONDS), "스레드 준비 실패");
+			start.countDown();   // 동시 출발
+			assertTrue(done.await(10, TimeUnit.SECONDS), "동시 검증이 끝나지 않았다");
+		} finally {
+			pool.shutdownNow();
+		}
+
+		assertEquals(1, passed.get(),
+				"확인·소비가 원자적이어야 한다 — 통과 건수: " + passed.get());
+	}
+
+	// ─────────────────────────────── 토큰 키 ───────────────────────────────
+
+	@Test
+	@DisplayName("토큰 키가 다르면 서로 간섭하지 않는다(폼 여러 개 동시 사용)")
+	void 토큰_키_분리() {
+		MockHttpSession session = new MockHttpSession();
+		String orderToken = EgovSubmitTokens.issue(requestWith(session, null), "orderForm");
+		String memberToken = EgovSubmitTokens.issue(requestWith(session, null), "memberForm");
+
+		assertTrue(EgovSubmitTokens.validate(requestWith(session, orderToken), "orderForm"));
+		assertTrue(EgovSubmitTokens.validate(requestWith(session, memberToken), "memberForm"),
+				"다른 폼의 토큰은 소비되지 않아야 한다");
+	}
+
+	@Test
+	@DisplayName("다른 키의 토큰으로는 통과할 수 없다")
+	void 키_교차_거부() {
+		MockHttpSession session = new MockHttpSession();
+		String orderToken = EgovSubmitTokens.issue(requestWith(session, null), "orderForm");
+		EgovSubmitTokens.issue(requestWith(session, null), "memberForm");
+
+		assertFalse(EgovSubmitTokens.validate(requestWith(session, orderToken), "memberForm"));
+	}
+
+	@Test
+	@DisplayName("키가 null·공백이면 기본 키로 동작한다")
+	void 키_기본값() {
+		MockHttpSession session = new MockHttpSession();
+		String token = EgovSubmitTokens.issue(requestWith(session, null), null);
+
+		assertTrue(EgovSubmitTokens.validate(requestWith(session, token), "  "));
+	}
+
+	// ─────────────────────────────── 예외 계약 ───────────────────────────────
+
+	@Test
+	@DisplayName("validateOrThrow 는 중복 제출을 TOKEN_NOT_ISSUED 로 알린다")
+	void 예외_중복제출() {
+		MockHttpSession session = new MockHttpSession();
+		String token = EgovSubmitTokens.issue(requestWith(session, null));
+		EgovSubmitTokens.validateOrThrow(requestWith(session, token));   // 첫 제출
+
+		EgovSubmitTokenException e = assertThrows(EgovSubmitTokenException.class,
+				() -> EgovSubmitTokens.validateOrThrow(requestWith(session, token)));
+
+		assertEquals(Reason.TOKEN_NOT_ISSUED, e.getReason());
+		assertTrue(e.isDuplicateSubmit(), "중복 제출로 분류돼야 한다");
+		assertEquals(EgovSubmitTokens.DEFAULT_TOKEN_KEY, e.getTokenKey());
+	}
+
+	@Test
+	@DisplayName("사유별로 예외가 구분된다 — 세션 없음·파라미터 없음·불일치")
+	void 예외_사유_구분() {
+		MockHttpServletRequest noSession = new MockHttpServletRequest();
+		noSession.setParameter(EgovSubmitTokens.PARAMETER_NAME, "x");
+		assertEquals(Reason.NO_SESSION,
+				assertThrows(EgovSubmitTokenException.class,
+						() -> EgovSubmitTokens.validateOrThrow(noSession)).getReason());
+
+		MockHttpSession session = new MockHttpSession();
+		EgovSubmitTokens.issue(requestWith(session, null));
+		assertEquals(Reason.NO_PARAMETER,
+				assertThrows(EgovSubmitTokenException.class,
+						() -> EgovSubmitTokens.validateOrThrow(requestWith(session, null))).getReason());
+
+		assertEquals(Reason.TOKEN_MISMATCH,
+				assertThrows(EgovSubmitTokenException.class,
+						() -> EgovSubmitTokens.validateOrThrow(requestWith(session, "wrong"))).getReason());
+	}
+
+	@Test
+	@DisplayName("세션 만료·화면 구성 누락은 중복 제출로 분류하지 않는다")
+	void 예외_비중복_분류() {
+		MockHttpServletRequest noSession = new MockHttpServletRequest();
+		noSession.setParameter(EgovSubmitTokens.PARAMETER_NAME, "x");
+		EgovSubmitTokenException e = assertThrows(EgovSubmitTokenException.class,
+				() -> EgovSubmitTokens.validateOrThrow(noSession));
+
+		assertFalse(e.isDuplicateSubmit());
+	}
+
+	@Test
+	@DisplayName("request 가 null 이면 명시 예외")
+	void request_null_예외() {
+		assertThrows(IllegalArgumentException.class, () -> EgovSubmitTokens.issue(null));
+		assertThrows(IllegalArgumentException.class, () -> EgovSubmitTokens.validate(null));
+		assertThrows(IllegalArgumentException.class, () -> EgovSubmitTokens.reset(null));
+	}
+
+	// ─────────────────────────────── 저장소 상한·초기화 ───────────────────────────────
+
+	@Test
+	@DisplayName("세션당 토큰 수 상한을 넘으면 가장 오래된 토큰부터 제거된다")
+	void 토큰_상한() {
+		MockHttpSession session = new MockHttpSession();
+		String oldest = EgovSubmitTokens.issue(requestWith(session, null), "key-0");
+		for (int i = 1; i <= EgovSubmitTokens.MAX_TOKENS_PER_SESSION; i++) {
+			EgovSubmitTokens.issue(requestWith(session, null), "key-" + i);
+		}
+
+		EgovSubmitTokenStore store = (EgovSubmitTokenStore)
+				session.getAttribute(EgovSubmitTokens.SESSION_ATTRIBUTE_NAME);
+		assertEquals(EgovSubmitTokens.MAX_TOKENS_PER_SESSION, store.size(), "상한을 넘지 않아야 한다");
+		assertFalse(EgovSubmitTokens.validate(requestWith(session, oldest), "key-0"),
+				"가장 오래된 토큰이 제거돼야 한다");
+	}
+
+	@Test
+	@DisplayName("reset 은 세션의 토큰을 모두 제거한다")
+	void 초기화() {
+		MockHttpSession session = new MockHttpSession();
+		String token = EgovSubmitTokens.issue(requestWith(session, null));
+
+		EgovSubmitTokens.reset(requestWith(session, null));
+
+		assertFalse(EgovSubmitTokens.validate(requestWith(session, token)));
+	}
+
+	@Test
+	@DisplayName("세션이 없어도 reset 은 예외 없이 통과한다")
+	void 초기화_세션_없음() {
+		EgovSubmitTokens.reset(new MockHttpServletRequest());
+	}
+
+	@Test
+	@DisplayName("저장소 상한은 1 미만일 수 없다")
+	void 저장소_상한_검증() {
+		assertThrows(IllegalArgumentException.class, () -> new EgovSubmitTokenStore(0));
+	}
+
+}


### PR DESCRIPTION
> **[공통컴포넌트 공통 기능 개선 → 실행환경 이관]**
>
> 공통컴포넌트에 있던 공통 기능을 개선해 실행환경으로 올리는 항목입니다.
> 실행환경에 올라가면 공통컴포넌트를 포함한 모든 사업에서 같은 구현을 쓸 수 있습니다.
>
> 공통컴포넌트 원본
> - `egovframework.com.cmm.util.EgovDoubleSubmitHelper`

## 수정 사유 Reason for modification

- [ ] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [X] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

### 배경

새로고침·더블클릭·뒤로가기 후 재제출로 **같은 등록이 두 번 들어가는** 문제는 어느 사업에나
있는데 실행환경에 수단이 없습니다.

자체 구현이 흔히 세션에 **비동기화 `HashMap`** 을 두고 *"있으면 통과, 그 뒤 제거"* 식
**check-then-act** 로 처리하는데, **동시 요청에서는 둘 다 통과**합니다. 더블클릭은 바로 그
동시 요청입니다.

### 추가한 것

| 클래스 | 역할 |
|---|---|
| `token/EgovSubmitTokens` | 발급·검증 정적 API |
| `token/EgovSubmitTokenStore` | 세션 보관소(상한 32, 초과 시 오래된 것부터 제거) |
| `token/EgovSubmitTokenException` | 거부 사유를 `Reason` 으로 구분 |
| `tags/ui/SubmitTokenTag` + `taglib.tld` | hidden input 출력 태그 |

```java
// 화면
<egov:submitToken />

// 컨트롤러
EgovSubmitTokens.validateOrThrow(request);
```

- `issue` / `validate` / `validateOrThrow` / `reset` (각각 토큰 키 오버로드 있음)
- **검증은 원자적으로 소비**합니다 — 같은 토큰으로 **동시에 20건이 들어와도 정확히 1건만
  통과**합니다(테스트로 고정)

### 설계 메모

- **발급 로직은 태그가 아니라 `EgovSubmitTokens` 에 있습니다.** 태그에 로직이 있으면 JSP 를
  쓰지 않는 화면에서 재구현하게 됩니다
- **토큰 키**를 두어 한 화면에 폼이 여럿이어도 서로 간섭하지 않습니다. 키가 `null`·공백이면
  기본 키로 동작합니다
- **같은 키로 재발급하면 이전 토큰은 무효**가 됩니다(화면을 다시 연 경우)
- **검증이 세션을 새로 만들지 않습니다.** 세션이 없으면 거부입니다
- **세션 만료·화면 구성 누락을 중복 제출과 다른 사유로 구분**합니다. 사용자에게 보여줄 안내
  문구가 달라야 하기 때문입니다
- 세션당 토큰 상한을 두어 **무한 증가를 막습니다**(초과 시 가장 오래된 것부터 제거)

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

`EgovSubmitTokensTest` **19건** + 보안 회귀 `EgovSubmitTokensSecurityTest` **5건**, 합계 **24건 신규**. `ptl.mvc` 모듈 전건 통과.

| 환경 | 기본 로케일(Locale) | 모듈 실행 건수 | 결과 |
|---|---|---:|---|
| **Windows** | ko_KR | **66** | `Tests run: 66, Failures: 0, Errors: 0, Skipped: 0` |
| **Linux** (Ubuntu 22.04 / OpenJDK 17) | C.UTF-8 | **66** | `Tests run: 66, Failures: 0, Errors: 0, Skipped: 0` |

| 구분 | 건수 | 내용 |
|---|---:|---|
| 발급·검증 | 7 | 발급 시 세션 저장소 생성 · 매번 다른 값 · **재발급 시 이전 토큰 무효** · **한 번만 통과** · 미발급 토큰 거부 · 파라미터 없으면 거부 · **세션 없으면 거부하되 생성하지 않음** |
| **동시성** | 1 | **같은 토큰 동시 20건 중 정확히 1건만 통과** |
| 토큰 키 | 3 | 키가 다르면 무간섭 · 다른 키로는 통과 불가 · `null`·공백은 기본 키 |
| 예외 사유 | 4 | `validateOrThrow` 사유 전달 · 사유별 구분(세션 없음·파라미터 없음·불일치) · **세션 만료·구성 누락을 중복 제출과 분리** · `request` `null` 명시 예외 |
| 상한·정리 | 4 | **상한 초과 시 오래된 것부터 제거** · `reset` 전체 제거 · 세션 없어도 `reset` 무예외 · 상한 1 미만 거부 |

`EgovSubmitTokensSecurityTest` 5건 — **64 스레드 동시 소비에서 정확히 1건만 통과**(래치로 결정적) · UUID v4 형식과 2,000건 유일성 · 세션 바인딩(다른 세션의 같은 토큰은 소비되지 않음) · 실패 메시지에 요청 토큰 미반사 · 태그 출력 고정.

**수동 확인(2026-09-08)**: `taglib.tld` 는 JSP 컨테이너가 읽는 파일이라 단위 테스트로 검증되지 않으므로,
이 실행환경 위에서 공통컴포넌트 WAR 를 **Tomcat 11(내장) 로 기동해 실제 렌더링**을 확인했습니다.
- 배포 시 TLD 스캔·Jasper 오류 0건, 같은 `ui` URI 를 임포트하는 기존 JSP(로그인 화면·부서 조회 화면) 정상 렌더링
- `<ui:submitToken/>` 과 `<ui:submitToken tokenKey="…"/>` 가 `<input type="hidden" name="egovSubmitToken" value="<UUID v4>"/>`
  로 출력되고, 같은 세션의 재요청·다른 세션에서 각각 새 토큰이 발급됨

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

*(JSP 스모크 테스트 수행 후 사용 브라우저를 체크한다)*

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

*(JSP 렌더링 결과 캡처를 첨부한다)*

---

<sub>base: `eGovFramework:main` @ `cd9fd9c` (2026-09-08 fetch 기준) · 단일 커밋</sub>
