### PR TITLE
feat: 유일한 저장 파일명 생성 EgovStoredFileNames 추가

### DIFF
--- a/Foundation/org.egovframe.rte.fdl.filehandling/src/main/java/org/egovframe/rte/fdl/filehandling/upload/EgovStoredFileNames.java
+++ b/Foundation/org.egovframe.rte.fdl.filehandling/src/main/java/org/egovframe/rte/fdl/filehandling/upload/EgovStoredFileNames.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2009-2026 MOIS(Ministry of the Interior and Safety).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.egovframe.rte.fdl.filehandling.upload;
+
+import java.util.Locale;
+import java.util.Objects;
+import java.util.UUID;
+
+import org.egovframe.rte.fdl.filehandling.EgovFiles;
+
+/**
+ * 업로드 파일을 서버에 저장할 때 쓸 <b>유일한 파일명</b>을 만든다.
+ *
+ * <p><b>NOTE:</b> 사용자가 보낸 이름을 그대로 저장 경로에 쓰면 세 가지가 한꺼번에 걸린다 —
+ * 같은 이름이 오면 <b>덮어써지고</b>, 이름에 섞인 경로·특수문자가 저장 위치를 흔들며,
+ * 다른 사용자의 파일명을 <b>추측</b>할 수 있게 된다. 저장명은 새로 만들고 원본 이름은
+ * 별도 컬럼에 보관하는 것이 표준적인 처리다.</p>
+ *
+ * <pre>
+ * String stored = EgovStoredFileNames.generate(file.getOriginalFilename());
+ * // 예: "0a7f3c1e9b4d42f8a1c6d5e2f7b8c9d0.pdf"
+ *
+ * Path target = EgovFiles.resolveSecurely(baseDir, stored);   // 경로까지 확정
+ * </pre>
+ *
+ * <p><b>원본 이름은 애플리케이션이 보관한다.</b> 이 클래스는 저장명만 만든다 — 다운로드 시
+ * 원래 이름으로 내려주려면 DB 등에 원본 이름을 함께 저장해 두었다가
+ * {@code Content-Disposition} 에 실어야 한다. 한글 파일명이 깨지지 않는 헤더 값 생성은
+ * {@link org.egovframe.rte.fdl.filehandling.EgovContentDispositions} 를 쓴다.</p>
+ *
+ * <p><b>확장자는 기본적으로 보존한다.</b> 확장자를 버리면 운영자가 파일을 알아볼 수 없고
+ * 다운로드 시 형식 판별도 어려워지기 때문이다. 다만 확장자가 남아 있다는 것은
+ * <b>업로드 디렉터리에서 실행 권한이 제거되어 있다는 전제</b> 위에서만 안전하다. 실행 가능한
+ * 위치에 두어야 하는 사정이 있다면 {@link #generateWithoutExtension()} 을 쓴다.</p>
+ *
+ * <pre>
+ * &lt;&lt; 개정이력(Modification Information) &gt;&gt;
+ *
+ *  수정일        수정자        수정내용
+ *  ----------  --------    ---------------------------
+ *  2026.09.01  실행환경팀     최초 생성 (공통컴포넌트 EgovFileMngUtil.getTimeStamp 의
+ *                            목적(유일한 저장명)만 차용하고 구현은 재작성 — 원본은
+ *                            12시간제 hh 로 오전·오후를 구분하지 못하고, 밀리초 해상도
+ *                            시각만으로 이름을 만들어 동시 업로드 시 덮어써지며,
+ *                            시각 기반이라 파일명이 예측 가능했다. 코드 이식 아님)
+ * </pre>
+ *
+ * @author 실행환경 개발팀
+ * @since 5.1
+ */
+public final class EgovStoredFileNames {
+
+	/** 확장자로 인정하는 최대 길이 — 이보다 길면 확장자가 아닌 것으로 본다. */
+	private static final int MAX_EXTENSION_LENGTH = 20;
+
+	private EgovStoredFileNames() {
+	}
+
+	/**
+	 * 무작위 저장명을 만든다(확장자 보존).
+	 *
+	 * <p>이름은 하이픈을 제거한 UUID 32자에 확장자를 붙인 형태다. 시각 정보를 담지 않으므로
+	 * <b>다른 파일의 이름을 추측할 수 없다.</b></p>
+	 *
+	 * @param originalFileName 사용자가 보낸 원본 파일명({@code null} 허용)
+	 * @return 저장용 파일명(예: {@code "0a7f...d0.pdf"})
+	 */
+	public static String generate(String originalFileName) {
+		return generate(originalFileName, UUID.randomUUID());
+	}
+
+	/**
+	 * 주어진 UUID 로 저장명을 만든다(확장자 보존).
+	 *
+	 * <p><b>시간순 정렬이 필요하면 UUIDv7 을 넘긴다.</b> 파일명이 생성 시각 순서로 정렬되면서도
+	 * 뒤쪽 난수 때문에 예측은 되지 않는다. 실행환경은 {@code fdl.idgnr} 의
+	 * {@code EgovUuidV7GnrServiceImpl.generate()} 로 UUIDv7 을 제공한다 — 본 모듈이 그 모듈을
+	 * 의존하지 않으므로(파일명 생성만을 위해 JDBC 계열 의존을 끌어오지 않는다) 값을 넘겨받는 형태로 둔다.</p>
+	 *
+	 * <pre>
+	 * String stored = EgovStoredFileNames.generate(name, EgovUuidV7GnrServiceImpl.generate());
+	 * </pre>
+	 *
+	 * @param originalFileName 원본 파일명({@code null} 허용)
+	 * @param uuid             사용할 UUID(필수)
+	 * @return 저장용 파일명
+	 */
+	public static String generate(String originalFileName, UUID uuid) {
+		Objects.requireNonNull(uuid, "uuid must not be null");
+		String base = uuid.toString().replace("-", "");
+		String extension = extensionOf(originalFileName);
+		return extension.isEmpty() ? base : base + "." + extension;
+	}
+
+	/**
+	 * 확장자 없는 무작위 저장명을 만든다.
+	 *
+	 * <p>업로드 디렉터리를 실행 가능한 위치에 두어야 하는 등 확장자를 남길 수 없는 사정이
+	 * 있을 때 쓴다. 대신 파일 형식은 애플리케이션이 따로 기록해야 한다.</p>
+	 *
+	 * @return 저장용 파일명(하이픈 없는 UUID 32자)
+	 */
+	public static String generateWithoutExtension() {
+		return UUID.randomUUID().toString().replace("-", "");
+	}
+
+	/**
+	 * 저장명에 붙일 <b>정규화된 확장자</b>를 반환한다.
+	 *
+	 * <p>경로를 제거하고 소문자로 바꾼 뒤, <b>ASCII 영숫자로만 이루어진 경우에만</b> 확장자로
+	 * 인정한다. 공백·따옴표·널 바이트처럼 경로나 헤더를 흔들 수 있는 문자가 저장명에
+	 * 섞이지 않게 하기 위해서다. 인정되지 않으면 빈 문자열을 돌려주며, 그 경우 저장명은
+	 * 확장자 없이 만들어진다.</p>
+	 *
+	 * @param originalFileName 원본 파일명({@code null} 허용)
+	 * @return 소문자 확장자(점 없음). 없거나 인정되지 않으면 빈 문자열
+	 */
+	public static String extensionOf(String originalFileName) {
+		if (originalFileName == null) {
+			return "";
+		}
+		String extension = EgovFiles.getExtension(originalFileName.trim()).toLowerCase(Locale.ROOT);
+		if (extension.isEmpty() || extension.length() > MAX_EXTENSION_LENGTH) {
+			return "";
+		}
+		for (int i = 0; i < extension.length(); i++) {
+			char ch = extension.charAt(i);
+			boolean alphaNumeric = (ch >= 'a' && ch <= 'z') || (ch >= '0' && ch <= '9');
+			if (!alphaNumeric) {
+				return "";
+			}
+		}
+		return extension;
+	}
+}

