### PR TITLE
feat: 제약 위반을 400 problem+json 으로 해석하는 EgovRestExceptionHandler 추가

### DIFF
--- a/Presentation/org.egovframe.rte.ptl.mvc/pom.xml
+++ b/Presentation/org.egovframe.rte.ptl.mvc/pom.xml
@@ -26,6 +26,7 @@
     <properties>
         <org.egovframe.rte.version>5.0.0</org.egovframe.rte.version>
         <jakarta.annotation.version>3.0.0</jakarta.annotation.version>
+        <jakarta.validation.version>3.1.1</jakarta.validation.version>
         <jakarta.servlet.version>6.0.0</jakarta.servlet.version>
         <jakarta.servlet.jsp.version>4.0.0</jakarta.servlet.jsp.version>
         <log4j2.version>2.25.3</log4j2.version>
@@ -76,6 +77,13 @@
             <groupId>jakarta.annotation</groupId>
             <artifactId>jakarta.annotation-api</artifactId>
             <version>${jakarta.annotation.version}</version>
+        </dependency>
+        <!-- EgovRestExceptionHandler 가 제약 위반(ConstraintViolationException)을 해석하는 데 쓴다.
+             구현체는 애플리케이션이 선택한다(hibernate-validator 등). -->
+        <dependency>
+            <groupId>jakarta.validation</groupId>
+            <artifactId>jakarta.validation-api</artifactId>
+            <version>${jakarta.validation.version}</version>
         </dependency>
         <dependency>
             <groupId>jakarta.servlet</groupId>

