### PR TITLE
feat: 음력↔양력 변환 EgovLunarDates 추가 (icu4j optional)

### DIFF
--- a/Foundation/org.egovframe.rte.fdl.string/pom.xml
+++ b/Foundation/org.egovframe.rte.fdl.string/pom.xml
@@ -27,6 +27,7 @@
         <org.egovframe.rte.version>5.0.0</org.egovframe.rte.version>
         <jakarta.annotation.version>3.0.0</jakarta.annotation.version>
         <commons.codec.version>1.18.0</commons.codec.version>
+        <icu4j.version>77.1</icu4j.version>
         <easymock.version>5.3.0</easymock.version>
     </properties>
 
@@ -63,6 +64,14 @@
             <groupId>commons-codec</groupId>
             <artifactId>commons-codec</artifactId>
             <version>${commons.codec.version}</version>
+        </dependency>
+        <!-- EgovLunarDates 의 음력 변환 전용 - optional 이므로 전이되지 않는다.
+             음력 변환을 쓰는 애플리케이션만 icu4j 를 직접 선언하면 된다. -->
+        <dependency>
+            <groupId>com.ibm.icu</groupId>
+            <artifactId>icu4j</artifactId>
+            <version>${icu4j.version}</version>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.easymock</groupId>

--- a/Foundation/org.egovframe.rte.fdl.string/src/main/java/org/egovframe/rte/fdl/string/EgovLunarDate.java
+++ b/Foundation/org.egovframe.rte.fdl.string/src/main/java/org/egovframe/rte/fdl/string/EgovLunarDate.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2009-2026 MOIS(Ministry of the Interior and Safety).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.egovframe.rte.fdl.string;
+
+import java.util.Objects;
+
+/**
+ * 음력 날짜를 담는 <b>불변</b> 값 객체 — 연·월·일에 <b>윤달 여부</b>가 더해진다.
+ *
+ * <p><b>NOTE:</b> 음력은 같은 연·월·일이 평달과 윤달로 두 번 있을 수 있어 세 필드만으로는
+ * 날짜가 특정되지 않는다. 윤달 여부까지 가진 전용 타입을 둔 이유다 — 문자열이나
+ * {@code Map} 으로 나르면 이 정보가 어디선가 빠진다.</p>
+ *
+ * <p>변환은 {@link EgovLunarDates} 가 한다.</p>
+ *
+ * <pre>
+ * &lt;&lt; 개정이력(Modification Information) &gt;&gt;
+ *
+ *  수정일        수정자        수정내용
+ *  ----------  --------    ---------------------------
+ *  2026.09.01  실행환경팀     최초 생성
+ * </pre>
+ *
+ * @author 실행환경 개발팀
+ * @since 5.1
+ */
+public final class EgovLunarDate {
+
+	private final int year;
+
+	private final int month;
+
+	private final int day;
+
+	private final boolean leapMonth;
+
+	private EgovLunarDate(int year, int month, int day, boolean leapMonth) {
+		if (month < 1 || month > 12) {
+			throw new IllegalArgumentException("month must be 1..12: " + month);
+		}
+		if (day < 1 || day > 30) {
+			throw new IllegalArgumentException("lunar day must be 1..30: " + day);
+		}
+		this.year = year;
+		this.month = month;
+		this.day = day;
+		this.leapMonth = leapMonth;
+	}
+
+	/**
+	 * 평달 음력 날짜를 만든다.
+	 *
+	 * @param year  음력 연도
+	 * @param month 음력 월(1~12)
+	 * @param day   음력 일(1~30)
+	 * @return 음력 날짜
+	 */
+	public static EgovLunarDate of(int year, int month, int day) {
+		return new EgovLunarDate(year, month, day, false);
+	}
+
+	/**
+	 * 윤달 음력 날짜를 만든다.
+	 *
+	 * @param year  음력 연도
+	 * @param month 음력 월(1~12)
+	 * @param day   음력 일(1~30)
+	 * @return 윤달 날짜
+	 */
+	public static EgovLunarDate ofLeapMonth(int year, int month, int day) {
+		return new EgovLunarDate(year, month, day, true);
+	}
+
+	/**
+	 * 음력 연도를 반환한다.
+	 *
+	 * @return 연도
+	 */
+	public int getYear() {
+		return year;
+	}
+
+	/**
+	 * 음력 월을 반환한다(1~12).
+	 *
+	 * @return 월
+	 */
+	public int getMonth() {
+		return month;
+	}
+
+	/**
+	 * 음력 일을 반환한다(1~30).
+	 *
+	 * @return 일
+	 */
+	public int getDay() {
+		return day;
+	}
+
+	/**
+	 * 윤달 여부를 반환한다.
+	 *
+	 * @return 윤달이면 {@code true}
+	 */
+	public boolean isLeapMonth() {
+		return leapMonth;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj) {
+			return true;
+		}
+		if (!(obj instanceof EgovLunarDate)) {
+			return false;
+		}
+		EgovLunarDate other = (EgovLunarDate) obj;
+		return year == other.year && month == other.month
+				&& day == other.day && leapMonth == other.leapMonth;
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(year, month, day, leapMonth);
+	}
+
+	/**
+	 * {@code 2026-01-15} · 윤달이면 {@code 2026-01-15(윤)} 형태로 표기한다.
+	 */
+	@Override
+	public String toString() {
+		return String.format("%04d-%02d-%02d%s", year, month, day, leapMonth ? "(윤)" : "");
+	}
+}

