### PR TITLE
feat: HTMLTagFilter 에 허용 태그·리치텍스트 우회·제외 경로 초기화 파라미터 추가

### DIFF
--- a/Presentation/org.egovframe.rte.ptl.mvc/src/main/java/org/egovframe/rte/ptl/mvc/filter/HTMLTagFilter.java
+++ b/Presentation/org.egovframe.rte.ptl.mvc/src/main/java/org/egovframe/rte/ptl/mvc/filter/HTMLTagFilter.java
@@ -19,9 +19,29 @@ import jakarta.servlet.*;
 import jakarta.servlet.http.HttpServletRequest;
 
 import java.io.IOException;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.Set;
 
 /**
  * HTMLTagFilter.java
+ *
+ * <p>요청 파라미터의 HTML 특수문자를 엔티티로 인코딩하는 필터. 초기화 파라미터 없이 등록하면
+ * 종전과 완전히 같은 동작(모든 {@code < > & " '} 인코딩)이며, 아래 초기화 파라미터로
+ * 허용 태그·리치텍스트 우회·제외 경로를 지정할 수 있다.</p>
+ *
+ * <pre>
+ * &lt;filter&gt;
+ *     &lt;filter-name&gt;htmlTagFilter&lt;/filter-name&gt;
+ *     &lt;filter-class&gt;org.egovframe.rte.ptl.mvc.filter.HTMLTagFilter&lt;/filter-class&gt;
+ *     &lt;init-param&gt;&lt;param-name&gt;allowedTags&lt;/param-name&gt;&lt;param-value&gt;p, br&lt;/param-value&gt;&lt;/init-param&gt;
+ *     &lt;init-param&gt;&lt;param-name&gt;richTextParameters&lt;/param-name&gt;&lt;param-value&gt;nttCn&lt;/param-value&gt;&lt;/init-param&gt;
+ *     &lt;init-param&gt;&lt;param-name&gt;excludePaths&lt;/param-name&gt;&lt;param-value&gt;/api/*&lt;/param-value&gt;&lt;/init-param&gt;
+ * &lt;/filter&gt;
+ * </pre>
+ *
+ * <p><b>리치텍스트 우회 파라미터는 출력 시점 정제가 전제다.</b> 우회한 값은 저장·출력 전에
+ * 반드시 {@link EgovHtmlSanitizer} 로 정제한다 — 우회만 하고 정제하지 않으면 XSS 무방비가 된다.</p>
  *
  * @author 실행환경 개발팀 함철
  * @version 1.0
@@ -31,23 +51,78 @@ import java.io.IOException;
  * 수정일		수정자				수정내용
  * ----------------------------------------------
  * 2009.05.30	함철				최초 생성
+ * 2026.09.01	실행환경 개발팀		FilterConfig 초기화 파라미터 승격 —
+ *                              allowedTags·richTextParameters·excludePaths
  * </pre>
  * @since 2009.06.01
  */
 public class HTMLTagFilter implements Filter {
 
-    @SuppressWarnings("unused")
-    private FilterConfig config;
+    /** 초기화 파라미터 — 쉼표 구분 허용 태그 이름(예: {@code p, br}). 속성 없는 형태만 통과한다. */
+    public static final String INIT_PARAM_ALLOWED_TAGS = "allowedTags";
+
+    /** 초기화 파라미터 — 쉼표 구분 리치텍스트 파라미터명. 해당 파라미터는 인코딩을 우회한다. */
+    public static final String INIT_PARAM_RICH_TEXT_PARAMETERS = "richTextParameters";
+
+    /** 초기화 파라미터 — 쉼표 구분 제외 경로. {@code /*} 로 끝나면 접두 일치, 아니면 정확 일치. */
+    public static final String INIT_PARAM_EXCLUDE_PATHS = "excludePaths";
+
+    private Set<String> allowedTagNames = Collections.emptySet();
+    private Set<String> richTextParameterNames = Collections.emptySet();
+    private Set<String> excludePaths = Collections.emptySet();
 
     public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
-        chain.doFilter(new HTMLTagFilterRequestWrapper((HttpServletRequest) request), response);
+        HttpServletRequest httpRequest = (HttpServletRequest) request;
+        if (isExcludedPath(httpRequest)) {
+            chain.doFilter(request, response);
+            return;
+        }
+        chain.doFilter(new HTMLTagFilterRequestWrapper(httpRequest, allowedTagNames, richTextParameterNames), response);
     }
 
     public void init(FilterConfig config) {
-        this.config = config;
+        if (config == null) {
+            return;
+        }
+        this.allowedTagNames = parseCsv(config.getInitParameter(INIT_PARAM_ALLOWED_TAGS));
+        this.richTextParameterNames = parseCsv(config.getInitParameter(INIT_PARAM_RICH_TEXT_PARAMETERS));
+        this.excludePaths = parseCsv(config.getInitParameter(INIT_PARAM_EXCLUDE_PATHS));
     }
 
     public void destroy() {
+    }
+
+    /** 컨텍스트 상대 경로 기준으로 제외 대상인지 판정한다. */
+    private boolean isExcludedPath(HttpServletRequest request) {
+        if (excludePaths.isEmpty()) {
+            return false;
+        }
+        String path = request.getRequestURI().substring(request.getContextPath().length());
+        for (String exclude : excludePaths) {
+            if (exclude.endsWith("/*")) {
+                String base = exclude.substring(0, exclude.length() - 2);
+                if (path.equals(base) || path.startsWith(base + "/")) {
+                    return true;
+                }
+            } else if (path.equals(exclude)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static Set<String> parseCsv(String raw) {
+        if (raw == null || raw.trim().isEmpty()) {
+            return Collections.emptySet();
+        }
+        Set<String> parsed = new LinkedHashSet<String>();
+        for (String token : raw.split(",")) {
+            String trimmed = token.trim();
+            if (!trimmed.isEmpty()) {
+                parsed.add(trimmed);
+            }
+        }
+        return parsed;
     }
 
 }

--- a/Presentation/org.egovframe.rte.ptl.mvc/src/main/java/org/egovframe/rte/ptl/mvc/filter/HTMLTagFilterRequestWrapper.java
+++ b/Presentation/org.egovframe.rte.ptl.mvc/src/main/java/org/egovframe/rte/ptl/mvc/filter/HTMLTagFilterRequestWrapper.java
@@ -18,11 +18,21 @@ package org.egovframe.rte.ptl.mvc.filter;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletRequestWrapper;
 
+import java.util.Collections;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * HTMLTagFilterRequestWrapper.java
+ *
+ * <p>요청 파라미터의 HTML 특수문자를 엔티티로 인코딩하는 래퍼. 기본 동작(인자 없는 생성자)은
+ * 모든 {@code < > & " '} 를 인코딩하며, {@link HTMLTagFilter}의 초기화 파라미터로
+ * <b>허용 태그</b>(속성 없는 {@code <p>}·{@code </p>}·{@code <br/>} 형태만 통과)와
+ * <b>리치텍스트 우회 파라미터</b>(인코딩 전체 우회 — 출력 시점에 {@code EgovHtmlSanitizer}
+ * 정제가 전제)를 지정할 수 있다.</p>
  *
  * @author 실행환경 개발팀 함철
  * @version 1.0
@@ -32,19 +42,48 @@ import java.util.Map;
  * 수정일		수정자				수정내용
  * ----------------------------------------------
  * 2009.05.30	함철				최초 생성
+ * 2026.09.01	실행환경 개발팀		허용 태그·리치텍스트 우회 목록 지원(공통컴포넌트
+ *                              분기 기능을 하드코딩 없이 설정형으로 승격 — & 인코딩 유지,
+ *                              사본과 달리 원본 배열·맵은 변조하지 않는다)
  * </pre>
  * @since 2009.06.01
  */
 public class HTMLTagFilterRequestWrapper extends HttpServletRequestWrapper {
 
+    /** 인코딩하지 않고 통과시킬 허용 태그 이름(소문자) — 속성이 붙으면 통과하지 않는다. */
+    private final Set<String> allowedTagNames;
+
+    /** 인코딩을 통째로 우회하는 리치텍스트 파라미터명. */
+    private final Set<String> richTextParameterNames;
+
     public HTMLTagFilterRequestWrapper(HttpServletRequest request) {
+        this(request, Collections.emptySet(), Collections.emptySet());
+    }
+
+    /**
+     * 허용 태그·리치텍스트 우회 목록을 받는 생성자. 두 목록이 비어 있으면
+     * 기존 생성자와 동작이 완전히 같다.
+     *
+     * @param request                요청
+     * @param allowedTagNames        허용 태그 이름 목록(예: {@code p}, {@code br} — 대소문자 무관)
+     * @param richTextParameterNames 인코딩을 우회할 파라미터명 목록
+     */
+    public HTMLTagFilterRequestWrapper(HttpServletRequest request, Set<String> allowedTagNames,
+            Set<String> richTextParameterNames) {
         super(request);
+        this.allowedTagNames = lowerCased(allowedTagNames);
+        this.richTextParameterNames = (richTextParameterNames == null || richTextParameterNames.isEmpty())
+                ? Collections.emptySet()
+                : new LinkedHashSet<String>(richTextParameterNames);
     }
 
     public String[] getParameterValues(String parameter) {
         String[] values = super.getParameterValues(parameter);
         if (values == null) {
             return null;
+        }
+        if (isRichTextParameter(parameter)) {
+            return values.clone();
         }
         String[] safeValues = new String[values.length];
         for (int i = 0; i < values.length; i++) {
@@ -62,6 +101,9 @@ public class HTMLTagFilterRequestWrapper extends HttpServletRequestWrapper {
         if (value == null) {
             return null;
         }
+        if (isRichTextParameter(parameter)) {
+            return value;
+        }
         value = getSafeParamData(value);
         return value;
     }
@@ -71,6 +113,10 @@ public class HTMLTagFilterRequestWrapper extends HttpServletRequestWrapper {
         Map<String, String[]> safeValueMap = new LinkedHashMap<String, String[]>();
         for (String key : valueMap.keySet()) {
             String[] values = valueMap.get(key);
+            if (isRichTextParameter(key)) {
+                safeValueMap.put(key, (values == null) ? null : values.clone());
+                continue;
+            }
             String[] safeValues = new String[values.length];
             for (int i = 0; i < values.length; i++) {
                 if (values[i] != null) {
@@ -87,6 +133,10 @@ public class HTMLTagFilterRequestWrapper extends HttpServletRequestWrapper {
     /**
      * XSS 방지를 위해 파라미터 값을 HTML 엔티티로 이스케이프.
      * null 입력 시 null 반환 (NPE 방지).
+     *
+     * <p>허용 태그가 설정된 경우, 속성 없는 여닫는 형태({@code <p>}·{@code </p>}·{@code <br/>}·
+     * {@code <br />})만 원문 그대로 통과한다 — 속성이 하나라도 붙으면({@code <p onclick=…>})
+     * 통과하지 않는다.</p>
      */
     public String getSafeParamData(String value) {
         if (value == null) {
@@ -97,7 +147,13 @@ public class HTMLTagFilterRequestWrapper extends HttpServletRequestWrapper {
             char c = value.charAt(i);
             switch (c) {
                 case '<':
-                    stringBuilder.append("&lt;");
+                    int tagEnd = matchAllowedTag(value, i);
+                    if (tagEnd >= 0) {
+                        stringBuilder.append(value, i, tagEnd + 1);
+                        i = tagEnd;
+                    } else {
+                        stringBuilder.append("&lt;");
+                    }
                     break;
                 case '>':
                     stringBuilder.append("&gt;");
@@ -118,6 +174,62 @@ public class HTMLTagFilterRequestWrapper extends HttpServletRequestWrapper {
         }
         value = stringBuilder.toString();
         return value;
+    }
+
+    private boolean isRichTextParameter(String parameter) {
+        return !richTextParameterNames.isEmpty() && richTextParameterNames.contains(parameter);
+    }
+
+    /**
+     * {@code ltIndex}({@code '<'} 위치)에서 시작하는 부분이 허용 태그의 온전한 여닫는 형태이면
+     * 닫는 {@code '>'} 의 인덱스를, 아니면 -1 을 반환한다. 문자열 끝에 걸친 태그도 정상 판정한다
+     * (공통컴포넌트 사본은 끝 경계에서 {@code &lt;p>} 혼종을 만드는 버그가 있었다).
+     */
+    private int matchAllowedTag(String value, int ltIndex) {
+        if (allowedTagNames.isEmpty()) {
+            return -1;
+        }
+        int length = value.length();
+        int i = ltIndex + 1;
+        boolean closing = (i < length && value.charAt(i) == '/');
+        if (closing) {
+            i++;
+        }
+        int nameStart = i;
+        while (i < length && isAsciiLetter(value.charAt(i))) {
+            i++;
+        }
+        if (i == nameStart) {
+            return -1;
+        }
+        String name = value.substring(nameStart, i).toLowerCase(Locale.ROOT);
+        if (!allowedTagNames.contains(name)) {
+            return -1;
+        }
+        while (i < length && value.charAt(i) == ' ') {
+            i++;
+        }
+        if (!closing && i < length && value.charAt(i) == '/') {
+            i++;
+        }
+        return (i < length && value.charAt(i) == '>') ? i : -1;
+    }
+
+    private static boolean isAsciiLetter(char c) {
+        return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z');
+    }
+
+    private static Set<String> lowerCased(Set<String> names) {
+        if (names == null || names.isEmpty()) {
+            return Collections.emptySet();
+        }
+        Set<String> lowered = new LinkedHashSet<String>();
+        for (String name : names) {
+            if (name != null && !name.isEmpty()) {
+                lowered.add(name.toLowerCase(Locale.ROOT));
+            }
+        }
+        return lowered;
     }
 
 }

--- a/Presentation/org.egovframe.rte.ptl.mvc/src/test/java/org/egovframe/rte/ptl/mvc/filter/HTMLTagFilterSecurityTest.java
+++ b/Presentation/org.egovframe.rte.ptl.mvc/src/test/java/org/egovframe/rte/ptl/mvc/filter/HTMLTagFilterSecurityTest.java
@@ -1,0 +1,116 @@
+package org.egovframe.rte.ptl.mvc.filter;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockFilterConfig;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * {@link HTMLTagFilter} 초기화 파라미터의 <b>보안 경계</b> 회귀 검증(CWE-79 입력 필터).
+ *
+ * <p>기능 테스트({@link HTMLTagFilterTest})가 정상 동작을 다루고, 이 클래스는 세 설정
+ * (allowedTags·richTextParameters·excludePaths)이 우회 입력에서 방어를 잃지 않는지 고정한다.</p>
+ */
+public class HTMLTagFilterSecurityTest {
+
+    private HttpServletRequest wrap(HTMLTagFilter filter, MockHttpServletRequest request)
+            throws IOException, ServletException {
+        MockFilterChain chain = new MockFilterChain();
+        filter.doFilter(request, new MockHttpServletResponse(), chain);
+        return (HttpServletRequest) chain.getRequest();
+    }
+
+    private HTMLTagFilter filterWith(String name, String value) {
+        HTMLTagFilter filter = new HTMLTagFilter();
+        MockFilterConfig config = new MockFilterConfig();
+        config.addInitParameter(name, value);
+        filter.init(config);
+        return filter;
+    }
+
+    @Test
+    public void 허용_태그를_지정해도_속성_붙은_태그는_통과하지_못한다() throws IOException, ServletException {
+        HTMLTagFilter filter = filterWith("allowedTags", "p, br, b");
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        String[] attacks = {
+                "<p onclick=alert(1)>x</p>",
+                "<p onclick=\"alert(1)\">x</p>",
+                "<b style=\"x:expression(alert(1))\">x</b>",
+                "<p id=x>y</p>",
+                "<br onfocus=alert(1)>",
+                "<p\tonclick=alert(1)>x</p>" };
+        for (int i = 0; i < attacks.length; i++) {
+            request.setParameter("p" + i, attacks[i]);
+        }
+        HttpServletRequest filtered = wrap(filter, request);
+        for (int i = 0; i < attacks.length; i++) {
+            String out = filtered.getParameter("p" + i);
+            assertFalse(out.contains("onclick") && out.contains("<p onclick"), "속성 태그 원문 통과: " + out);
+            assertTrue(out.startsWith("&lt;"), "속성이 붙은 태그의 여는 꺾쇠는 인코딩돼야 한다: " + out);
+        }
+    }
+
+    @Test
+    public void 허용_태그가_있어도_스크립트_꺾쇠와_앰퍼샌드는_계속_인코딩된다() throws IOException, ServletException {
+        HTMLTagFilter filter = filterWith("allowedTags", "p, br");
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setParameter("a", "<script>alert(1)</script>");
+        request.setParameter("b", "&lt;script&gt;");
+        request.setParameter("c", "<img src=x onerror=alert(1)>");
+        HttpServletRequest filtered = wrap(filter, request);
+        assertFalse(filtered.getParameter("a").contains("<script"), "script 원문 통과: " + filtered.getParameter("a"));
+        assertTrue(filtered.getParameter("b").startsWith("&amp;lt;"), "앰퍼샌드 미인코딩: " + filtered.getParameter("b"));
+        assertFalse(filtered.getParameter("c").contains("<img"), "img 원문 통과: " + filtered.getParameter("c"));
+    }
+
+    @Test
+    public void 허용_태그_이름은_ASCII_글자만_인정하고_제어문자_섞인_태그는_인코딩된다() throws IOException, ServletException {
+        HTMLTagFilter filter = filterWith("allowedTags", "p");
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setParameter("a", "<p" + (char) 0x00 + ">x");
+        request.setParameter("b", "<p" + (char) 0x09 + ">x");
+        request.setParameter("c", "<pscript>x");
+        HttpServletRequest filtered = wrap(filter, request);
+        assertTrue(filtered.getParameter("a").startsWith("&lt;"), "NUL 섞인 태그가 통과: " + filtered.getParameter("a"));
+        assertTrue(filtered.getParameter("c").startsWith("&lt;"), "다른 태그가 접두 일치로 통과: " + filtered.getParameter("c"));
+    }
+
+    @Test
+    public void 리치텍스트_우회_파라미터만_우회하고_다른_파라미터는_인코딩된다() throws IOException, ServletException {
+        HTMLTagFilter filter = filterWith("richTextParameters", "nttCn");
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setParameter("nttCn", "<b>본문</b>");
+        request.setParameter("title", "<img src=x onerror=alert(1)>");
+        HttpServletRequest filtered = wrap(filter, request);
+        assertFalse(filtered.getParameter("title").contains("<img"), "일반 파라미터가 우회됨: " + filtered.getParameter("title"));
+        assertTrue(filtered.getParameter("nttCn").contains("<b>"), "우회 파라미터가 인코딩됨: " + filtered.getParameter("nttCn"));
+    }
+
+    @Test
+    public void 제외_경로는_접미_트릭으로_과도하게_일치하지_않는다() throws IOException, ServletException {
+        HTMLTagFilter filter = new HTMLTagFilter();
+        MockFilterConfig config = new MockFilterConfig();
+        config.addInitParameter("excludePaths", "/api/*, /health");
+        filter.init(config);
+
+        // 제외 대상이 "아닌" 경로들은 여전히 래핑(인코딩)돼야 한다 — 접미 트릭으로 필터를 우회할 수 없다
+        String[] notExcluded = { "/apix/things", "/health-check", "/board/list", "/health/sub" };
+        for (String path : notExcluded) {
+            MockHttpServletRequest request = new MockHttpServletRequest("POST", path);
+            request.setParameter("c", "<b>");
+            HttpServletRequest filtered = wrap(filter, request);
+            assertInstanceOf(HTMLTagFilterRequestWrapper.class, filtered, path + " 이 래핑을 벗어남");
+            assertTrue("&lt;b&gt;".equals(filtered.getParameter("c")), path + " 에서 인코딩 누락: " + filtered.getParameter("c"));
+        }
+    }
+
+}

--- a/Presentation/org.egovframe.rte.ptl.mvc/src/test/java/org/egovframe/rte/ptl/mvc/filter/HTMLTagFilterTest.java
+++ b/Presentation/org.egovframe.rte.ptl.mvc/src/test/java/org/egovframe/rte/ptl/mvc/filter/HTMLTagFilterTest.java
@@ -4,6 +4,7 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import org.junit.jupiter.api.Test;
 import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockFilterConfig;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 
@@ -12,6 +13,8 @@ import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 public class HTMLTagFilterTest {
 
@@ -89,6 +92,118 @@ public class HTMLTagFilterTest {
         requestWrapper.getParameterValues("param01");
 
         assertEquals("<b>test</b>", request.getParameter("param01"));
+    }
+
+    // ---------------------------------------------------------------- FilterConfig 초기화 파라미터
+
+    private HttpServletRequest filteredRequest(HTMLTagFilter filter, MockHttpServletRequest request)
+            throws IOException, ServletException {
+        MockFilterChain chain = new MockFilterChain();
+        filter.doFilter(request, new MockHttpServletResponse(), chain);
+        return (HttpServletRequest) chain.getRequest();
+    }
+
+    @Test
+    public void 설정이_없으면_기존_동작_그대로_모든_태그를_인코딩한다() throws IOException, ServletException {
+        HTMLTagFilter filter = new HTMLTagFilter();
+        filter.init(new MockFilterConfig());
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addParameter("content", "<p>단락</p>");
+
+        assertEquals("&lt;p&gt;단락&lt;/p&gt;", filteredRequest(filter, request).getParameter("content"));
+    }
+
+    @Test
+    public void 허용_태그는_속성_없는_여닫는_형태만_통과한다() throws IOException, ServletException {
+        HTMLTagFilter filter = new HTMLTagFilter();
+        MockFilterConfig config = new MockFilterConfig();
+        config.addInitParameter("allowedTags", " p , , br ");
+        filter.init(config);
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addParameter("content", "<p>단락</p><br/><BR><br /><script>alert(1)</script>");
+        request.addParameter("attack", "<p onclick=x>y</p>");
+
+        HttpServletRequest filtered = filteredRequest(filter, request);
+        assertEquals("<p>단락</p><br/><BR><br />&lt;script&gt;alert(1)&lt;/script&gt;",
+                filtered.getParameter("content"), "허용 태그(대소문자·자기닫힘 포함)만 통과");
+        assertEquals("&lt;p onclick=x&gt;y</p>", filtered.getParameter("attack"),
+                "속성이 붙으면 허용 태그라도 통과하지 않는다");
+    }
+
+    @Test
+    public void 문자열_끝의_허용_태그도_통과한다_공통컴포넌트_사본의_경계_버그_회귀() throws IOException, ServletException {
+        // 공통컴포넌트 사본은 값이 허용 태그로 끝나면 &lt;p> 혼종을 만들었다(checkNextWhiteListTag 경계 오류)
+        HTMLTagFilter filter = new HTMLTagFilter();
+        MockFilterConfig config = new MockFilterConfig();
+        config.addInitParameter("allowedTags", "p");
+        filter.init(config);
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addParameter("content", "문단 시작 <p>");
+
+        assertEquals("문단 시작 <p>", filteredRequest(filter, request).getParameter("content"));
+    }
+
+    @Test
+    public void 허용_태그가_있어도_앰퍼샌드는_계속_인코딩한다_사본의_주석_처리와_대조() throws IOException, ServletException {
+        // 공통컴포넌트 사본은 & 인코딩이 주석 처리되어 &lt; 선인코딩 입력이 그대로 통과했다
+        HTMLTagFilter filter = new HTMLTagFilter();
+        MockFilterConfig config = new MockFilterConfig();
+        config.addInitParameter("allowedTags", "p");
+        filter.init(config);
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addParameter("content", "&lt;script&gt;");
+
+        assertEquals("&amp;lt;script&amp;gt;", filteredRequest(filter, request).getParameter("content"));
+    }
+
+    @Test
+    public void 리치텍스트_파라미터는_인코딩을_우회하고_나머지는_인코딩한다() throws IOException, ServletException {
+        HTMLTagFilter filter = new HTMLTagFilter();
+        MockFilterConfig config = new MockFilterConfig();
+        config.addInitParameter("richTextParameters", "nttCn");
+        filter.init(config);
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addParameter("nttCn", "<b>본문&\"'</b>");
+        request.addParameter("title", "<b>");
+
+        HttpServletRequest filtered = filteredRequest(filter, request);
+        assertEquals("<b>본문&\"'</b>", filtered.getParameter("nttCn"), "우회 파라미터는 원문 유지");
+        assertEquals("&lt;b&gt;", filtered.getParameter("title"), "그 외 파라미터는 종전대로 인코딩");
+        assertArrayEquals(new String[]{"<b>본문&\"'</b>"}, filtered.getParameterValues("nttCn"));
+        assertArrayEquals(new String[]{"<b>본문&\"'</b>"}, filtered.getParameterMap().get("nttCn"));
+    }
+
+    @Test
+    public void 리치텍스트_우회도_원본_배열을_노출하지_않는다() {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addParameter("nttCn", "<b>본문</b>");
+        HTMLTagFilterRequestWrapper wrapper = new HTMLTagFilterRequestWrapper(
+                request, java.util.Collections.emptySet(), java.util.Collections.singleton("nttCn"));
+
+        wrapper.getParameterValues("nttCn")[0] = "변조";
+
+        assertEquals("<b>본문</b>", wrapper.getParameter("nttCn"), "반환 배열을 바꿔도 원본은 그대로");
+    }
+
+    @Test
+    public void 제외_경로는_래핑_없이_통과한다() throws IOException, ServletException {
+        HTMLTagFilter filter = new HTMLTagFilter();
+        MockFilterConfig config = new MockFilterConfig();
+        config.addInitParameter("excludePaths", "/api/*, /health");
+        filter.init(config);
+
+        MockHttpServletRequest apiRequest = new MockHttpServletRequest("POST", "/api/things");
+        apiRequest.addParameter("content", "<b>");
+        assertSame(apiRequest, filteredRequest(filter, apiRequest), "접두 일치 경로는 원 요청 그대로");
+
+        MockHttpServletRequest healthRequest = new MockHttpServletRequest("GET", "/health");
+        assertSame(healthRequest, filteredRequest(filter, healthRequest), "정확 일치 경로도 제외");
+
+        MockHttpServletRequest boardRequest = new MockHttpServletRequest("POST", "/board/list");
+        boardRequest.addParameter("content", "<b>");
+        HttpServletRequest filtered = filteredRequest(filter, boardRequest);
+        assertInstanceOf(HTMLTagFilterRequestWrapper.class, filtered, "그 외 경로는 래핑");
+        assertEquals("&lt;b&gt;", filtered.getParameter("content"));
     }
 
 }


### PR DESCRIPTION
> **[공통컴포넌트 포크 해소]**
>
> 실행환경 필터가 설정을 받지 못해 공통컴포넌트가 같은 클래스를 포크해 두고 있습니다.
> 포크본은 업무 필드명을 소스에 하드코딩합니다.
> 실행환경이 설정을 받도록 열면 그 포크가 필요 없어집니다.
>
> 공통컴포넌트 포크본
> - `egovframework.com.cmm.filter.HTMLTagFilter`

## 수정 사유 Reason for modification

- [ ] 버그수정 Bug fixes
- [X] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

### 배경

`HTMLTagFilter` 는 요청 파라미터의 HTML 특수문자를 **전량 인코딩**합니다. 안전하지만
**설정 지점이 없어**, 리치 텍스트 에디터로 작성한 본문처럼 HTML 을 허용해야 하는 경로가
하나라도 있으면 **필터를 통째로 끄게** 됩니다. 그러면 그 애플리케이션의 **모든 파라미터가
방어를 잃습니다.**

### 추가한 초기화 파라미터

```xml
<filter>
    <filter-name>htmlTagFilter</filter-name>
    <filter-class>org.egovframe.rte.ptl.mvc.filter.HTMLTagFilter</filter-class>
    <init-param><param-name>allowedTags</param-name><param-value>p, br</param-value></init-param>
    <init-param><param-name>richTextParameters</param-name><param-value>nttCn</param-value></init-param>
    <init-param><param-name>excludePaths</param-name><param-value>/api/*</param-value></init-param>
</filter>
```

| 파라미터 | 뜻 |
|---|---|
| `allowedTags` | 속성 없는 여닫는 형태만 통과시킬 태그 목록 |
| `richTextParameters` | 인코딩을 우회할 파라미터 이름 목록 |
| `excludePaths` | 필터 래핑 자체를 건너뛸 경로 패턴 |

### 호환성 — 기본 동작이 바뀌지 않습니다

- **초기화 파라미터를 하나도 주지 않으면 종전과 완전히 같은 동작**입니다
  (모든 `< > & " '` 인코딩)
- **기존 테스트 7건이 무수정으로 통과**합니다
- 기존 생성자·메서드 시그니처를 바꾸지 않았습니다

### 설계 메모

- **허용 태그는 속성 없는 형태만** 통과시킵니다. 속성을 허용하면 `onclick` 같은 이벤트
  핸들러가 들어올 수 있습니다
- **허용 태그를 지정해도 앰퍼샌드는 계속 인코딩**합니다
- **리치텍스트 우회는 출력 시점 정제가 전제입니다.** 우회한 값을 그대로 출력하면 방어가 없는
  것과 같으므로 javadoc 에 명시했습니다
- **우회 경로에서도 컨테이너의 원본 파라미터 배열을 노출하지 않습니다**

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

**12건 신규**(기존 7건 유지 → `HTMLTagFilterTest` 14건 · 보안 회귀 `HTMLTagFilterSecurityTest` 5건), `ptl.mvc` 모듈 전건 통과.

| 환경 | 기본 로케일(Locale) | 모듈 실행 건수 | 결과 |
|---|---|---:|---|
| **Windows** | ko_KR | **54** | `Tests run: 54, Failures: 0, Errors: 0, Skipped: 0` |
| **Linux** (Ubuntu 22.04 / OpenJDK 17) | C.UTF-8 | **54** | `Tests run: 54, Failures: 0, Errors: 0, Skipped: 0` |

| 구분 | 건수 | 내용 |
|---|---:|---|
| **기존 동작 유지(무수정 통과)** | 7 | `doFilter` · Wrapper · `getParameterMap`/`getParameterValues` 의 반복 호출 이중 인코딩 방지 · 원본 요청 무변조 · 가변 사본 반환 |
| **설정 없음 = 종전 동작** | 1 | 초기화 파라미터가 없으면 모든 태그 인코딩 |
| 허용 태그 | 3 | 속성 없는 여닫는 형태만 통과 · **문자열 끝의 허용 태그도 통과**(공통컴포넌트 사본의 경계 버그 회귀) · **앰퍼샌드는 계속 인코딩** |
| 리치텍스트 우회 | 2 | 지정 파라미터만 우회하고 나머지는 인코딩 · **우회 경로도 원본 배열 미노출** |
| 제외 경로 | 1 | 래핑 없이 통과 |

`HTMLTagFilterSecurityTest` 5건 — 허용 태그를 지정해도 **속성이 붙은 태그는 통과하지 못함** · 꺾쇠·앰퍼샌드는 계속 인코딩 · 태그 이름은 ASCII 글자만 인정(제어 문자 섞인 태그 인코딩) · 리치 텍스트 우회는 지정 파라미터에만 · 제외 경로는 접미 트릭(`/apix`·`/health-check`)으로 과도하게 일치하지 않음(fail-closed).

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

해당 없음 — 서블릿 필터 수정이며, 검증은 위 JUnit 으로 수행했습니다.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

해당 없음 — 위 JUnit 테스트 결과로 갈음합니다.

---

<sub>base: `eGovFramework:main` @ `cd9fd9c` (2026-09-08 fetch 기준) · 단일 커밋</sub>