--- a/Presentation/org.egovframe.rte.ptl.mvc/src/main/java/org/egovframe/rte/ptl/mvc/bind/exception/EgovRestExceptionHandler.java
+++ b/Presentation/org.egovframe.rte.ptl.mvc/src/main/java/org/egovframe/rte/ptl/mvc/bind/exception/EgovRestExceptionHandler.java
@@ -1,0 +1,300 @@
+/*
+ * Copyright 2009-2026 MOIS(Ministry of the Interior and Safety).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.egovframe.rte.ptl.mvc.bind.exception;
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.ConstraintViolationException;
+import org.egovframe.rte.fdl.cmmn.exception.BaseException;
+import org.egovframe.rte.fdl.cmmn.exception.EgovBizException;
+import org.egovframe.rte.fdl.cmmn.exception.FdlException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.TypeMismatchException;
+import org.springframework.context.MessageSource;
+import org.springframework.context.MessageSourceResolvable;
+import org.springframework.context.NoSuchMessageException;
+import org.springframework.context.i18n.LocaleContextHolder;
+import org.springframework.context.support.DefaultMessageSourceResolvable;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ProblemDetail;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.validation.BindException;
+import org.springframework.validation.FieldError;
+import org.springframework.validation.ObjectError;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * REST 응답용 기본 예외 핸들러 — <b>동작하는 기본 구현</b> + RFC 9457(ProblemDetail) 정렬.
+ *
+ * <p>기존 {@link AbstractAnnotationExceptionHandler}는 전 메서드가 abstract 인 시그니처 골격이라
+ * 사용자가 전부 직접 구현해야 했다(잔여 모듈 점검 8-B-4). 본 클래스는 실행환경 예외 계층
+ * 을 RFC 9457 {@code application/problem+json} 응답으로 매핑하는 기본 구현을 제공한다:</p>
+ *
+ * <ul>
+ *   <li>{@link EgovBizException}(업무 예외) → 400 + 예외 메시지 + {@code messageKey} 확장 필드</li>
+ *   <li><b>제약 위반</b>({@code @Valid} 본문·바인딩 {@link BindException} 계열,
+ *       {@code @Validated} 파라미터 {@link ConstraintViolationException}) → <b>400</b> +
+ *       {@code errors} 확장 필드(필드명·메시지 — <b>거부된 값은 싣지 않는다</b>: 입력
+ *       반사·민감값 노출 방지). 종전에는 {@code Exception} 폴백으로 500 이 되던 정합성
+ *       결함의 수정이다(고지). 메시지는 {@link #setMessageSource(MessageSource)}
+ *       연동 시 코드 해석 우선, 미연동이면 제약의 기본 메시지</li>
+ *   <li><b>형 변환 실패</b>(바인딩 중 {@code typeMismatch} 필드 오류 · 단일 값 {@link TypeMismatchException})와
+ *       <b>읽을 수 없는 본문</b>({@link HttpMessageNotReadableException}) → <b>400</b> + 일반화 메시지.
+ *       Spring 의 기본 메시지는 거부된 입력값과 자바 타입명(또는 파서 상세)을 담으므로 응답에
+ *       싣지 않는다 — {@link MessageSource} 에 {@code typeMismatch} 코드가 있으면 그 메시지를 쓴다</li>
+ *   <li>{@link FdlException}/{@link BaseException}/그 외 → 500 + <b>일반화 메시지</b>
+ *       (내부 정보 노출 방지 — CWE-209, 원본은 서버 로그)</li>
+ * </ul>
+ *
+ * <p>사용: 그대로 빈 등록이 아니라 <b>애플리케이션에서 {@code @RestControllerAdvice}를 붙인
+ * 하위 클래스로 등록</b>한다(적용 범위·추가 예외 매핑을 앱이 결정). 개별 응답 커스터마이징은
+ * {@code protected} 메서드 오버라이드로 한다.</p>
+ *
+ * <pre>{@code
+ * @RestControllerAdvice(basePackages = "egovframework.example")
+ * public class ExampleExceptionHandler extends EgovRestExceptionHandler { }
+ * }</pre>
+ *
+ * @author 실행환경 개발팀
+ * @since 5.1
+ * @version 1.0
+ * <pre>
+ * 개정이력(Modification Information)
+ *
+ * 수정일        수정자           수정내용
+ * ----------  --------------  ---------------------------
+ * 2026.08.16  실행환경 개발팀    최초 생성 (검증·응답 표준화)
+ * 2026.09.02  실행환경 개발팀    제약 위반 400 응답·메시지 해석 추가(종전 500 폴백은 정합성 결함)
+ * 2026.09.07  실행환경 개발팀    형 변환 실패·읽을 수 없는 본문을 400 으로 매핑, 거부된 입력값·타입명 미노출
+ * </pre>
+ */
+public class EgovRestExceptionHandler {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(EgovRestExceptionHandler.class);
+
+    /** 내부 오류 응답에 사용할 일반화 메시지(원본 메시지는 서버 로그에만 남긴다) */
+    private static final String INTERNAL_ERROR_DETAIL = "An internal server error has occurred.";
+
+    /** 제약 위반 응답의 detail(개별 사유는 errors 확장 필드) */
+    private static final String VALIDATION_ERROR_DETAIL = "Request validation failed.";
+
+    /**
+     * 형 변환 실패 필드에 쓸 일반화 메시지 — Spring 의 기본 메시지는 거부된 입력값과 자바 타입명을
+     * 담으므로(Failed to convert ... to required type ... For input string: ...) 응답에 싣지 않는다.
+     */
+    private static final String BINDING_FAILURE_DETAIL = "Invalid value.";
+
+    /** 읽을 수 없는 요청 본문 응답의 detail(파서 상세는 싣지 않는다) */
+    private static final String UNREADABLE_BODY_DETAIL = "Request body could not be read.";
+
+    private MessageSource messageSource;
+
+    /**
+     * 위반 메시지의 코드 해석에 쓸 {@link MessageSource}(opt-in — 미연동이면 제약의 기본
+     * 메시지로 완결된다).
+     *
+     * @since 5.1
+     */
+    public void setMessageSource(MessageSource messageSource) {
+        this.messageSource = messageSource;
+    }
+
+    /**
+     * 제약 위반(@Valid 본문·바인딩) — 400 + 필드 오류 목록. 거부된 값은 싣지 않는다.
+     *
+     * <p>{@code MethodArgumentNotValidException} 은 {@link BindException} 의 하위라 본
+     * 핸들러 하나로 본문·바인딩 두 경로를 흡수한다.</p>
+     *
+     * @since 5.1
+     */
+    @ExceptionHandler(BindException.class)
+    public ResponseEntity<ProblemDetail> handleBindException(BindException e) {
+        LOGGER.debug("Validation failure handled: {} error(s)", e.getErrorCount());
+        List<Map<String, String>> errors = new ArrayList<>();
+        for (FieldError fieldError : e.getFieldErrors()) {
+            if (fieldError.isBindingFailure()) {
+                // 원본(입력값·타입명 포함)은 서버 로그로만 남긴다
+                LOGGER.debug("Binding failure on field '{}': {}", fieldError.getField(), fieldError.getDefaultMessage());
+            }
+            errors.add(errorEntry(fieldError.getField(), resolveMessage(fieldError)));
+        }
+        for (ObjectError globalError : e.getGlobalErrors()) {
+            errors.add(errorEntry(globalError.getObjectName(), resolveMessage(globalError)));
+        }
+        return toResponse(validationProblem(errors));
+    }
+
+    /**
+     * 제약 위반(@Validated 파라미터) — 본문 위반과 같은 400 형식으로 정규화한다.
+     *
+     * @since 5.1
+     */
+    @ExceptionHandler(ConstraintViolationException.class)
+    public ResponseEntity<ProblemDetail> handleConstraintViolation(ConstraintViolationException e) {
+        LOGGER.debug("Constraint violation handled: {} violation(s)", e.getConstraintViolations().size());
+        List<Map<String, String>> errors = new ArrayList<>();
+        for (ConstraintViolation<?> violation : e.getConstraintViolations()) {
+            errors.add(errorEntry(lastPathNode(violation), violation.getMessage()));
+        }
+        return toResponse(validationProblem(errors));
+    }
+
+    /**
+     * 업무 예외 — 사용자 대상 메시지이므로 그대로 전달하고 messageKey 를 확장 필드로 싣는다.
+     */
+    @ExceptionHandler(EgovBizException.class)
+    public ResponseEntity<ProblemDetail> handleEgovBizException(EgovBizException e) {
+        LOGGER.debug("Business exception handled: {}", e.getMessage());
+        ProblemDetail problem = baseProblem(HttpStatus.BAD_REQUEST, e.getMessage());
+        problem.setTitle("Business Error");
+        if (e.getMessageKey() != null) {
+            problem.setProperty("messageKey", e.getMessageKey());
+        }
+        return toResponse(problem);
+    }
+
+    /**
+     * 단일 값 형 변환 실패({@code @PathVariable}·{@code @RequestParam} 등) — 400 + 일반화 메시지.
+     * 종전에는 {@code Exception} 폴백으로 500 이 되고 스택이 ERROR 로 기록되던 클라이언트 오류다.
+     *
+     * @since 5.1
+     */
+    @ExceptionHandler(TypeMismatchException.class)
+    public ResponseEntity<ProblemDetail> handleTypeMismatch(TypeMismatchException e) {
+        String name = (e instanceof MethodArgumentTypeMismatchException)
+                ? ((MethodArgumentTypeMismatchException) e).getName() : e.getPropertyName();
+        if (name == null) {
+            name = "value";
+        }
+        LOGGER.debug("Type mismatch handled for '{}': {}", name, e.getMessage());
+        List<Map<String, String>> errors = new ArrayList<>();
+        errors.add(errorEntry(name, BINDING_FAILURE_DETAIL));
+        return toResponse(validationProblem(errors));
+    }
+
+    /**
+     * 읽을 수 없는 요청 본문(JSON 문법 오류 등) — 400. 파서가 준 상세(클래스명·위치)는 싣지 않는다.
+     *
+     * @since 5.1
+     */
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<ProblemDetail> handleNotReadable(HttpMessageNotReadableException e) {
+        LOGGER.debug("Unreadable request body handled: {}", e.getMessage());
+        ProblemDetail problem = baseProblem(HttpStatus.BAD_REQUEST, UNREADABLE_BODY_DETAIL);
+        problem.setTitle("Malformed Request");
+        return toResponse(problem);
+    }
+
+    /**
+     * 실행환경 확장모듈 예외 — 내부 오류로 일반화한다.
+     */
+    @ExceptionHandler(FdlException.class)
+    public ResponseEntity<ProblemDetail> handleFdlException(FdlException e) {
+        return internalError(e);
+    }
+
+    /**
+     * 그 외 실행환경 checked 예외 — 내부 오류로 일반화한다.
+     */
+    @ExceptionHandler(BaseException.class)
+    public ResponseEntity<ProblemDetail> handleBaseException(BaseException e) {
+        return internalError(e);
+    }
+
+    /**
+     * 미분류 예외 — 내부 오류로 일반화한다(원본 메시지·스택은 서버 로그로만).
+     */
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ProblemDetail> handleException(Exception e) {
+        return internalError(e);
+    }
+
+    /**
+     * 내부 오류 공통 처리 — 원본은 로그, 응답은 일반화 메시지(CWE-209 방지).
+     */
+    protected ResponseEntity<ProblemDetail> internalError(Exception e) {
+        LOGGER.error("Unhandled exception mapped to internal server error", e);
+        ProblemDetail problem = baseProblem(HttpStatus.INTERNAL_SERVER_ERROR, INTERNAL_ERROR_DETAIL);
+        problem.setTitle("Internal Server Error");
+        return toResponse(problem);
+    }
+
+    /**
+     * 공통 ProblemDetail 골격 — timestamp 확장 필드를 포함한다.
+     */
+    protected ProblemDetail baseProblem(HttpStatus status, String detail) {
+        ProblemDetail problem = ProblemDetail.forStatusAndDetail(status, detail);
+        problem.setProperty("timestamp", OffsetDateTime.now().toString());
+        return problem;
+    }
+
+    /** 제약 위반 공통 골격 — 400 + errors 확장 필드. */
+    protected ProblemDetail validationProblem(List<Map<String, String>> errors) {
+        ProblemDetail problem = baseProblem(HttpStatus.BAD_REQUEST, VALIDATION_ERROR_DETAIL);
+        problem.setTitle("Validation Failed");
+        problem.setProperty("errors", errors);
+        return problem;
+    }
+
+    /**
+     * 위반 메시지 해석 — {@link MessageSource} 연동 시 오류 코드 해석 우선(기본 메시지 폴백은
+     * Spring 표준 {@code MessageSourceResolvable} 규칙), 미연동이면 제약의 기본 메시지.
+     */
+    protected String resolveMessage(ObjectError error) {
+        boolean bindingFailure = (error instanceof FieldError) && ((FieldError) error).isBindingFailure();
+        if (messageSource != null) {
+            try {
+                // 형 변환 실패는 코드만 해석한다 — 기본 메시지(입력값·타입명 포함)로 폴백하지 않기 위해서다
+                MessageSourceResolvable resolvable = bindingFailure
+                        ? new DefaultMessageSourceResolvable(error.getCodes(), error.getArguments())
+                        : error;
+                return messageSource.getMessage(resolvable, LocaleContextHolder.getLocale());
+            } catch (NoSuchMessageException noMessage) {
+                // 코드·기본 메시지 모두 없음 — 아래 기본 메시지 경로로 폴백
+            }
+        }
+        // 형 변환 실패의 기본 메시지는 거부된 입력값과 자바 타입명을 담는다(입력 반사·내부 정보 노출) —
+        // 응답에는 일반화 메시지를 싣고 원본은 handleBindException 이 debug 로그로 남긴다
+        return bindingFailure ? BINDING_FAILURE_DETAIL : error.getDefaultMessage();
+    }
+
+    private static Map<String, String> errorEntry(String field, String message) {
+        Map<String, String> entry = new LinkedHashMap<>(2);
+        entry.put("field", field);
+        entry.put("message", message);
+        return entry;
+    }
+
+    /** 파라미터 위반의 property path 말단을 필드명으로 정규화한다({@code selectOne.userId} → {@code userId}). */
+    private static String lastPathNode(ConstraintViolation<?> violation) {
+        String path = String.valueOf(violation.getPropertyPath());
+        int lastDot = path.lastIndexOf('.');
+        return (lastDot < 0) ? path : path.substring(lastDot + 1);
+    }
+
+    private static ResponseEntity<ProblemDetail> toResponse(ProblemDetail problem) {
+        return ResponseEntity.status(problem.getStatus()).body(problem);
+    }
+
+}