--- a/Foundation/org.egovframe.rte.fdl.string/src/main/java/org/egovframe/rte/fdl/string/EgovLunarDates.java
+++ b/Foundation/org.egovframe.rte.fdl.string/src/main/java/org/egovframe/rte/fdl/string/EgovLunarDates.java
@@ -1,0 +1,188 @@
+/*
+ * Copyright 2009-2026 MOIS(Ministry of the Interior and Safety).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.egovframe.rte.fdl.string;
+
+import java.time.LocalDate;
+
+import com.ibm.icu.util.Calendar;
+import com.ibm.icu.util.TimeZone;
+import com.ibm.icu.util.ULocale;
+
+/**
+ * 양력({@link LocalDate})과 음력({@link EgovLunarDate})을 서로 변환하는 유틸 클래스.
+ *
+ * <p><b>NOTE:</b> ICU4J 의 <b>단기력(Dangi) 달력</b> — 한국 전통 역법 — 으로 계산한다.
+ * 중국 기준인 {@code ChineseCalendar} 가 아니다: 두 역법은 기준 자오선이 달라 합삭 시각이
+ * 자정 부근인 달의 월 시작이 하루 밀리며, <b>2000~2026년 실측으로 418일이 서로 다르다</b>.
+ * 한국 음력에는 한국 기준 달력을 쓴다(공통컴포넌트 원본은 ChineseCalendar 를 썼다).</p>
+ *
+ * <p><b>icu4j 는 optional 의존</b>이라(원칙 3) 이 클래스를 쓰는 애플리케이션만 의존을
+ * 선언하면 된다 — 선언 없이 호출하면 {@code NoClassDefFoundError: com/ibm/icu/...} 가 난다.</p>
+ *
+ * <pre>
+ * &lt;dependency&gt;
+ *     &lt;groupId&gt;com.ibm.icu&lt;/groupId&gt;
+ *     &lt;artifactId&gt;icu4j&lt;/artifactId&gt;
+ *     &lt;version&gt;77.1&lt;/version&gt;
+ * &lt;/dependency&gt;
+ * </pre>
+ *
+ * <pre>
+ * EgovLunarDates.toLunar(LocalDate.of(2025, 1, 29))          → 2025-01-01 (설날)
+ * EgovLunarDates.toSolar(EgovLunarDate.of(2025, 1, 1))       → 2025-01-29
+ * EgovLunarDates.toSolar(EgovLunarDate.ofLeapMonth(2025, 6, 1)) → 2025-07-25 (윤6월)
+ * </pre>
+ *
+ * <p><b>지원 범위</b> — 입력 연도(양력·음력 모두)는 {@value #MIN_YEAR}~{@value #MAX_YEAR}년이며
+ * 그 밖은 {@code IllegalArgumentException} 이다. ICU 의 천문 계산은 먼 미래에서 일관성을 잃고
+ * (실측: 64032년부터 왕복 불일치와 예외가 나타난다), ±580만 년 밖에서는 달력이 시각을 조용히
+ * 한계값으로 고정해 <b>틀린 날짜를 예외 없이</b> 돌려준다. 사용자 입력이 그대로 들어오는 자리에서
+ * 그런 결과가 새지 않도록 범위를 명시적으로 닫는다.</p>
+ *
+ * <p><b>한계 고지</b> — ICU 의 천문 근사 계산이 한국천문연구원(KASI) 발표와 극단적인
+ * 경계(합삭이 자정 수 초 이내)에서 다를 가능성은 이론상 남는다. 법정 공휴일 판정처럼
+ * 공식 음력이 필요한 자리는 KASI 자료(공공데이터 특일 정보 API 등)를 원천으로 쓰고,
+ * 이 클래스는 일반 표시 용도로 쓴다.</p>
+ *
+ * <pre>
+ * &lt;&lt; 개정이력(Modification Information) &gt;&gt;
+ *
+ *  수정일        수정자        수정내용
+ *  ----------  --------    ---------------------------
+ *  2026.09.01  실행환경팀     최초 생성 (공통컴포넌트 EgovDateUtil 의 toLunar/toSolar
+ *                            착상을 차용하되 재구성 — 원본은 길이가 8이 아닌 입력에 빈 Map 을
+ *                            돌려줘 실패가 침묵했고, 반환형이 Map&lt;String,String&gt; 이라 윤달
+ *                            정보가 문자열 "0/1" 로 흘렀으며, 존재하지 않는 윤달을 지정해도
+ *                            다른 날짜로 미끄러졌고, 무엇보다 한국 음력에 중국 기준
+ *                            ChineseCalendar 를 썼다(2000~2026 실측 418일 차이) →
+ *                            단기력(Dangi)으로 교체. 코드 이식 아님)
+ *  2026.09.07  실행환경팀     입력 연도 범위(1~9999) 검증 추가 — 범위 밖에서 ICU 가 틀린 날짜를
+ *                            예외 없이 돌려주거나 내부 필드 오류를 던지던 것을 즉시 실패로 닫음
+ * </pre>
+ *
+ * @author 실행환경 개발팀
+ * @since 5.1
+ */
+public final class EgovLunarDates {
+
+	/** 지원하는 최소 연도(양력·음력 입력 공통). */
+	public static final int MIN_YEAR = 1;
+
+	/** 지원하는 최대 연도(양력·음력 입력 공통). */
+	public static final int MAX_YEAR = 9999;
+
+	/**
+	 * 단기력의 {@code EXTENDED_YEAR} 와 서기 연도의 차 — 단군기원(檀紀, 기원전 2333년) 기산이다
+	 * (2025년 = 단기 4358년).
+	 */
+	private static final int EXTENDED_YEAR_OFFSET = 2333;
+
+	/** 하루의 밀리초. */
+	private static final long MILLIS_PER_DAY = 86_400_000L;
+
+	/** 단기력(Dangi) 달력을 지정하는 로케일. */
+	private static final ULocale DANGI_LOCALE = new ULocale("ko_KR@calendar=dangi");
+
+	private EgovLunarDates() {
+	}
+
+	/**
+	 * UTC 로 고정한 단기력 달력을 만든다 — 벽시계 해석이 JVM 기본 시간대를 따르면
+	 * epoch 일수 변환에서 하루가 밀린다(KST 자정 = UTC 전날 15시).
+	 * 역법 자체의 천문 기준(한국 자오선)은 달력 구현에 내장되어 있어 이 설정과 무관하다.
+	 */
+	private static Calendar newCalendar() {
+		Calendar lunarCalendar = Calendar.getInstance(DANGI_LOCALE);
+		lunarCalendar.setTimeZone(TimeZone.getTimeZone("Etc/UTC"));
+		lunarCalendar.clear();
+		return lunarCalendar;
+	}
+
+	/**
+	 * 양력 날짜를 음력으로 변환한다.
+	 *
+	 * @param solarDate 양력 날짜(필수, 연도 {@value #MIN_YEAR}~{@value #MAX_YEAR})
+	 * @return 음력 날짜(윤달 여부 포함)
+	 * @throws IllegalArgumentException {@code null} 이거나 지원 범위 밖의 연도인 경우
+	 */
+	public static EgovLunarDate toLunar(LocalDate solarDate) {
+		if (solarDate == null) {
+			throw new IllegalArgumentException("solarDate must not be null");
+		}
+		requireSupportedYear(solarDate.getYear(), "solarDate");
+		return toLunarUnchecked(solarDate);
+	}
+
+	/**
+	 * 범위 검사 없는 변환 — {@link #toSolar(EgovLunarDate)} 의 역변환 대조에 쓴다
+	 * (음력 {@value #MAX_YEAR}년 말은 양력 {@value #MAX_YEAR}+1 년 초에 해당하므로 대조 단계에서
+	 * 범위 검사를 하면 정상 입력이 거부된다).
+	 */
+	private static EgovLunarDate toLunarUnchecked(LocalDate solarDate) {
+		Calendar lunarCalendar = newCalendar();
+		// GregorianCalendar 경유 없이 epoch 일수로 직접 지정한다(UTC 자정 = UTC 달력 해석).
+		lunarCalendar.setTimeInMillis(solarDate.toEpochDay() * MILLIS_PER_DAY);
+
+		int year = lunarCalendar.get(Calendar.EXTENDED_YEAR) - EXTENDED_YEAR_OFFSET;
+		int month = lunarCalendar.get(Calendar.MONTH) + 1;
+		int day = lunarCalendar.get(Calendar.DAY_OF_MONTH);
+		boolean leap = lunarCalendar.get(Calendar.IS_LEAP_MONTH) == 1;
+
+		return leap ? EgovLunarDate.ofLeapMonth(year, month, day) : EgovLunarDate.of(year, month, day);
+	}
+
+	/**
+	 * 음력 날짜를 양력으로 변환한다.
+	 *
+	 * <p><b>존재하지 않는 날짜는 예외로 알린다</b> — 없는 윤달({@code 2026년 윤1월} 등)이나
+	 * 없는 30일을 지정하면 {@code IllegalArgumentException} 이다. 원본은 이런 입력을
+	 * 달력이 임의로 해석한 다른 날짜로 조용히 돌려줬다.</p>
+	 *
+	 * @param lunarDate 음력 날짜(필수, 연도 {@value #MIN_YEAR}~{@value #MAX_YEAR})
+	 * @return 양력 날짜
+	 * @throws IllegalArgumentException {@code null} 이거나 지원 범위 밖의 연도이거나
+	 *                                  달력에 존재하지 않는 음력 날짜인 경우
+	 */
+	public static LocalDate toSolar(EgovLunarDate lunarDate) {
+		if (lunarDate == null) {
+			throw new IllegalArgumentException("lunarDate must not be null");
+		}
+		requireSupportedYear(lunarDate.getYear(), "lunarDate");
+		Calendar lunarCalendar = newCalendar();
+		lunarCalendar.set(Calendar.EXTENDED_YEAR, lunarDate.getYear() + EXTENDED_YEAR_OFFSET);
+		lunarCalendar.set(Calendar.MONTH, lunarDate.getMonth() - 1);
+		lunarCalendar.set(Calendar.DAY_OF_MONTH, lunarDate.getDay());
+		lunarCalendar.set(Calendar.IS_LEAP_MONTH, lunarDate.isLeapMonth() ? 1 : 0);
+
+		LocalDate solar = LocalDate.ofEpochDay(Math.floorDiv(lunarCalendar.getTimeInMillis(), MILLIS_PER_DAY));
+
+		// ICU 달력은 lenient 라 없는 날짜를 다른 날로 미끄러뜨린다 — 역변환 대조로 검증한다.
+		EgovLunarDate roundTrip = toLunarUnchecked(solar);
+		if (!roundTrip.equals(lunarDate)) {
+			throw new IllegalArgumentException(
+					"lunar date does not exist in the calendar: " + lunarDate
+							+ " (resolved to " + roundTrip + ")");
+		}
+		return solar;
+	}
+
+	private static void requireSupportedYear(int year, String name) {
+		if (year < MIN_YEAR || year > MAX_YEAR) {
+			throw new IllegalArgumentException(
+					name + " year must be " + MIN_YEAR + ".." + MAX_YEAR + ": " + year);
+		}
+	}
+}