--- a/Foundation/org.egovframe.rte.fdl.filehandling/src/test/java/org/egovframe/rte/fdl/filehandling/upload/EgovStoredFileNamesSecurityTest.java
+++ b/Foundation/org.egovframe.rte.fdl.filehandling/src/test/java/org/egovframe/rte/fdl/filehandling/upload/EgovStoredFileNamesSecurityTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2009-2026 MOIS(Ministry of the Interior and Safety).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.egovframe.rte.fdl.filehandling.upload;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * EgovStoredFileNames 의 <b>저장명 오염</b> 회귀 검증.
+ *
+ * <p>저장명은 결국 파일시스템 경로와 다운로드 헤더에 실린다. 공격자가 원본 파일명에 무엇을
+ * 실어 보내든 저장명에는 <b>UUID 32자 + 소문자 영숫자 확장자</b> 외의 문자가 들어가지 않아야 한다.
+ * 확장자 자리로 경로 구분자·인용부호·널바이트·ADS 구분자가 새어 들어오면 그 자체가 취약점이다.</p>
+ *
+ * <pre>
+ * &lt;&lt; 개정이력(Modification Information) &gt;&gt;
+ *
+ *  수정일        수정자        수정내용
+ *  ----------  --------    ---------------------------
+ *  2026.09.07  실행환경팀     최초 생성
+ * </pre>
+ *
+ * @author 실행환경 개발팀
+ * @since 5.1
+ */
+class EgovStoredFileNamesSecurityTest {
+
+	private static final String BS = String.valueOf((char) 92);
+
+	@Test
+	@DisplayName("저장명은 어떤 원본명에서도 UUID32 + 영숫자 확장자 형식을 벗어나지 않는다")
+	void 저장명_형식_불변() {
+		List<String> hostile = List.of(
+				"../../etc/passwd.txt", "dir" + BS + "shell.jsp", "shell.jsp::$DATA", "a.png\"; rm -rf ~",
+				"a.png'", "a.png;b", "shell.jsp" + (char) 0 + ".png", "shell．jsp", "x." + "p".repeat(25),
+				"file.PNG", "file.pNg", "file.png.", "  spaced.txt  ", "", "no-extension", ".", "..");
+		for (String name : hostile) {
+			String stored = EgovStoredFileNames.generate(name);
+			assertTrue(stored.matches("[0-9a-f]{32}(\\.[a-z0-9]{1,20})?"),
+					"형식 위반: " + name.replace("\0", "<NUL>") + " -> " + stored);
+		}
+	}
+
+	@Test
+	@DisplayName("확장자로 인정되지 않는 입력은 확장자 없이 저장된다 — 오염 문자가 새지 않는다")
+	void 오염_확장자_탈락() {
+		assertEquals("", EgovStoredFileNames.extensionOf("shell.jsp::$DATA"));
+		assertEquals("", EgovStoredFileNames.extensionOf("a.png\""));
+		assertEquals("", EgovStoredFileNames.extensionOf("a.png;b"));
+		assertEquals("", EgovStoredFileNames.extensionOf("shell．jsp"));
+		assertEquals("", EgovStoredFileNames.extensionOf("x." + "p".repeat(25)));
+		assertEquals("", EgovStoredFileNames.extensionOf("file.png."));
+	}
+
+	@Test
+	@DisplayName("널바이트 앞의 가짜 확장자는 무시되고 진짜 마지막 확장자만 남는다")
+	void 널바이트_확장자() {
+		// 정책 단계에서 이미 거부되지만, 저장명 생성 단계 단독으로도 위험 문자가 남지 않아야 한다
+		String stored = EgovStoredFileNames.generate("shell.jsp" + (char) 0 + ".png");
+		assertTrue(stored.endsWith(".png"), stored);
+		assertFalse(stored.contains("\0") || stored.contains("jsp"), stored);
+	}
+
+	@Test
+	@DisplayName("경로가 섞여도 저장명에는 구분자가 없다")
+	void 구분자_없음() {
+		for (String name : List.of("../../etc/passwd.txt", "dir" + BS + "x.png", "/abs/x.png")) {
+			String stored = EgovStoredFileNames.generate(name);
+			assertFalse(stored.contains("/") || stored.contains(BS) || stored.contains(".."), stored);
+		}
+	}
+}