--- a/Presentation/org.egovframe.rte.ptl.mvc/src/test/java/org/egovframe/rte/ptl/mvc/bind/exception/EgovRestExceptionHandlerSecurityTest.java
+++ b/Presentation/org.egovframe.rte.ptl.mvc/src/test/java/org/egovframe/rte/ptl/mvc/bind/exception/EgovRestExceptionHandlerSecurityTest.java
@@ -1,0 +1,273 @@
+package org.egovframe.rte.ptl.mvc.bind.exception;
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.ConstraintViolationException;
+import jakarta.validation.Path;
+import jakarta.validation.metadata.ConstraintDescriptor;
+import org.egovframe.rte.fdl.cmmn.exception.BaseException;
+import org.egovframe.rte.fdl.cmmn.exception.EgovBizException;
+import org.egovframe.rte.fdl.cmmn.exception.FdlException;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.MutablePropertyValues;
+import org.springframework.context.i18n.LocaleContextHolder;
+import org.springframework.context.support.StaticMessageSource;
+import org.springframework.http.ProblemDetail;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.mock.http.MockHttpInputMessage;
+import org.springframework.validation.BindException;
+import org.springframework.validation.DataBinder;
+import org.springframework.web.method.annotation.ExceptionHandlerMethodResolver;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+
+import java.lang.reflect.Method;
+import java.sql.SQLException;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * EgovRestExceptionHandler 의 <b>정보 노출·입력 반사</b> 회귀 검증(CWE-209, 반사형 CWE-79 의 서버 측 경로).
+ *
+ * <p>응답 본문은 클라이언트에게 그대로 전달된다. 어떤 예외에서도 <b>원본 예외 메시지·자바 타입명·
+ * 거부된 입력값·파서 상세</b>가 실리지 않아야 하고, 클라이언트가 유발한 오류는 5xx 가 아니라 4xx 여야
+ * 한다(5xx 는 스택과 함께 ERROR 로 기록되므로 익명 요청으로 오류 로그를 채울 수 있다).</p>
+ *
+ * <p>기능 테스트({@link EgovRestExceptionHandlerTest})와 별도로 공격자가 유발할 수 있는 예외를 모아
+ * 두고 한 건이라도 새면 실패한다. 예외는 핸들러 메서드를 직접 부르지 않고 {@code @ExceptionHandler}
+ * 해석기를 거쳐 보낸다 — 실제 요청 처리에서 어느 메서드로 가는지까지 검증하기 위해서다.</p>
+ */
+public class EgovRestExceptionHandlerSecurityTest {
+
+    private final EgovRestExceptionHandler handler = new EgovRestExceptionHandler();
+
+    /** 바인딩 대상 — 숫자 필드에 문자열을 넣어 형 변환 실패(typeMismatch)를 만든다. */
+    public static class Form {
+        private int age;
+        private String name;
+
+        public int getAge() {
+            return age;
+        }
+
+        public void setAge(int age) {
+            this.age = age;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+    }
+
+    @Test
+    public void 내부_예외의_원본_메시지는_어떤_계층에서도_응답에_실리지_않는다() throws Exception {
+        List<Exception> internal = List.of(
+                new SQLException("ORA-00942: table SECRET_USERS does not exist"),
+                new RuntimeException("/etc/app/config.yml: Permission denied"),
+                new FdlException("fdl-internal-secret"),
+                new BaseException("base-internal-secret"),
+                new IllegalStateException("db password is hunter2"));
+        for (Exception e : internal) {
+            ResponseEntity<ProblemDetail> response = dispatch(e);
+            assertEquals(500, response.getStatusCode().value(), e.getClass().getSimpleName());
+            String body = flatten(response);
+            assertFalse(body.contains("SECRET") || body.contains("hunter2") || body.contains("Permission denied")
+                    || body.contains("internal-secret"), "원본 메시지 노출: " + body);
+            assertFalse(body.contains("Exception") || body.contains("java."), "예외 클래스명·스택 흔적: " + body);
+        }
+    }
+
+    @Test
+    public void 형_변환_실패의_거부된_값과_자바_타입명은_응답에_실리지_않는다() throws Exception {
+        // Spring 의 typeMismatch 기본 메시지는 "Failed to convert ... 'java.lang.String' ... For input string: \"...\"" 이다
+        ResponseEntity<ProblemDetail> response = dispatch(typeMismatch("<script>alert(1)</script>"));
+
+        assertEquals(400, response.getStatusCode().value());
+        String body = flatten(response);
+        assertTrue(body.contains("age"), "위반 필드명은 남는다: " + body);
+        assertFalse(body.contains("<script>") || body.contains("java.lang") || body.contains("For input string"),
+                "거부된 입력값·자바 타입명이 반사됨: " + body);
+    }
+
+    @Test
+    public void 메시지소스에_typeMismatch_코드가_없어도_기본_메시지로_새지_않는다() throws Exception {
+        StaticMessageSource messageSource = new StaticMessageSource();
+        handler.setMessageSource(messageSource);
+        try {
+            String body = flatten(dispatch(typeMismatch("<script>alert(1)</script>")));
+            assertFalse(body.contains("<script>") || body.contains("java.lang"),
+                    "코드 미정의 시 기본 메시지로 폴백하며 샘: " + body);
+
+            messageSource.addMessage("typeMismatch", LocaleContextHolder.getLocale(), "값 형식이 올바르지 않습니다");
+            body = flatten(dispatch(typeMismatch("<script>alert(1)</script>")));
+            assertTrue(body.contains("값 형식이 올바르지 않습니다"), "코드가 있으면 그 메시지를 쓴다: " + body);
+            assertFalse(body.contains("<script>"), body);
+        } finally {
+            handler.setMessageSource(null);
+        }
+    }
+
+    @Test
+    public void 제약_위반의_invalidValue는_응답에_실리지_않는다() throws Exception {
+        Set<ConstraintViolation<?>> violations = new LinkedHashSet<>();
+        violations.add(violation("selectOne.userId", "must match pattern", "SECRET-VALUE"));
+
+        ResponseEntity<ProblemDetail> response = dispatch(new ConstraintViolationException(violations));
+
+        assertEquals(400, response.getStatusCode().value());
+        String body = flatten(response);
+        assertTrue(body.contains("userId") && body.contains("must match pattern"), body);
+        assertFalse(body.contains("SECRET-VALUE"), "invalidValue 노출: " + body);
+    }
+
+    @Test
+    public void 단일_값_형_변환_실패는_400이고_입력값을_반사하지_않는다() throws Exception {
+        MethodArgumentTypeMismatchException e = new MethodArgumentTypeMismatchException(
+                "<script>alert(1)</script>", int.class, "id", null,
+                new NumberFormatException("For input string: \"<script>alert(1)</script>\""));
+
+        ResponseEntity<ProblemDetail> response = dispatch(e);
+
+        assertEquals(400, response.getStatusCode().value(), "클라이언트 입력 오류는 400 이다(500 이면 스택이 ERROR 로 남는다)");
+        String body = flatten(response);
+        assertTrue(body.contains("id"), body);
+        assertFalse(body.contains("<script>") || body.contains("java.lang") || body.contains("For input string"), body);
+    }
+
+    @Test
+    public void 읽을_수_없는_본문은_400이고_파서_상세를_싣지_않는다() throws Exception {
+        HttpMessageNotReadableException e = new HttpMessageNotReadableException(
+                "JSON parse error: Unexpected character; nested exception is com.fasterxml.jackson.core.JsonParseException"
+                        + " at [Source: (PushbackInputStream); line: 1, column: 2]",
+                new MockHttpInputMessage(new byte[0]));
+
+        ResponseEntity<ProblemDetail> response = dispatch(e);
+
+        assertEquals(400, response.getStatusCode().value());
+        String body = flatten(response);
+        assertFalse(body.contains("jackson") || body.contains("JSON parse error") || body.contains("PushbackInputStream"),
+                "파서 상세 노출: " + body);
+    }
+
+    @Test
+    public void 확장_필드는_timestamp_errors_messageKey_뿐이다() throws Exception {
+        List<Exception> samples = List.of(
+                new SQLException("x"),
+                typeMismatch("v"),
+                new EgovBizException("잔액이 부족합니다"),
+                new MethodArgumentTypeMismatchException("v", int.class, "id", null, null));
+        for (Exception e : samples) {
+            Map<String, Object> properties = dispatch(e).getBody().getProperties();
+            assertNotNull(properties);
+            assertTrue(Set.of("timestamp", "errors", "messageKey").containsAll(properties.keySet()),
+                    "예상 밖 확장 필드(스택·예외명 등): " + properties.keySet());
+        }
+    }
+
+    // ------------------------------------------------------------ helpers
+
+    /** 실제 요청 처리와 같은 규칙({@code @ExceptionHandler} 해석)으로 핸들러 메서드를 고른 뒤 호출한다. */
+    @SuppressWarnings("unchecked")
+    private ResponseEntity<ProblemDetail> dispatch(Exception e) throws Exception {
+        Method method = new ExceptionHandlerMethodResolver(EgovRestExceptionHandler.class).resolveMethod(e);
+        assertNotNull(method, "매핑되는 @ExceptionHandler 가 있어야 한다: " + e.getClass().getName());
+        return (ResponseEntity<ProblemDetail>) method.invoke(handler, e);
+    }
+
+    private static String flatten(ResponseEntity<ProblemDetail> response) {
+        ProblemDetail problem = response.getBody();
+        assertNotNull(problem);
+        return problem.getTitle() + "|" + problem.getDetail() + "|" + problem.getProperties();
+    }
+
+    private static BindException typeMismatch(String rawValue) {
+        DataBinder binder = new DataBinder(new Form(), "form");
+        MutablePropertyValues values = new MutablePropertyValues();
+        values.add("age", rawValue);
+        values.add("name", "ok");
+        binder.bind(values);
+        return new BindException(binder.getBindingResult());
+    }
+
+    /** 핸들러는 getMessage()·getPropertyPath() 만 읽는다 — 검증 구현체 없이 스텁으로 충분하다. */
+    private static ConstraintViolation<Object> violation(String path, String message, Object invalidValue) {
+        return new ConstraintViolation<Object>() {
+            @Override
+            public String getMessage() {
+                return message;
+            }
+
+            @Override
+            public String getMessageTemplate() {
+                return message;
+            }
+
+            @Override
+            public Object getRootBean() {
+                return null;
+            }
+
+            @Override
+            public Class<Object> getRootBeanClass() {
+                return Object.class;
+            }
+
+            @Override
+            public Object getLeafBean() {
+                return null;
+            }
+
+            @Override
+            public Object[] getExecutableParameters() {
+                return new Object[0];
+            }
+
+            @Override
+            public Object getExecutableReturnValue() {
+                return null;
+            }
+
+            @Override
+            public Path getPropertyPath() {
+                return new Path() {
+                    @Override
+                    public Iterator<Node> iterator() {
+                        return Collections.emptyIterator();
+                    }
+
+                    @Override
+                    public String toString() {
+                        return path;
+                    }
+                };
+            }
+
+            @Override
+            public Object getInvalidValue() {
+                return invalidValue;
+            }
+
+            @Override
+            public ConstraintDescriptor<?> getConstraintDescriptor() {
+                return null;
+            }
+
+            @Override
+            public <U> U unwrap(Class<U> type) {
+                throw new UnsupportedOperationException();
+            }
+        };
+    }
+}

--- a/Presentation/org.egovframe.rte.ptl.mvc/src/test/java/org/egovframe/rte/ptl/mvc/bind/exception/EgovRestExceptionHandlerTest.java
+++ b/Presentation/org.egovframe.rte.ptl.mvc/src/test/java/org/egovframe/rte/ptl/mvc/bind/exception/EgovRestExceptionHandlerTest.java
@@ -1,0 +1,140 @@
+package org.egovframe.rte.ptl.mvc.bind.exception;
+
+import org.egovframe.rte.fdl.cmmn.exception.BaseException;
+import org.egovframe.rte.fdl.cmmn.exception.EgovBizException;
+import org.egovframe.rte.fdl.cmmn.exception.FdlException;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.ProblemDetail;
+import org.springframework.http.ResponseEntity;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * EgovRestExceptionHandler — RFC 9457(ProblemDetail) 매핑 기본 구현 검증.
+ */
+public class EgovRestExceptionHandlerTest {
+
+    private final EgovRestExceptionHandler handler = new EgovRestExceptionHandler();
+
+    @Test
+    public void 업무예외는_400과_메시지를_그대로_전달한다() {
+        ResponseEntity<ProblemDetail> response =
+                handler.handleEgovBizException(new EgovBizException("잔액이 부족합니다"));
+
+        assertEquals(400, response.getStatusCode().value());
+        ProblemDetail problem = response.getBody();
+        assertNotNull(problem);
+        assertEquals("Business Error", problem.getTitle());
+        assertEquals("잔액이 부족합니다", problem.getDetail());
+        assertNotNull(problem.getProperties().get("timestamp"));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void 제약위반은_400과_필드오류_목록으로_응답하고_거부된_값은_싣지_않는다() {
+        // 종전에는 Exception 폴백으로 500 이 되던 정합성 결함 — 400 계약의 회귀 고정
+        org.springframework.validation.BindException bindException =
+                new org.springframework.validation.BindException(new Object(), "memberDto");
+        bindException.addError(new org.springframework.validation.FieldError("memberDto", "email",
+                "secret-input@internal", false, new String[] {"EgovEmailCheck.memberDto.email"}, null,
+                "이메일 형식이 아닙니다"));
+        bindException.addError(new org.springframework.validation.FieldError("memberDto", "name",
+                null, false, null, null, "이름은 필수입니다"));
+
+        ResponseEntity<ProblemDetail> response = handler.handleBindException(bindException);
+
+        assertEquals(400, response.getStatusCode().value());
+        ProblemDetail problem = response.getBody();
+        assertNotNull(problem);
+        assertEquals("Validation Failed", problem.getTitle());
+        java.util.List<java.util.Map<String, String>> errors =
+                (java.util.List<java.util.Map<String, String>>) problem.getProperties().get("errors");
+        assertEquals(2, errors.size(), "위반 필드 전부가 목록으로 담겨야 한다");
+        assertEquals("email", errors.get(0).get("field"));
+        assertEquals("이메일 형식이 아닙니다", errors.get(0).get("message"));
+        assertFalse(errors.toString().contains("secret-input"),
+                "거부된 입력 값은 어떤 형태로도 응답에 실리면 안 된다(입력 반사·민감값 노출 방지)");
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void 파라미터_제약위반도_동일_형식의_400으로_정규화된다() {
+        jakarta.validation.ConstraintViolationException violationException =
+                new jakarta.validation.ConstraintViolationException(
+                        java.util.Set.of(violation("selectMember.userId", "사용자 ID 형식이 아닙니다")));
+
+        ResponseEntity<ProblemDetail> response = handler.handleConstraintViolation(violationException);
+
+        assertEquals(400, response.getStatusCode().value());
+        java.util.List<java.util.Map<String, String>> errors =
+                (java.util.List<java.util.Map<String, String>>) response.getBody().getProperties().get("errors");
+        assertEquals("userId", errors.get(0).get("field"), "property path 말단이 필드명으로 정규화되어야 한다");
+        assertEquals("사용자 ID 형식이 아닙니다", errors.get(0).get("message"));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void 메시지소스_연동_시_코드_해석이_기본_메시지보다_우선한다() {
+        org.springframework.context.support.StaticMessageSource messages =
+                new org.springframework.context.support.StaticMessageSource();
+        messages.addMessage("EgovEmailCheck.memberDto.email",
+                org.springframework.context.i18n.LocaleContextHolder.getLocale(), "해석된 이메일 오류 메시지");
+        EgovRestExceptionHandler resolvingHandler = new EgovRestExceptionHandler();
+        resolvingHandler.setMessageSource(messages);
+        org.springframework.validation.BindException bindException =
+                new org.springframework.validation.BindException(new Object(), "memberDto");
+        bindException.addError(new org.springframework.validation.FieldError("memberDto", "email",
+                null, false, new String[] {"EgovEmailCheck.memberDto.email"}, null, "기본 메시지"));
+
+        java.util.List<java.util.Map<String, String>> errors = (java.util.List<java.util.Map<String, String>>)
+                resolvingHandler.handleBindException(bindException).getBody().getProperties().get("errors");
+
+        assertEquals("해석된 이메일 오류 메시지", errors.get(0).get("message"), "코드 해석 우선");
+        // 미연동(기본 핸들러)은 기본 메시지로 완결 — 위 제약위반 테스트가 함께 증명한다
+    }
+
+    /** ConstraintViolation 테스트 스텁 — 핸들러가 쓰는 propertyPath(toString)·message 만 실값 */
+    private static jakarta.validation.ConstraintViolation<Object> violation(String path, String message) {
+        return new jakarta.validation.ConstraintViolation<>() {
+            @Override public String getMessage() { return message; }
+            @Override public String getMessageTemplate() { return message; }
+            @Override public Object getRootBean() { return null; }
+            @Override public Class<Object> getRootBeanClass() { return Object.class; }
+            @Override public Object getLeafBean() { return null; }
+            @Override public Object[] getExecutableParameters() { return new Object[0]; }
+            @Override public Object getExecutableReturnValue() { return null; }
+            @Override public jakarta.validation.Path getPropertyPath() {
+                return new jakarta.validation.Path() {
+                    @Override public java.util.Iterator<Node> iterator() { return java.util.Collections.emptyIterator(); }
+                    @Override public String toString() { return path; }
+                };
+            }
+            @Override public Object getInvalidValue() { return null; }
+            @Override public jakarta.validation.metadata.ConstraintDescriptor<?> getConstraintDescriptor() { return null; }
+            @Override public <U> U unwrap(Class<U> type) { throw new UnsupportedOperationException(); }
+        };
+    }
+
+    @Test
+    public void 내부예외는_500과_일반화_메시지로_응답한다_CWE209() {
+        ResponseEntity<ProblemDetail> fdl = handler.handleFdlException(
+                new FdlException("jdbc:oracle:thin:@10.0.0.1 connection failed"));
+        ResponseEntity<ProblemDetail> base = handler.handleBaseException(
+                new BaseException("internal table EGOV_SECRET missing"));
+        ResponseEntity<ProblemDetail> plain = handler.handleException(
+                new IllegalStateException("stacktrace details"));
+
+        for (ResponseEntity<ProblemDetail> response : java.util.List.of(fdl, base, plain)) {
+            assertEquals(500, response.getStatusCode().value());
+            ProblemDetail problem = response.getBody();
+            assertNotNull(problem);
+            assertEquals("Internal Server Error", problem.getTitle());
+            // 내부 정보(접속 문자열·테이블명 등)가 응답에 노출되면 안 된다
+            assertFalse(problem.getDetail().contains("oracle"));
+            assertFalse(problem.getDetail().contains("EGOV_SECRET"));
+        }
+    }
+
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [ ] 버그수정 Bug fixes
- [X] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

### 배경

REST 컨트롤러에서 Bean Validation 제약이 위반되면 `ConstraintViolationException` 이 나는데,
이를 처리하는 **기본 핸들러가 없어 `Exception` 폴백으로 500** 이 됩니다.
**클라이언트 입력 오류가 서버 오류로 보고되는 정합성 결함**입니다.

### 추가한 것

**`bind/exception/EgovRestExceptionHandler`** — RFC 9457 `application/problem+json` 매핑

| 예외 | 응답 |
|---|---|
| `ConstraintViolationException` · `BindException` | **400** + 위반 필드 목록 |
| `EgovBizException` · `BaseException` · `FdlException` | 각 계층에 맞는 상태 코드 |

- 위반 메시지는 `MessageSource` 로 해석하며, **코드가 없으면 제약이 준 기본 메시지**를 씁니다
  (해석 실패로 응답이 비지 않게). 단 **형 변환 실패는 예외**입니다 — Spring 기본 메시지가 거부된 입력값과
  자바 타입명을 담으므로 코드가 없으면 일반화 메시지(`Invalid value.`)를 씁니다
- **내부 예외 정보를 응답에 싣지 않습니다**

### 하위 호환 고지

- **제약 위반의 응답 상태가 500 에서 400 으로 바뀝니다.** 종전 동작에 의존하던 클라이언트가
  있으면 영향을 받으나, **400 이 올바른 계약**이라 정합성 결함의 수정으로 봅니다
  (javadoc 에 고지)
- **이 핸들러는 `@ControllerAdvice` 로 등록해야 동작합니다.** 등록하지 않으면 종전과
  완전히 같습니다

### 추가되는 의존성

| 좌표 | 버전 | 라이선스 | 크기 | 비고 |
|---|---|---|---:|---|
| `jakarta.validation:jakarta.validation-api` | 3.1.1 | **Apache-2.0** (artifact pom 명시) | 104 KB | **API 만** — 구현체(Hibernate Validator 등)는 애플리케이션이 선택 |

실행환경 자체와 **같은 Apache-2.0** 이며, 104 KB 의 **규격 API 만** 들어옵니다.
검증 구현체는 포함되지 않으므로, 실제로 검증을 수행하려면 애플리케이션이 Hibernate Validator
같은 구현체를 별도로 선언해야 합니다.

**보안 재검증 반영(2026-09-07)** — 두 가지를 고쳤습니다. ① 폼 바인딩의 형 변환 실패(`typeMismatch`)가 400 응답에 Spring 기본 메시지를 그대로 실어 **거부된 입력값과 자바 타입명이 반사**되던 것(예: `Failed to convert … 'int' … For input string: "<script>…"`)을 일반화 메시지로 바꿨습니다. `MessageSource` 에 `typeMismatch` 코드가 있으면 그것을 쓰고 원본은 debug 로그로만 남깁니다. ② 단일 값 형 변환 실패(`TypeMismatchException`)와 읽을 수 없는 본문(`HttpMessageNotReadableException`)이 `Exception` 폴백으로 500 + ERROR 스택이 되던 것을 400 + 일반화 메시지로 매핑했습니다 — 익명 요청으로 오류 로그를 채우던 클라이언트 오류입니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

`EgovRestExceptionHandlerTest` **5건** + 보안 회귀 `EgovRestExceptionHandlerSecurityTest` **7건**, 합계 **12건 신규**. `ptl.mvc` 모듈 전건 통과.

| 환경 | 기본 로케일(Locale) | 모듈 실행 건수 | 결과 |
|---|---|---:|---|
| **Windows** | ko_KR | **54** | `Tests run: 54, Failures: 0, Errors: 0, Skipped: 0` |
| **Linux** (Ubuntu 22.04 / OpenJDK 17) | C.UTF-8 | **54** | `Tests run: 54, Failures: 0, Errors: 0, Skipped: 0` |

테스트는 제약 위반이 **400 으로 나가는 계약을 회귀 고정**하고(종전 500 폴백),
위반 필드 목록·메시지 코드 해석 우선순위·업무 예외 매핑을 덮습니다.

`EgovRestExceptionHandlerSecurityTest` 7건 — `SQLException`·경로가 든 `RuntimeException`·`FdlException` 등 **5xx 본문에 원본 메시지·클래스명 없음** · 제약 위반의 `invalidValue` 미노출 · **실제 `DataBinder` 형 변환 실패에서 거부된 값·타입명 비반사**(MessageSource 유무 모두) · 단일 값 형 변환 실패와 읽을 수 없는 본문은 400.

**수동 확인**: 메시지 해석이 `LocaleContextHolder` 를 거치므로 기본 로케일이 다른
Linux(`C.UTF-8`) 환경에서 별도로 교차 검증했습니다.

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

해당 없음 — REST 응답 매핑이며 화면 렌더링과 무관합니다.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

해당 없음 — 위 JUnit 테스트 결과로 갈음합니다.

---

<sub>base: `eGovFramework:main` @ `cd9fd9c` (2026-09-08 fetch 기준) · 단일 커밋</sub>