--- a/Foundation/org.egovframe.rte.fdl.string/src/test/java/org/egovframe/rte/fdl/string/EgovLunarDatesSecurityTest.java
+++ b/Foundation/org.egovframe.rte.fdl.string/src/test/java/org/egovframe/rte/fdl/string/EgovLunarDatesSecurityTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2009-2026 MOIS(Ministry of the Interior and Safety).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.egovframe.rte.fdl.string;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * {@link EgovLunarDates} 의 <b>입력 범위 검증</b> 회귀 검증.
+ *
+ * <p>양력·음력 날짜는 화면 입력이 그대로 들어오는 값이다. 지원 범위 밖의 연도에서 ICU 달력은
+ * 예외 없이 <b>틀린 날짜</b>를 돌려주거나(±580만 년 밖: 시각을 한계값으로 고정, 64032년 이후:
+ * 왕복 불일치) 내부 필드 오류를 던진다. 이 클래스는 그런 입력이 <b>즉시, 범위를 말하는 예외</b>로
+ * 닫히고, 범위 안에서는 왕복이 성립함을 고정한다.</p>
+ *
+ * <pre>
+ * &lt;&lt; 개정이력(Modification Information) &gt;&gt;
+ *
+ *  수정일        수정자        수정내용
+ *  ----------  --------    ---------------------------
+ *  2026.09.07  실행환경팀     최초 생성
+ * </pre>
+ *
+ * @author 실행환경 개발팀
+ * @since 5.1
+ */
+class EgovLunarDatesSecurityTest {
+
+	@Test
+	@DisplayName("지원 범위 밖의 양력 연도는 계산 전에 범위를 말하는 예외로 닫힌다")
+	void 양력_범위_밖_즉시_거부() {
+		for (LocalDate solar : List.of(LocalDate.of(0, 12, 31), LocalDate.of(10_000, 1, 1), LocalDate.of(67_685, 1, 1),
+				LocalDate.of(10_000_000, 6, 15), LocalDate.MAX, LocalDate.MIN)) {
+			IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> EgovLunarDates.toLunar(solar), solar.toString());
+			assertTrue(e.getMessage().contains("1..9999"), "범위를 말해야 한다: " + e.getMessage());
+		}
+	}
+
+	@Test
+	@DisplayName("지원 범위 밖의 음력 연도는 계산 전에 범위를 말하는 예외로 닫힌다")
+	void 음력_범위_밖_즉시_거부() {
+		for (EgovLunarDate lunar : List.of(EgovLunarDate.of(0, 1, 1), EgovLunarDate.of(10_000, 1, 1),
+				EgovLunarDate.of(Integer.MAX_VALUE, 1, 1), EgovLunarDate.of(Integer.MIN_VALUE, 1, 1))) {
+			IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> EgovLunarDates.toSolar(lunar), lunar.toString());
+			assertTrue(e.getMessage().contains("1..9999"), "범위를 말해야 한다: " + e.getMessage());
+		}
+	}
+
+	@Test
+	@DisplayName("범위 경계는 성립한다 — 양력 0001-01-01 과 9999-12-31, 음력 1년 1월 1일과 9999년 12월 1일")
+	void 경계값_성립() {
+		assertEquals(0, EgovLunarDates.toLunar(LocalDate.of(1, 1, 1)).getYear(), "양력 1년 1월은 음력으로 전년도 12월");
+		assertEquals(9999, EgovLunarDates.toLunar(LocalDate.of(9999, 12, 31)).getYear());
+		assertEquals(1, EgovLunarDates.toSolar(EgovLunarDate.of(1, 1, 1)).getYear());
+		LocalDate lastLunarYearStart = EgovLunarDates.toSolar(EgovLunarDate.of(9999, 12, 1));
+		assertTrue(lastLunarYearStart.getYear() >= 9999, "음력 9999년 12월은 양력 9999년 말~10000년 초");
+	}
+
+	@Test
+	@DisplayName("범위 안에서는 양력→음력→양력 왕복이 성립한다 — 1~9999년을 7년 간격으로, 해마다 세 날짜")
+	void 범위_안_왕복_표본() {
+		int checked = 0;
+		for (int year = 1; year <= 9999; year += 7) {
+			for (LocalDate solar : List.of(LocalDate.of(year, 1, 1), LocalDate.of(year, 6, 15), LocalDate.of(year, 12, 31))) {
+				EgovLunarDate lunar = EgovLunarDates.toLunar(solar);
+				if (lunar.getYear() < 1 || lunar.getYear() > 9999) {
+					continue; // 양력 1년 초·9999년 말은 음력 연도가 범위 밖이라 역변환 입력이 될 수 없다
+				}
+				assertEquals(solar, EgovLunarDates.toSolar(lunar), "왕복 불일치: " + solar + " -> " + lunar);
+				checked++;
+			}
+		}
+		assertTrue(checked > 4_000, "표본 수: " + checked);
+	}
+
+	@Test
+	@DisplayName("변환 비용은 입력값에 따라 폭증하지 않는다 — 범위 양끝 1,000회가 수 초 안에 끝난다")
+	void 변환_비용_상한() {
+		long start = System.nanoTime();
+		for (int i = 0; i < 500; i++) {
+			EgovLunarDates.toLunar(LocalDate.of(9999, 1, 1).minusDays(i * 3L));
+			EgovLunarDates.toLunar(LocalDate.of(1, 1, 1).plusDays(i * 3L));
+		}
+		long millis = (System.nanoTime() - start) / 1_000_000;
+		assertTrue(millis < 10_000, "1,000회 변환에 " + millis + " ms");
+	}
+}