--- a/Foundation/org.egovframe.rte.fdl.filehandling/src/test/java/org/egovframe/rte/fdl/filehandling/upload/EgovStoredFileNamesTest.java
+++ b/Foundation/org.egovframe.rte.fdl.filehandling/src/test/java/org/egovframe/rte/fdl/filehandling/upload/EgovStoredFileNamesTest.java
@@ -1,0 +1,206 @@
+/*
+ * Copyright 2009-2026 MOIS(Ministry of the Interior and Safety).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.egovframe.rte.fdl.filehandling.upload;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * {@link EgovStoredFileNames} 단위 테스트.
+ *
+ * <p>일반 동작 검증과 함께 <b>공통컴포넌트 원본(EgovFileMngUtil·EgovStringUtil 의
+ * getTimeStamp)의 결함을 회귀로 고정</b>한다 — 12시간제로 오전·오후를 구분하지 못하는 문제,
+ * 시각만으로 이름을 만들어 동시 업로드가 덮어써지는 문제, 이름이 예측 가능한 문제.</p>
+ *
+ * <pre>
+ * &lt;&lt; 개정이력(Modification Information) &gt;&gt;
+ *
+ *  수정일        수정자        수정내용
+ *  ----------  --------    ---------------------------
+ *  2026.09.01  실행환경팀     최초 생성
+ * </pre>
+ *
+ * @author 실행환경 개발팀
+ * @since 5.1
+ */
+class EgovStoredFileNamesTest {
+
+	/** 파일명 널 바이트 — 소스에 리터럴로 두지 않는다. */
+	private static final String NUL = String.valueOf((char) 0x00);
+
+	@Nested
+	@DisplayName("원본 결함 회귀 — 공통컴포넌트 getTimeStamp 라면 실패한다")
+	class LegacyDefectRegression {
+
+		@Test
+		@DisplayName("연속 생성해도 이름이 겹치지 않는다 (원본은 같은 밀리초면 같은 이름 → 덮어쓰기)")
+		void 대량_생성_충돌_없음() {
+			Set<String> names = new HashSet<>();
+			for (int i = 0; i < 10000; i++) {
+				names.add(EgovStoredFileNames.generate("a.png"));
+			}
+			assertEquals(10000, names.size(), "생성한 수만큼 서로 다른 이름이어야 한다");
+		}
+
+		@Test
+		@DisplayName("이름에 시각이 드러나지 않는다 (원본은 yyyyMMddhhmmssSSS 라 추측이 가능했다)")
+		void 시각_비노출() {
+			String stored = EgovStoredFileNames.generate("a.png");
+			String base = stored.substring(0, stored.indexOf('.'));
+			String year = String.valueOf(java.time.Year.now().getValue());
+
+			assertFalse(base.startsWith(year), "이름이 연도로 시작하면 시각 기반이라는 뜻이다");
+			assertEquals(32, base.length());
+		}
+
+		@Test
+		@DisplayName("12시간제 충돌이 구조적으로 불가능하다 — 오전·오후가 같은 이름이 될 수 없다")
+		void 오전_오후_구분_불필요() {
+			// 원본은 hh(1~12) 를 써서 09:00 과 21:00 이 같은 문자열이 됐다.
+			// 저장명이 시각에 의존하지 않으므로 이 문제 자체가 성립하지 않는다.
+			Set<String> names = new HashSet<>();
+			for (int i = 0; i < 100; i++) {
+				names.add(EgovStoredFileNames.generateWithoutExtension());
+			}
+			assertEquals(100, names.size());
+		}
+
+		@Test
+		@DisplayName("원본 파일명이 저장명에 남지 않는다 — 경로·특수문자가 섞여 들어갈 여지가 없다")
+		void 원본명_비반영() {
+			String stored = EgovStoredFileNames.generate("../../etc/passwd.png");
+
+			assertFalse(stored.contains(".."));
+			assertFalse(stored.contains("/"));
+			assertFalse(stored.contains("passwd"));
+			assertTrue(stored.endsWith(".png"));
+		}
+	}
+
+	@Nested
+	@DisplayName("저장명 생성")
+	class Generate {
+
+		@Test
+		@DisplayName("하이픈 없는 32자 + 확장자")
+		void 기본_형식() {
+			String stored = EgovStoredFileNames.generate("보고서.pdf");
+
+			assertTrue(stored.matches("[0-9a-f]{32}\\.pdf"), "실제 값: " + stored);
+		}
+
+		@Test
+		@DisplayName("확장자가 없으면 붙이지 않는다")
+		void 확장자_없는_원본() {
+			String stored = EgovStoredFileNames.generate("README");
+
+			assertTrue(stored.matches("[0-9a-f]{32}"), "실제 값: " + stored);
+		}
+
+		@Test
+		@DisplayName("null·빈 문자열도 예외 없이 처리한다")
+		void null_허용() {
+			assertTrue(EgovStoredFileNames.generate(null).matches("[0-9a-f]{32}"));
+			assertTrue(EgovStoredFileNames.generate("").matches("[0-9a-f]{32}"));
+		}
+
+		@Test
+		@DisplayName("확장자 없는 형태를 따로 만들 수 있다")
+		void 확장자_제외_생성() {
+			assertTrue(EgovStoredFileNames.generateWithoutExtension().matches("[0-9a-f]{32}"));
+		}
+
+		@Test
+		@DisplayName("UUID 를 주입하면 그 값이 쓰인다 — UUIDv7 로 시간 정렬이 가능하다")
+		void uuid_주입() {
+			UUID uuid = UUID.fromString("018f1a2b-3c4d-7e5f-8a9b-0c1d2e3f4a5b");
+
+			assertEquals("018f1a2b3c4d7e5f8a9b0c1d2e3f4a5b.pdf",
+					EgovStoredFileNames.generate("a.pdf", uuid));
+		}
+
+		@Test
+		@DisplayName("UUID 가 null 이면 즉시 실패한다")
+		void uuid_null_거부() {
+			assertThrows(NullPointerException.class,
+					() -> EgovStoredFileNames.generate("a.pdf", null));
+		}
+	}
+
+	@Nested
+	@DisplayName("확장자 정규화")
+	class ExtensionNormalization {
+
+		@Test
+		@DisplayName("대문자는 소문자로")
+		void 소문자화() {
+			assertEquals("pdf", EgovStoredFileNames.extensionOf("보고서.PDF"));
+			assertTrue(EgovStoredFileNames.generate("a.PNG").endsWith(".png"));
+		}
+
+		@Test
+		@DisplayName("경로가 붙어 있어도 확장자만 뽑는다")
+		void 경로_제거() {
+			assertEquals("png", EgovStoredFileNames.extensionOf("C:\\tmp\\a.png"));
+			assertEquals("png", EgovStoredFileNames.extensionOf("/home/me/a.png"));
+		}
+
+		@Test
+		@DisplayName("영숫자가 아닌 문자가 섞이면 확장자로 인정하지 않는다")
+		void 비영숫자_거부() {
+			assertEquals("", EgovStoredFileNames.extensionOf("a.p g"));
+			assertEquals("", EgovStoredFileNames.extensionOf("a.pn" + NUL + "g"));
+			assertEquals("", EgovStoredFileNames.extensionOf("a.p\"g"));
+		}
+
+		@Test
+		@DisplayName("비정상적으로 긴 확장자는 인정하지 않는다")
+		void 과도한_길이_거부() {
+			String longExt = "a".repeat(21);
+
+			assertEquals("", EgovStoredFileNames.extensionOf("file." + longExt));
+			assertEquals("a".repeat(20), EgovStoredFileNames.extensionOf("file." + "a".repeat(20)));
+		}
+
+		@Test
+		@DisplayName("이중 확장자는 마지막만 쓴다")
+		void 이중_확장자() {
+			assertEquals("png", EgovStoredFileNames.extensionOf("shell.jsp.png"));
+		}
+
+		@Test
+		@DisplayName("점으로 끝나면 확장자가 없다")
+		void 점으로_끝남() {
+			assertEquals("", EgovStoredFileNames.extensionOf("noext."));
+		}
+
+		@Test
+		@DisplayName("한글 확장자는 인정하지 않는다 — 저장명은 ASCII 로 유지한다")
+		void 한글_확장자_거부() {
+			assertEquals("", EgovStoredFileNames.extensionOf("파일.한글"));
+		}
+	}
+}