--- a/Foundation/org.egovframe.rte.fdl.string/src/test/java/org/egovframe/rte/fdl/string/EgovLunarDatesTest.java
+++ b/Foundation/org.egovframe.rte.fdl.string/src/test/java/org/egovframe/rte/fdl/string/EgovLunarDatesTest.java
@@ -1,0 +1,221 @@
+/*
+ * Copyright 2009-2026 MOIS(Ministry of the Interior and Safety).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.egovframe.rte.fdl.string;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.LocalDate;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * {@link EgovLunarDates} · {@link EgovLunarDate} 단위 테스트.
+ *
+ * <p>알려진 명절 날짜로 변환을 검증하고, <b>공통컴포넌트 원본(EgovDateUtil)의 침묵 실패</b>
+ * (잘못된 입력 → 빈 Map, 없는 윤달 → 다른 날짜로 미끄러짐)를 예외 계약으로 고정한다.</p>
+ *
+ * <pre>
+ * &lt;&lt; 개정이력(Modification Information) &gt;&gt;
+ *
+ *  수정일        수정자        수정내용
+ *  ----------  --------    ---------------------------
+ *  2026.09.01  실행환경팀     최초 생성
+ * </pre>
+ *
+ * @author 실행환경 개발팀
+ * @since 5.1
+ */
+class EgovLunarDatesTest {
+
+	@Nested
+	@DisplayName("알려진 날짜 검증")
+	class KnownDates {
+
+		@Test
+		@DisplayName("설날 — 2025-01-29 는 음력 2025년 1월 1일")
+		void 설날_2025() {
+			EgovLunarDate lunar = EgovLunarDates.toLunar(LocalDate.of(2025, 1, 29));
+
+			assertEquals(EgovLunarDate.of(2025, 1, 1), lunar);
+			assertFalse(lunar.isLeapMonth());
+		}
+
+		@Test
+		@DisplayName("추석 — 2025-10-06 은 음력 2025년 8월 15일")
+		void 추석_2025() {
+			assertEquals(EgovLunarDate.of(2025, 8, 15),
+					EgovLunarDates.toLunar(LocalDate.of(2025, 10, 6)));
+		}
+
+		@Test
+		@DisplayName("음력 → 양력 — 설날 역방향")
+		void 음력에서_양력() {
+			assertEquals(LocalDate.of(2025, 1, 29),
+					EgovLunarDates.toSolar(EgovLunarDate.of(2025, 1, 1)));
+		}
+
+		@Test
+		@DisplayName("윤달 — 2025년 윤6월 1일은 양력 2025-07-25")
+		void 윤달_2025_윤6월() {
+			LocalDate solar = EgovLunarDates.toSolar(EgovLunarDate.ofLeapMonth(2025, 6, 1));
+			assertEquals(LocalDate.of(2025, 7, 25), solar);
+
+			EgovLunarDate back = EgovLunarDates.toLunar(solar);
+			assertTrue(back.isLeapMonth(), "역변환에서 윤달 정보가 보존돼야 한다");
+			assertEquals(EgovLunarDate.ofLeapMonth(2025, 6, 1), back);
+		}
+
+		@Test
+		@DisplayName("한국 기준(단기력)으로 계산한다 — 중국 기준 ChineseCalendar 라면 실패한다")
+		void 한국_기준_역법() {
+			// 2001-04-24: 단기력(한국)은 음력 4/1, ChineseCalendar(중국)는 4/2 —
+			// 합삭 시각이 자정 부근이라 월 시작이 하루 갈리는 구간이다(2000~2026 실측 418일).
+			assertEquals(EgovLunarDate.of(2001, 4, 1),
+					EgovLunarDates.toLunar(LocalDate.of(2001, 4, 24)));
+		}
+
+		@Test
+		@DisplayName("평달 6월과 윤6월은 서로 다른 양력 날짜다 — 윤달 구분이 값 객체에 실리는 이유")
+		void 평달과_윤달_구분() {
+			LocalDate plain = EgovLunarDates.toSolar(EgovLunarDate.of(2025, 6, 1));
+			LocalDate leap = EgovLunarDates.toSolar(EgovLunarDate.ofLeapMonth(2025, 6, 1));
+
+			assertEquals(LocalDate.of(2025, 6, 25), plain);
+			assertFalse(plain.equals(leap));
+		}
+	}
+
+	@Nested
+	@DisplayName("KASI 확정값 대조 — 정부 공휴일 고시 30점")
+	class KasiConformance {
+
+		/** 공휴일 고시 기준 설날(음력 1/1) 양력 날짜 — 2004~2026. */
+		private static final String[] SEOLLAL = {
+				"2004-01-22", "2005-02-09", "2006-01-29", "2007-02-18", "2008-02-07",
+				"2009-01-26", "2010-02-14", "2011-02-03", "2012-01-23", "2013-02-10",
+				"2014-01-31", "2015-02-19", "2016-02-08", "2017-01-28", "2018-02-16",
+				"2019-02-05", "2020-01-25", "2021-02-12", "2022-02-01", "2023-01-22",
+				"2024-02-10", "2025-01-29", "2026-02-17"};
+
+		/** 공휴일 고시 기준 추석(음력 8/15) 양력 날짜 — 2020~2026. */
+		private static final String[] CHUSEOK = {
+				"2020-10-01", "2021-09-21", "2022-09-10", "2023-09-29",
+				"2024-09-17", "2025-10-06", "2026-09-25"};
+
+		@Test
+		@DisplayName("설날 23년치가 전부 음력 1월 1일이다 — icu4j 업그레이드 시 정합 감시")
+		void 설날_전수() {
+			for (String solar : SEOLLAL) {
+				EgovLunarDate lunar = EgovLunarDates.toLunar(LocalDate.parse(solar));
+				assertEquals(EgovLunarDate.of(lunar.getYear(), 1, 1), lunar, "설날 불일치: " + solar);
+			}
+		}
+
+		@Test
+		@DisplayName("추석 7년치가 전부 음력 8월 15일이다")
+		void 추석_전수() {
+			for (String solar : CHUSEOK) {
+				EgovLunarDate lunar = EgovLunarDates.toLunar(LocalDate.parse(solar));
+				assertEquals(EgovLunarDate.of(lunar.getYear(), 8, 15), lunar, "추석 불일치: " + solar);
+			}
+		}
+
+		@Test
+		@DisplayName("2017년은 한국 윤5월이다 — 중국력(윤6월)이라면 실패한다")
+		void 이천십칠년_윤오월() {
+			// 한·중 윤달 위치가 다른 해로 알려진 사례 — 계통 오차가 아니라 역법 차이의 크기를 보여준다.
+			EgovLunarDate june25 = EgovLunarDates.toLunar(LocalDate.of(2017, 6, 25));
+			assertTrue(june25.isLeapMonth(), "2017-06-25 는 윤5월 구간이어야 한다: " + june25);
+			assertEquals(5, june25.getMonth());
+		}
+	}
+
+	@Nested
+	@DisplayName("왕복 일관성")
+	class RoundTrip {
+
+		@Test
+		@DisplayName("1년치 매일 왕복 변환이 원본과 일치한다")
+		void 일년_왕복() {
+			LocalDate date = LocalDate.of(2025, 1, 1);
+			for (int i = 0; i < 365; i++) {
+				EgovLunarDate lunar = EgovLunarDates.toLunar(date);
+				assertEquals(date, EgovLunarDates.toSolar(lunar), "왕복 불일치: " + date);
+				date = date.plusDays(1);
+			}
+		}
+	}
+
+	@Nested
+	@DisplayName("원본 결함 회귀 — 침묵 실패를 예외 계약으로")
+	class LegacyDefectRegression {
+
+		@Test
+		@DisplayName("존재하지 않는 윤달은 예외다 (원본은 다른 날짜로 조용히 미끄러졌다)")
+		void 없는_윤달() {
+			// 2026년에는 윤1월이 없다.
+			assertThrows(IllegalArgumentException.class,
+					() -> EgovLunarDates.toSolar(EgovLunarDate.ofLeapMonth(2026, 1, 1)));
+		}
+
+		@Test
+		@DisplayName("존재하지 않는 30일은 예외다")
+		void 없는_30일() {
+			// 2025년 음력 4월은 29일까지다(작은달).
+			assertThrows(IllegalArgumentException.class,
+					() -> EgovLunarDates.toSolar(EgovLunarDate.of(2025, 4, 30)));
+		}
+
+		@Test
+		@DisplayName("null 입력은 즉시 예외다 (원본은 빈 Map 을 돌려줬다)")
+		void null_입력() {
+			assertThrows(IllegalArgumentException.class, () -> EgovLunarDates.toLunar(null));
+			assertThrows(IllegalArgumentException.class, () -> EgovLunarDates.toSolar(null));
+		}
+
+		@Test
+		@DisplayName("값 객체 자체도 범위를 검증한다")
+		void 값_객체_검증() {
+			assertThrows(IllegalArgumentException.class, () -> EgovLunarDate.of(2025, 13, 1));
+			assertThrows(IllegalArgumentException.class, () -> EgovLunarDate.of(2025, 1, 31));
+			assertThrows(IllegalArgumentException.class, () -> EgovLunarDate.of(2025, 0, 1));
+		}
+	}
+
+	@Nested
+	@DisplayName("값 객체")
+	class ValueObject {
+
+		@Test
+		@DisplayName("동일성은 연·월·일·윤달 네 필드")
+		void 동일성() {
+			assertEquals(EgovLunarDate.of(2025, 6, 1), EgovLunarDate.of(2025, 6, 1));
+			assertFalse(EgovLunarDate.of(2025, 6, 1).equals(EgovLunarDate.ofLeapMonth(2025, 6, 1)));
+		}
+
+		@Test
+		@DisplayName("표기 — 윤달은 (윤) 이 붙는다")
+		void 표기() {
+			assertEquals("2025-06-01", EgovLunarDate.of(2025, 6, 1).toString());
+			assertEquals("2025-06-01(윤)", EgovLunarDate.ofLeapMonth(2025, 6, 1).toString());
+		}
+	}
+}