### PR DESCRIPTION
> **[공통컴포넌트 공통 기능 개선 → 실행환경 이관]**
>
> 공통컴포넌트에 있던 공통 기능을 개선해 실행환경으로 올리는 항목입니다.
> 실행환경에 올라가면 공통컴포넌트를 포함한 모든 사업에서 같은 구현을 쓸 수 있습니다.
>
> 공통컴포넌트 원본
> - `egovframework.com.utl.fcc.service.EgovFormBasedFileUtil`

## 수정 사유 Reason for modification

- [ ] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [X] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

### 배경

업로드 파일을 **원본 이름 그대로 저장하면** 경로 조작·덮어쓰기·한글 파일명 문제가 한꺼번에
따라옵니다. 그래서 저장명을 따로 만들어야 하는데, 실행환경에 그 수단이 없어 사업마다 자체
구현을 반복합니다.

그 재구현에서 반복되는 결함이 있습니다. 공통컴포넌트 `EgovFileMngUtil.getTimeStamp` 가
대표적인데, **12시간제 `hh`** 를 써서 오전 10시와 오후 10시가 같은 이름을 만들고,
**밀리초 해상도 시각만으로** 이름을 지어 동시 업로드 시 덮어써지며, **시각 기반이라 다음
파일명이 예측 가능**합니다.

### 추가한 것

**`upload/EgovStoredFileNames`** — UUID 기반 저장명 생성

| API | 동작 |
|---|---|
| `generate(원본이름)` | 앞부분을 UUID 로 대체하고 **확장자는 보존** |
| `generate(원본이름, UUID)` | 테스트·재현을 위해 UUID 주입 |
| `generateWithoutExtension()` | 확장자가 필요 없는 자리 |
| `extensionOf(원본이름)` | 정규화된 확장자만 추출 |

### 설계 메모

- **확장자를 기본 보존합니다.** 버리면 운영자가 파일을 알아볼 수 없고 다운로드 시 MIME 추론도
  어렵습니다. 확장자는 `Locale.ROOT` 로 고정해 소문자화하므로 **터키어 로케일(Locale) 등에서도
  동일하게 동작**합니다
- **원본 이름은 저장하지 않습니다.** 원래 이름으로 내려주려면 DB 등에 함께 보관했다가
  `Content-Disposition` 에 실어야 하며, 그 헤더 값 생성은 `EgovContentDispositions` 가 담당합니다
- 저장 경로까지 확정하려면 `EgovFiles.resolveSecurely(baseDir, 저장명)` 를 함께 씁니다

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

`EgovStoredFileNamesTest` **17건** + 보안 회귀 `EgovStoredFileNamesSecurityTest` **4건**, 합계 **21건 신규**. `fdl.filehandling` 모듈 전건 통과.