### PR DESCRIPTION
> **[공통컴포넌트 공통 기능 개선 → 실행환경 이관]**
>
> 공통컴포넌트에 있던 공통 기능을 개선해 실행환경으로 올리는 항목입니다.
> 실행환경에 올라가면 공통컴포넌트를 포함한 모든 사업에서 같은 구현을 쓸 수 있습니다.
>
> 공통컴포넌트 원본
> - `egovframework.com.utl.fcc.service.EgovDateUtil` — 음력 변환 메서드

## 수정 사유 Reason for modification

- [ ] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [X] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

### 배경

기념일·제례·명절 안내처럼 음력을 다뤄야 하는 업무가 있는데 실행환경에 변환 수단이 없습니다.

공통컴포넌트 `EgovDateUtil` 의 `toLunar`/`toSolar` 는 **한국 음력에 중국 기준
`ChineseCalendar`** 를 씁니다. 두 역법은 **기준 자오선이 달라** 합삭 시각이 자정 부근인 달의
월 시작이 하루 밀리며, **2000~2026년 실측으로 418일이 서로 다릅니다.**

그 밖에도 다음이 있습니다.

| 결함 | 결과 |
|---|---|
| 길이가 8이 아닌 입력에 빈 `Map` 반환 | **실패가 침묵한다** |
| 반환형이 `Map<String,String>` | 윤달 정보가 `"0"`/`"1"` 문자열로 흐른다 |
| 존재하지 않는 윤달을 지정해도 통과 | **다른 날짜로 조용히 미끄러진다** |