| 환경 | 모듈 실행 건수 | 결과 |
|---|---:|---|
| **Windows** (ko_KR) | 97 | `Tests run: 97, Failures: 0, Errors: 0, Skipped: 2` |
| **Linux** (Ubuntu 22.04 / OpenJDK 17 / ext4, C.UTF-8) | 97 | `Tests run: 97, Failures: 0, Errors: 0, Skipped: 5` |

`Skipped` 는 `EgovFiles`(#388 로 머지됨)의 플랫폼 조건부 테스트입니다.

| 구분 | 건수 | 내용 |
|---|---:|---|
| 저장명 생성 | 6 | 하이픈 없는 32자 + 확장자 · 확장자 없으면 미부착 · `null`/빈 문자열 무예외 · 확장자 없는 형태 · **UUID 주입**(UUIDv7 로 시간 정렬 가능) · UUID `null` 즉시 실패 |
| 확장자 정규화 | 7 | 대문자→소문자 · 경로가 붙어도 확장자만 추출 · 영숫자 아닌 문자 거부 · 비정상적으로 긴 확장자 거부 · 이중 확장자는 마지막만 · 점으로 끝나면 확장자 없음 · **한글 확장자 거부**(저장명은 ASCII 유지) |
| 원본 결함 회귀 | 4 | 연속 생성 시 이름 미충돌(원본은 같은 밀리초면 덮어쓰기) · **이름에 시각이 드러나지 않음**(원본 `yyyyMMddhhmmssSSS` 는 추측 가능) · **12시간제 충돌이 구조적으로 불가능** · 원본 파일명이 저장명에 남지 않음 |

`EgovStoredFileNamesSecurityTest` 4건 — 저장명은 결국 파일시스템 경로와 다운로드 헤더에 실리므로,
**어떤 원본명에서도 저장명이 UUID 32자 + 소문자 영숫자 확장자 형식을 벗어나지 않음**을 고정합니다:
경로 혼입·인용부호·세미콜론·널 바이트·대체 데이터 스트림(`::$DATA`)·전각 점·비정상 길이 확장자를 한 표로
검사 · 확장자로 인정되지 않는 입력은 확장자 없이 저장 · 널 바이트 앞의 가짜 확장자 무시 · 저장명에 경로 구분자 없음.

**수동 확인**: 한글 파일명·확장자 정규화가 로케일과 파일시스템에 얽히므로 Linux(ext4, `C.UTF-8`)
에서 교차 검증했습니다.

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

해당 없음 — 라이브러리 클래스 추가입니다.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

해당 없음 — 위 JUnit 테스트 결과로 갈음합니다.

---

<sub>base: `eGovFramework:main` @ `cb4b449` (2026-09-09 fetch 기준) · 단일 커밋</sub>