### 추가한 것

- **`EgovLunarDates`** — 음력↔양력 변환
  - **ICU4J 의 단기력(Dangi)** — 한국 전통 역법 — 으로 계산합니다
  - 달력의 벽시계 해석은 **`Etc/UTC` 로 고정**합니다. JVM 기본 시간대를 따르면 epoch 일수
    변환에서 하루가 밀립니다(KST 자정 = UTC 전날 15시). 역법 자체의 천문 기준은 달력 구현에
    내장돼 있어 이 설정과 무관합니다
  - 존재하지 않는 윤달·일자는 **예외**입니다
- **`EgovLunarDate`** — 음력 날짜 값 객체(연·월·일·윤달)
  - **윤달을 문자열이 아니라 값으로** 표현합니다. 평달 6월과 윤6월은 **서로 다른 양력
    날짜**이므로 호출부가 구분할 수 있어야 합니다

### 추가되는 의존성

| 좌표 | 버전 | 라이선스 | 크기 | 스코프 |
|---|---|---|---:|---|
| `com.ibm.icu:icu4j` | **77.1** | **Unicode-3.0** | **14.0 MB** | **`optional`** |

**이미 표준프레임워크가 채택해 쓰고 있는 의존입니다.**

공통컴포넌트(`egovframe-common-components`)가 **같은 버전 77.1 을 일반 compile 스코프로**
선언하고 있으며, 버전은 부모 BOM `egovframe-web-config-parent:5.0.0` 의
`<icu4j.version>77.1</icu4j.version>` 가 관리합니다.

```xml
<!-- 공통컴포넌트 pom.xml — 요소기술 달력을 위한 라이브러리 -->
<dependency>
    <groupId>com.ibm.icu</groupId>
    <artifactId>icu4j</artifactId>
</dependency>
```

실제 사용처는 `egovframework/com/utl/fcc/service/EgovDateUtil.java` 의
`import com.ibm.icu.util.ChineseCalendar` — **이 PR 이 대체하려는 바로 그 코드**입니다.
따라서 이 PR 은 새 의존을 들이는 것이 아니라, **이미 채택된 의존을 실행환경에서
더 약한 형태(`optional`)로 쓰는 것**입니다.

**라이선스** — `Unicode-3.0` 은 **OSI 승인 오픈소스 라이선스**입니다(2023-11-17 승인,
관리 주체 Unicode Consortium). BSD/MIT 계열 **퍼미시브**이며 카피레프트가 아니고 사용 분야
제한도 없습니다. 의무는 저작권·허가 고지 유지와 무보증 조항이며, 저작권자 이름을 광고·판촉에
쓰지 않는 상표 조항이 있습니다.

**용량** — 14.0 MB 로 작지 않습니다. 다만 `optional` 이라 **전이되지 않으므로** 음력 변환을
쓰지 않는 애플리케이션의 클래스패스에는 들어오지 않습니다. 선언 없이 호출하면
`NoClassDefFoundError` 로 즉시 드러납니다(javadoc 에 명시).

`mvn dependency:tree` 실측 결과 전이 의존은 **0건**입니다.

```
[INFO] +- com.ibm.icu:icu4j:jar:77.1:compile (optional)
```

**보안 재검증 반영(2026-09-07)** — 입력 연도 범위를 **1~9999** 로 닫았습니다. 범위 밖에서는 ICU 가 ±580만 년 한계값으로 시각을 조용히 고정해 **틀린 날짜를 예외 없이** 돌려주거나(`LocalDate.MAX` 등), 64,032년부터 왕복 불일치와 내부 필드 오류를 던지는 것을 실측했습니다(연도 1~99,999 × 12개월 × 3일 스캔). 이제 `IllegalArgumentException` 입니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

`EgovLunarDatesTest` **16건** + 보안 회귀 `EgovLunarDatesSecurityTest` **5건**, 합계 **21건 신규**. `fdl.string` 모듈 전건 통과.

| 환경 | 기본 로케일(Locale) | 모듈 실행 건수 | 결과 |
|---|---|---:|---|
| **Windows** | ko_KR | **80** | `Tests run: 80, Failures: 0, Errors: 0, Skipped: 0` |
| **Linux** (Ubuntu 22.04 / OpenJDK 17) | C.UTF-8 | **80** | `Tests run: 80, Failures: 0, Errors: 0, Skipped: 0` |

| 구분 | 건수 | 내용 |
|---|---:|---|
| 알려진 날짜 | 6 | 설날 · 추석 · 역방향 변환 · **윤달**(2025 윤6월 1일 = 양력 07-25) · **한국 기준 계산**(중국 `ChineseCalendar` 라면 실패) · 평달 6월과 윤6월이 서로 다른 양력 날짜 |
| **KASI 확정값 대조** | 3 | **설날 23년치**가 전부 음력 1월 1일 · **추석 7년치**가 전부 음력 8월 15일 · **2017년은 한국 윤5월**(중국력 윤6월이라면 실패) |
| 왕복 일관성 | 1 | **1년치 매일** 왕복 변환이 원본과 일치 |
| 원본 결함 회귀 | 4 | 존재하지 않는 윤달은 예외(원본은 미끄러짐) · 존재하지 않는 30일은 예외 · `null` 즉시 예외(원본은 빈 `Map`) · 값 객체 자체 범위 검증 |
| 값 객체 | 2 | 동일성은 연·월·일·윤달 4필드 · 표기에 `(윤)` 부착 |

`EgovLunarDatesSecurityTest` 5건 — 지원 범위 밖 양력·음력 연도 즉시 거부(2) · 경계(1년·9999년) 정상(1) · 범위 안 4,000 표본 이상 왕복 일치(1) · 변환 비용 상한(1).

**수동 확인**: 역법 계산이 시간대·로케일에 얽히므로 기본 로케일·시간대가 다른 Linux(`C.UTF-8`)에서
교차 검증했습니다. **설날 23년치 대조는 icu4j 업그레이드 시 정합을 감시하는 역할**도 합니다.

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

해당 없음 — 라이브러리 클래스 추가입니다.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

해당 없음 — 위 JUnit 테스트 결과로 갈음합니다.

---

<sub>base: `eGovFramework:main` @ `cd9fd9c` (2026-09-08 fetch 기준) · 단일 커밋</sub>
