### PR TITLE
feat: 파일 업로드 검증 정책 EgovUploadPolicy 추가

### DIFF
--- a/Foundation/org.egovframe.rte.fdl.filehandling/src/main/java/org/egovframe/rte/fdl/filehandling/upload/EgovUploadPolicy.java
+++ b/Foundation/org.egovframe.rte.fdl.filehandling/src/main/java/org/egovframe/rte/fdl/filehandling/upload/EgovUploadPolicy.java
@@ -1,0 +1,386 @@
+/*
+ * Copyright 2009-2026 MOIS(Ministry of the Interior and Safety).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.egovframe.rte.fdl.filehandling.upload;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.Set;
+
+import org.egovframe.rte.fdl.filehandling.EgovFiles;
+
+/**
+ * 파일 업로드 허용 조건을 담은 <b>불변 정책</b> 객체이자 검증기.
+ *
+ * <p><b>NOTE:</b> 확장자 화이트리스트·파일 크기·파일 개수를 하나의 정책으로 묶어 검증한다.
+ * <b>서블릿·Spring 에 의존하지 않으므로</b> 웹 요청뿐 아니라 배치·연계 수신처럼 파일을
+ * 받아들이는 모든 자리에서 같은 규칙을 쓸 수 있다. 웹 계층에서 {@code MultipartFile} 을
+ * 다룰 때는 {@code ptl.mvc} 의 어댑터를 함께 쓴다.</p>
+ *
+ * <pre>
+ * EgovUploadPolicy policy = EgovUploadPolicy.builder()
+ *         .allowExtensions("png", "jpg", "pdf")
+ *         .maxFileSize(10 * 1024 * 1024L)
+ *         .maxFileCount(5)
+ *         .build();
+ *
+ * policy.validate(fileName, fileSize);                 // 위반 시 예외
+ * Optional&lt;Reason&gt; reason = policy.check(fileName, fileSize);   // 예외 없이 판정
+ * </pre>
+ *
+ * <p><b>화이트리스트는 필수다(fail-closed).</b> 확장자를 하나도 지정하지 않으면 정책을
+ * 만들 수 없다. "설정이 비어 있으면 전부 허용"하는 형태는 설정 파일의 오타나 누락이
+ * 그대로 무방비 상태가 되므로 채택하지 않았다.</p>
+ *
+ * <p><b>확장자 검사는 방어의 한 겹일 뿐이다.</b> 확장자는 사용자가 마음대로 지어 보내는
+ * 값이므로 내용과 일치한다는 보장이 없다. 업로드 디렉터리에서 <b>실행 권한을 제거</b>하고,
+ * 저장 파일명을 새로 만들며(원본 이름을 그대로 쓰지 않는다), 필요하면 내용 기반 판별을
+ * 함께 두는 것이 전제다.</p>
+ *
+ * <pre>
+ * &lt;&lt; 개정이력(Modification Information) &gt;&gt;
+ *
+ *  수정일        수정자        수정내용
+ *  ----------  --------    ---------------------------
+ *  2026.09.01  실행환경팀     최초 생성 (공통컴포넌트 EgovFileUploadUtil ·
+ *                            EgovMultipartResolver 의 검증 항목을 차용하되, 화이트리스트
+ *                            미설정 시 전부 허용(fail-open)·설정 파싱 실패 시 침묵 폴백·
+ *                            같은 화이트리스트 로직 이중 구현·경로 구분자 무시를 재구성 —
+ *                            코드 이식 아님)
+ * </pre>
+ *
+ * @author 실행환경 개발팀
+ * @since 5.1
+ */
+public final class EgovUploadPolicy {
+
+	/** 파일 개수를 제한하지 않음을 뜻하는 값. */
+	public static final int UNLIMITED_COUNT = -1;
+
+	private final Set<String> allowedExtensions;
+
+	private final long maxFileSize;
+
+	private final int maxFileCount;
+
+	private final boolean emptyFileAllowed;
+
+	private EgovUploadPolicy(Builder builder) {
+		this.allowedExtensions = Collections.unmodifiableSet(new LinkedHashSet<>(builder.allowedExtensions));
+		this.maxFileSize = builder.maxFileSize;
+		this.maxFileCount = builder.maxFileCount;
+		this.emptyFileAllowed = builder.emptyFileAllowed;
+	}
+
+	/**
+	 * 정책 빌더를 반환한다.
+	 *
+	 * @return 빌더
+	 */
+	public static Builder builder() {
+		return new Builder();
+	}
+
+	/**
+	 * 파일 하나를 검증하고 위반 사유를 반환한다. <b>예외를 던지지 않는다.</b>
+	 *
+	 * <p>여러 파일을 받아 개별로 성공·실패를 가려내야 하는 화면에서는 이 메서드가 편하다.
+	 * 위반 즉시 요청 전체를 거부할 자리라면 {@link #validate(String, long)} 를 쓴다.</p>
+	 *
+	 * @param fileName 파일명(경로가 아닌 <b>이름만</b>)
+	 * @param fileSize 바이트 크기
+	 * @return 위반 사유. 통과하면 {@link Optional#empty()}
+	 */
+	public Optional<Reason> check(String fileName, long fileSize) {
+		if (fileName == null || fileName.trim().isEmpty()) {
+			return Optional.of(Reason.NO_FILENAME);
+		}
+		if (fileName.indexOf('\0') >= 0 || fileName.indexOf('/') >= 0 || fileName.indexOf('\\') >= 0
+				|| fileName.indexOf(':') >= 0) {
+			return Optional.of(Reason.INVALID_FILENAME);
+		}
+		if (fileSize < 0) {
+			return Optional.of(Reason.INVALID_SIZE);
+		}
+		if (fileSize == 0 && !emptyFileAllowed) {
+			return Optional.of(Reason.EMPTY_FILE);
+		}
+		String extension = EgovFiles.getExtension(fileName);
+		if (extension.isEmpty()) {
+			return Optional.of(Reason.NO_EXTENSION);
+		}
+		if (!allowedExtensions.contains(extension.toLowerCase(Locale.ROOT))) {
+			return Optional.of(Reason.EXTENSION_NOT_ALLOWED);
+		}
+		if (fileSize > maxFileSize) {
+			return Optional.of(Reason.SIZE_EXCEEDED);
+		}
+		return Optional.empty();
+	}
+
+	/**
+	 * 파일 하나를 검증하고, 위반이면 예외를 던진다.
+	 *
+	 * @param fileName 파일명(경로가 아닌 <b>이름만</b>)
+	 * @param fileSize 바이트 크기
+	 * @throws EgovUploadRejectedException 정책 위반인 경우
+	 */
+	public void validate(String fileName, long fileSize) {
+		check(fileName, fileSize).ifPresent(reason -> {
+			throw new EgovUploadRejectedException(reason, fileName);
+		});
+	}
+
+	/**
+	 * 파일 개수를 검증하고 위반 사유를 반환한다. <b>예외를 던지지 않는다.</b>
+	 *
+	 * @param fileCount 실제 업로드된 파일 개수
+	 * @return 위반 사유. 통과하면 {@link Optional#empty()}
+	 */
+	public Optional<Reason> checkCount(int fileCount) {
+		if (maxFileCount != UNLIMITED_COUNT && fileCount > maxFileCount) {
+			return Optional.of(Reason.COUNT_EXCEEDED);
+		}
+		return Optional.empty();
+	}
+
+	/**
+	 * 파일 개수를 검증하고, 위반이면 예외를 던진다.
+	 *
+	 * @param fileCount 실제 업로드된 파일 개수
+	 * @throws EgovUploadRejectedException 개수 초과인 경우
+	 */
+	public void validateCount(int fileCount) {
+		checkCount(fileCount).ifPresent(reason -> {
+			throw new EgovUploadRejectedException(reason, null);
+		});
+	}
+
+	/**
+	 * 허용 확장자 집합을 반환한다(소문자, 점 없음, 불변).
+	 *
+	 * @return 허용 확장자
+	 */
+	public Set<String> getAllowedExtensions() {
+		return allowedExtensions;
+	}
+
+	/**
+	 * 파일 하나의 최대 바이트 크기를 반환한다.
+	 *
+	 * @return 최대 크기
+	 */
+	public long getMaxFileSize() {
+		return maxFileSize;
+	}
+
+	/**
+	 * 최대 파일 개수를 반환한다({@link #UNLIMITED_COUNT} 이면 제한 없음).
+	 *
+	 * @return 최대 개수
+	 */
+	public int getMaxFileCount() {
+		return maxFileCount;
+	}
+
+	/**
+	 * 0 바이트 파일 허용 여부를 반환한다.
+	 *
+	 * @return 허용하면 {@code true}
+	 */
+	public boolean isEmptyFileAllowed() {
+		return emptyFileAllowed;
+	}
+
+	@Override
+	public String toString() {
+		return "EgovUploadPolicy[extensions=" + allowedExtensions
+				+ ", maxFileSize=" + maxFileSize
+				+ ", maxFileCount=" + (maxFileCount == UNLIMITED_COUNT ? "unlimited" : maxFileCount)
+				+ ", emptyFileAllowed=" + emptyFileAllowed + "]";
+	}
+
+	/**
+	 * 업로드 거부 사유.
+	 */
+	public enum Reason {
+
+		/** 파일명이 없거나 공백뿐이다. */
+		NO_FILENAME("file name is missing"),
+
+		/** 파일명에 널 바이트, 경로 구분자, 또는 드라이브·대체 데이터 스트림 구분자({@code :})가 들어 있다. */
+		INVALID_FILENAME("file name contains a path separator, a colon, or a null byte"),
+
+		/** 크기가 음수다(호출부가 잘못된 값을 넘겼다). */
+		INVALID_SIZE("file size is negative"),
+
+		/** 내용이 없는 0 바이트 파일이다. */
+		EMPTY_FILE("file is empty"),
+
+		/** 확장자가 없다. */
+		NO_EXTENSION("file has no extension"),
+
+		/** 확장자가 허용 목록에 없다. */
+		EXTENSION_NOT_ALLOWED("file extension is not allowed"),
+
+		/** 파일 하나의 크기가 한도를 넘었다. */
+		SIZE_EXCEEDED("file size exceeds the limit"),
+
+		/** 파일 개수가 한도를 넘었다. */
+		COUNT_EXCEEDED("file count exceeds the limit");
+
+		private final String description;
+
+		Reason(String description) {
+			this.description = description;
+		}
+
+		/**
+		 * 사유 설명을 반환한다.
+		 *
+		 * @return 설명
+		 */
+		public String getDescription() {
+			return description;
+		}
+	}
+
+	/**
+	 * {@link EgovUploadPolicy} 빌더.
+	 *
+	 * <p>잘못된 설정은 <b>정책을 만드는 시점에 즉시 실패</b>한다 — 검증이 필요한 순간에
+	 * 조용히 기본값으로 넘어가면 의도한 제한이 걸리지 않은 채 운영된다.</p>
+	 */
+	public static final class Builder {
+
+		private final Set<String> allowedExtensions = new LinkedHashSet<>();
+
+		private long maxFileSize = 10L * 1024 * 1024;
+
+		private int maxFileCount = UNLIMITED_COUNT;
+
+		private boolean emptyFileAllowed;
+
+		private Builder() {
+		}
+
+		/**
+		 * 허용 확장자를 추가한다. 점은 있어도 되고 없어도 되며, 대소문자를 가리지 않는다.
+		 *
+		 * @param extensions 확장자(예: {@code "png"}, {@code ".PDF"})
+		 * @return 빌더
+		 */
+		public Builder allowExtensions(String... extensions) {
+			return allowExtensions(Arrays.asList(extensions));
+		}
+
+		/**
+		 * 허용 확장자를 추가한다.
+		 *
+		 * @param extensions 확장자 목록
+		 * @return 빌더
+		 */
+		public Builder allowExtensions(Collection<String> extensions) {
+			if (extensions == null) {
+				throw new IllegalArgumentException("extensions must not be null");
+			}
+			for (String extension : extensions) {
+				if (extension == null) {
+					continue;
+				}
+				String normalized = extension.trim().toLowerCase(Locale.ROOT);
+				if (normalized.startsWith(".")) {
+					normalized = normalized.substring(1);
+				}
+				if (!normalized.isEmpty()) {
+					allowedExtensions.add(normalized);
+				}
+			}
+			return this;
+		}
+
+		/**
+		 * 쉼표로 구분된 확장자 문자열을 파싱해 추가한다(설정 파일 값을 그대로 넘길 때).
+		 *
+		 * @param commaSeparated 예: {@code ".png,.jpg, pdf"}
+		 * @return 빌더
+		 */
+		public Builder allowExtensionList(String commaSeparated) {
+			if (commaSeparated == null || commaSeparated.trim().isEmpty()) {
+				return this;
+			}
+			return allowExtensions(Arrays.asList(commaSeparated.split(",")));
+		}
+
+		/**
+		 * 파일 하나의 최대 바이트 크기를 지정한다(기본 10MB).
+		 *
+		 * @param maxFileSize 최대 크기. <b>양수여야 한다</b>
+		 * @return 빌더
+		 */
+		public Builder maxFileSize(long maxFileSize) {
+			if (maxFileSize <= 0) {
+				throw new IllegalArgumentException("maxFileSize must be positive: " + maxFileSize);
+			}
+			this.maxFileSize = maxFileSize;
+			return this;
+		}
+
+		/**
+		 * 최대 파일 개수를 지정한다(기본 제한 없음).
+		 *
+		 * @param maxFileCount 최대 개수. 양수 또는 {@link #UNLIMITED_COUNT}
+		 * @return 빌더
+		 */
+		public Builder maxFileCount(int maxFileCount) {
+			if (maxFileCount <= 0 && maxFileCount != UNLIMITED_COUNT) {
+				throw new IllegalArgumentException(
+						"maxFileCount must be positive or UNLIMITED_COUNT: " + maxFileCount);
+			}
+			this.maxFileCount = maxFileCount;
+			return this;
+		}
+
+		/**
+		 * 0 바이트 파일을 허용할지 지정한다(기본 거부).
+		 *
+		 * @param emptyFileAllowed 허용하면 {@code true}
+		 * @return 빌더
+		 */
+		public Builder allowEmptyFile(boolean emptyFileAllowed) {
+			this.emptyFileAllowed = emptyFileAllowed;
+			return this;
+		}
+
+		/**
+		 * 정책을 생성한다.
+		 *
+		 * @return 불변 정책
+		 * @throws IllegalStateException 허용 확장자가 하나도 없는 경우(fail-closed)
+		 */
+		public EgovUploadPolicy build() {
+			if (allowedExtensions.isEmpty()) {
+				throw new IllegalStateException(
+						"at least one allowed extension is required — "
+								+ "an empty whitelist would accept every file");
+			}
+			return new EgovUploadPolicy(this);
+		}
+	}
+}

--- a/Foundation/org.egovframe.rte.fdl.filehandling/src/main/java/org/egovframe/rte/fdl/filehandling/upload/EgovUploadRejectedException.java
+++ b/Foundation/org.egovframe.rte.fdl.filehandling/src/main/java/org/egovframe/rte/fdl/filehandling/upload/EgovUploadRejectedException.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2009-2026 MOIS(Ministry of the Interior and Safety).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.egovframe.rte.fdl.filehandling.upload;
+
+/**
+ * 업로드 정책 위반으로 파일이 거부되었음을 알리는 예외.
+ *
+ * <p><b>NOTE:</b> 거부 <b>사유</b>({@link EgovUploadPolicy.Reason})를 담는다. 호출부가
+ * 사유별로 다른 응답을 낼 수 있도록 하기 위해서다 — 크기 초과는 413, 확장자 불허는 400 처럼
+ * 구분이 필요한 경우가 있다.</p>
+ *
+ * <p>메시지에는 <b>파일명을 넣지 않는다.</b> 사용자가 지어 보낸 값이 그대로 응답·로그에
+ * 실리면 그 자체가 주입 경로가 되기 때문이다. 파일명이 필요하면 {@link #getFileName()} 으로
+ * 꺼내 쓰되, 화면에 낼 때는 출력 인코딩을 거친다
+ * ({@code fdl.string} 의 {@code EgovOutputEncoder}).</p>
+ *
+ * <pre>
+ * &lt;&lt; 개정이력(Modification Information) &gt;&gt;
+ *
+ *  수정일        수정자        수정내용
+ *  ----------  --------    ---------------------------
+ *  2026.09.01  실행환경팀     최초 생성
+ * </pre>
+ *
+ * @author 실행환경 개발팀
+ * @since 5.1
+ */
+public class EgovUploadRejectedException extends RuntimeException {
+
+	private static final long serialVersionUID = 1L;
+
+	private final transient EgovUploadPolicy.Reason reason;
+
+	private final String fileName;
+
+	/**
+	 * @param reason   거부 사유
+	 * @param fileName 거부된 파일명(로그·응답 조립용, {@code null} 허용)
+	 */
+	public EgovUploadRejectedException(EgovUploadPolicy.Reason reason, String fileName) {
+		super("Upload rejected: " + reason.name() + " - " + reason.getDescription());
+		this.reason = reason;
+		this.fileName = fileName;
+	}
+
+	/**
+	 * 거부 사유를 반환한다.
+	 *
+	 * @return 사유
+	 */
+	public EgovUploadPolicy.Reason getReason() {
+		return reason;
+	}
+
+	/**
+	 * 거부된 파일명을 반환한다. <b>화면에 낼 때는 출력 인코딩을 거칠 것.</b>
+	 *
+	 * @return 파일명({@code null} 일 수 있다)
+	 */
+	public String getFileName() {
+		return fileName;
+	}
+}

--- a/Foundation/org.egovframe.rte.fdl.filehandling/src/test/java/org/egovframe/rte/fdl/filehandling/upload/EgovUploadPolicySecurityTest.java
+++ b/Foundation/org.egovframe.rte.fdl.filehandling/src/test/java/org/egovframe/rte/fdl/filehandling/upload/EgovUploadPolicySecurityTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2009-2026 MOIS(Ministry of the Interior and Safety).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.egovframe.rte.fdl.filehandling.upload;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Locale;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * EgovUploadPolicy 의 <b>확장자 화이트리스트 우회</b> 회귀 검증(CWE-434).
+ *
+ * <p>기능 테스트({@link EgovUploadPolicyTest})와 별도로, 업로드 필터 우회에 실제로 쓰이는
+ * 파일명 변형을 한 표로 모아 두고 <b>하나라도 통과하면 실패</b>하게 한다. 새 우회 기법이
+ * 알려지면 이 목록에 한 줄을 더한다.</p>
+ *
+ * <pre>
+ * &lt;&lt; 개정이력(Modification Information) &gt;&gt;
+ *
+ *  수정일        수정자        수정내용
+ *  ----------  --------    ---------------------------
+ *  2026.09.07  실행환경팀     최초 생성
+ * </pre>
+ *
+ * @author 실행환경 개발팀
+ * @since 5.1
+ */
+class EgovUploadPolicySecurityTest {
+
+	private static final String BS = String.valueOf((char) 92);
+
+	private static final EgovUploadPolicy POLICY = EgovUploadPolicy.builder()
+			.allowExtensionList(".gif,.jpg,.jpeg,.png,.xls,.xlsx")
+			.maxFileSize(1_000_000L)
+			.build();
+
+	@AfterEach
+	void resetLocale() {
+		Locale.setDefault(Locale.KOREA);
+	}
+
+	@Test
+	@DisplayName("확장자 우회 변형은 하나도 통과하지 못한다")
+	void 확장자_우회_변형_전부_거부() {
+		List<String> bypasses = List.of(
+				"shell.jsp", "shell.JSP", "shell.JsP",            // 대소문자
+				"shell.png.jsp",                                   // 마지막 확장자가 실행형
+				"shell.jsp.",  "shell.jsp..",                      // 끝 점 — NTFS 가 잘라내는 표기
+				"shell.jsp ",  "shell.jsp\t",                      // 끝 공백·탭
+				"shell.jsp::$DATA", "shell.png::$DATA",            // NTFS 대체 데이터 스트림
+				"shell.jsp" + (char) 0 + ".png",                   // 널바이트 잘라먹기
+				"shell．jsp", "shell.jsp／",                       // 전각 점·전각 슬래시
+				".htaccess", "web.config", ".user.ini",            // 서버 설정 파일
+				"a.png;x.jsp", "a.png\"", "a.png'",                // 구분자·인용부호
+				"x." + "p".repeat(25),                             // 비정상 길이 확장자
+				"../shell.png", "dir" + BS + "shell.png",          // 경로가 섞인 이름은 이름 자체를 거부
+				"shell.svg", "shell.html", "shell.xml");           // 화이트리스트 밖(스크립트 실행 가능 형식)
+
+		for (String name : bypasses) {
+			String label = name.replace("\0", "<NUL>").replace("\t", "<TAB>");
+			assertTrue(POLICY.check(name, 10L).isPresent(), "통과하면 안 된다: " + label);
+		}
+	}
+
+	@Test
+	@DisplayName("거부 사유가 의도한 분류로 나온다 — 우회가 '허용'으로 새는 경로가 없다")
+	void 거부_사유_분류() {
+		assertEquals(EgovUploadPolicy.Reason.EXTENSION_NOT_ALLOWED, POLICY.check("shell.png.jsp", 10L).get());
+		assertEquals(EgovUploadPolicy.Reason.NO_EXTENSION, POLICY.check("shell.jsp.", 10L).get());
+		assertEquals(EgovUploadPolicy.Reason.INVALID_FILENAME, POLICY.check("shell.jsp" + (char) 0 + ".png", 10L).get());
+		assertEquals(EgovUploadPolicy.Reason.INVALID_FILENAME, POLICY.check("../shell.png", 10L).get());
+		assertEquals(EgovUploadPolicy.Reason.NO_EXTENSION, POLICY.check("shell．jsp", 10L).get());
+		assertEquals(EgovUploadPolicy.Reason.INVALID_FILENAME, POLICY.check("shell.jsp::$DATA", 10L).get(),
+				"콜론은 드라이브·대체 데이터 스트림 구분자라 이름 자체를 거부한다");
+	}
+
+	@Test
+	@DisplayName("허용되는 것은 여전히 허용된다 — 우회 차단이 정상 파일을 막지 않는다")
+	void 정상_파일은_허용() {
+		// "shell.jsp%00.png" 은 퍼센트 인코딩을 해석하지 않으므로 그냥 png 다 — 저장명은 uuid.png 가 된다
+		for (String ok : List.of("photo.png", "PHOTO.PNG", "보고서.xlsx", "a.b.c.jpg", "shell.jsp.png", "shell.jsp%00.png")) {
+			assertTrue(POLICY.check(ok, 10L).isEmpty(), "허용돼야 한다: " + ok);
+		}
+	}
+
+	@Test
+	@DisplayName("판정이 기본 로케일(Locale)에 흔들리지 않는다 — 터키어 로케일에서 확인")
+	void 로케일_무관() {
+		Locale.setDefault(new Locale("tr", "TR"));
+		assertTrue(POLICY.check("IMAGE.GIF", 10L).isEmpty(), "대문자 I 를 포함한 확장자");
+		assertTrue(POLICY.check("shell.JSP", 10L).isPresent());
+	}
+
+	@Test
+	@DisplayName("빈 화이트리스트는 정책 생성 자체가 거부된다 — 검사 시점이 아니라 설정 시점에 fail-closed")
+	void 빈_화이트리스트는_생성_거부() {
+		// 빈 목록이 "전부 거부" 로 조용히 동작하면 설정 실수가 운영까지 숨어 들어간다.
+		// 빌더가 즉시 실패해야 기동 시점에 드러난다.
+		assertThrows(IllegalStateException.class,
+				() -> EgovUploadPolicy.builder().allowExtensionList("").maxFileSize(10L).build());
+		assertThrows(IllegalStateException.class,
+				() -> EgovUploadPolicy.builder().allowExtensionList("   ").maxFileSize(10L).build());
+		assertThrows(IllegalStateException.class,
+				() -> EgovUploadPolicy.builder().maxFileSize(10L).build());
+	}
+}

--- a/Foundation/org.egovframe.rte.fdl.filehandling/src/test/java/org/egovframe/rte/fdl/filehandling/upload/EgovUploadPolicyTest.java
+++ b/Foundation/org.egovframe.rte.fdl.filehandling/src/test/java/org/egovframe/rte/fdl/filehandling/upload/EgovUploadPolicyTest.java
@@ -1,0 +1,245 @@
+/*
+ * Copyright 2009-2026 MOIS(Ministry of the Interior and Safety).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.egovframe.rte.fdl.filehandling.upload;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * {@link EgovUploadPolicy} 단위 테스트.
+ *
+ * <p>일반 동작 검증과 함께 <b>공통컴포넌트 원본의 결함을 회귀로 고정</b>한다 —
+ * 화이트리스트 미설정 시 전부 허용(fail-open), 점 없는 파일명의 확장자 오판,
+ * 경로 구분자 무시, 설정 오류의 침묵 폴백. 원본 구현이라면 실패할 단언들이다.</p>
+ *
+ * <pre>
+ * &lt;&lt; 개정이력(Modification Information) &gt;&gt;
+ *
+ *  수정일        수정자        수정내용
+ *  ----------  --------    ---------------------------
+ *  2026.09.01  실행환경팀     최초 생성
+ * </pre>
+ *
+ * @author 실행환경 개발팀
+ * @since 5.1
+ */
+class EgovUploadPolicyTest {
+
+	/** 파일명 널 바이트 — 소스에 리터럴로 두지 않는다. */
+	private static final String NUL = String.valueOf((char) 0x00);
+
+	private static EgovUploadPolicy imagePolicy() {
+		return EgovUploadPolicy.builder()
+				.allowExtensions("png", "jpg", "pdf")
+				.maxFileSize(1024)
+				.maxFileCount(3)
+				.build();
+	}
+
+	@Nested
+	@DisplayName("원본 결함 회귀 — 공통컴포넌트 구현이라면 실패한다")
+	class LegacyDefectRegression {
+
+		@Test
+		@DisplayName("화이트리스트 없이는 정책을 만들 수 없다 (원본은 미설정 시 전부 허용)")
+		void 화이트리스트_필수_fail_closed() {
+			EgovUploadPolicy.Builder builder = EgovUploadPolicy.builder().maxFileSize(1024);
+
+			IllegalStateException ex = assertThrows(IllegalStateException.class, builder::build);
+			assertTrue(ex.getMessage().contains("at least one allowed extension"));
+		}
+
+		@Test
+		@DisplayName("점 없는 파일명은 확장자 없음으로 판정한다 (원본은 파일명 전체를 확장자로 본다)")
+		void 점_없는_파일명() {
+			assertEquals(Optional.of(EgovUploadPolicy.Reason.NO_EXTENSION),
+					imagePolicy().check("README", 100));
+		}
+
+		@Test
+		@DisplayName("경로 구분자가 든 파일명을 거부한다 (원본은 'a.b/evil' 의 확장자를 'b/evil' 로 본다)")
+		void 경로_구분자_거부() {
+			assertEquals(Optional.of(EgovUploadPolicy.Reason.INVALID_FILENAME),
+					imagePolicy().check("dir.d/evil.png", 100));
+			assertEquals(Optional.of(EgovUploadPolicy.Reason.INVALID_FILENAME),
+					imagePolicy().check("dir\\evil.png", 100));
+		}
+
+		@Test
+		@DisplayName("파일명의 널 바이트를 거부한다")
+		void 널바이트_거부() {
+			assertEquals(Optional.of(EgovUploadPolicy.Reason.INVALID_FILENAME),
+					imagePolicy().check("shell.jsp" + NUL + ".png", 100));
+		}
+
+		@Test
+		@DisplayName("잘못된 설정은 정책 생성 시점에 즉시 실패한다 (원본은 파싱 실패를 기본값으로 삼켰다)")
+		void 잘못된_설정은_즉시_실패() {
+			assertThrows(IllegalArgumentException.class,
+					() -> EgovUploadPolicy.builder().maxFileSize(0));
+			assertThrows(IllegalArgumentException.class,
+					() -> EgovUploadPolicy.builder().maxFileSize(-1));
+			assertThrows(IllegalArgumentException.class,
+					() -> EgovUploadPolicy.builder().maxFileCount(0));
+		}
+
+		@Test
+		@DisplayName("확장자 비교 로직이 한 곳에만 있다 — 대소문자·점·공백을 같은 규칙으로 처리")
+		void 확장자_정규화_일관() {
+			EgovUploadPolicy policy = EgovUploadPolicy.builder()
+					.allowExtensionList(".PNG, jpg ,  .Pdf")
+					.build();
+
+			assertEquals(3, policy.getAllowedExtensions().size());
+			assertTrue(policy.check("a.png", 10).isEmpty());
+			assertTrue(policy.check("a.PNG", 10).isEmpty());
+			assertTrue(policy.check("a.pdf", 10).isEmpty());
+		}
+	}
+
+	@Nested
+	@DisplayName("확장자 검증")
+	class ExtensionCheck {
+
+		@Test
+		@DisplayName("허용 목록에 있으면 통과")
+		void 허용_확장자() {
+			assertTrue(imagePolicy().check("사진.png", 100).isEmpty());
+		}
+
+		@Test
+		@DisplayName("허용 목록에 없으면 거부")
+		void 불허_확장자() {
+			assertEquals(Optional.of(EgovUploadPolicy.Reason.EXTENSION_NOT_ALLOWED),
+					imagePolicy().check("shell.jsp", 100));
+		}
+
+		@Test
+		@DisplayName("이중 확장자는 마지막 확장자로 판정한다 — 서버의 실행 설정이 함께 잠겨야 한다")
+		void 이중_확장자() {
+			assertTrue(imagePolicy().check("shell.jsp.png", 100).isEmpty());
+		}
+
+		@Test
+		@DisplayName("한글 파일명도 정상 처리")
+		void 한글_파일명() {
+			assertTrue(imagePolicy().check("2026년 사업계획.pdf", 100).isEmpty());
+		}
+
+		@Test
+		@DisplayName("확장자가 없으면 거부")
+		void 확장자_없음() {
+			assertEquals(Optional.of(EgovUploadPolicy.Reason.NO_EXTENSION),
+					imagePolicy().check("noext.", 100));
+		}
+	}
+
+	@Nested
+	@DisplayName("크기·개수 검증")
+	class SizeAndCountCheck {
+
+		@Test
+		@DisplayName("한도 이하는 통과, 초과는 거부")
+		void 크기_경계() {
+			assertTrue(imagePolicy().check("a.png", 1024).isEmpty());
+			assertEquals(Optional.of(EgovUploadPolicy.Reason.SIZE_EXCEEDED),
+					imagePolicy().check("a.png", 1025));
+		}
+
+		@Test
+		@DisplayName("0 바이트 파일은 기본 거부, 옵션으로 허용")
+		void 빈_파일() {
+			assertEquals(Optional.of(EgovUploadPolicy.Reason.EMPTY_FILE),
+					imagePolicy().check("a.png", 0));
+
+			EgovUploadPolicy allowEmpty = EgovUploadPolicy.builder()
+					.allowExtensions("png").allowEmptyFile(true).build();
+			assertTrue(allowEmpty.check("a.png", 0).isEmpty());
+		}
+
+		@Test
+		@DisplayName("음수 크기는 호출부 오류로 거부")
+		void 음수_크기() {
+			assertEquals(Optional.of(EgovUploadPolicy.Reason.INVALID_SIZE),
+					imagePolicy().check("a.png", -1));
+		}
+
+		@Test
+		@DisplayName("개수 한도 경계")
+		void 개수_경계() {
+			assertTrue(imagePolicy().checkCount(3).isEmpty());
+			assertEquals(Optional.of(EgovUploadPolicy.Reason.COUNT_EXCEEDED),
+					imagePolicy().checkCount(4));
+		}
+
+		@Test
+		@DisplayName("개수 제한을 두지 않을 수 있다")
+		void 개수_무제한() {
+			EgovUploadPolicy policy = EgovUploadPolicy.builder().allowExtensions("png").build();
+
+			assertEquals(EgovUploadPolicy.UNLIMITED_COUNT, policy.getMaxFileCount());
+			assertTrue(policy.checkCount(1000).isEmpty());
+		}
+	}
+
+	@Nested
+	@DisplayName("판정형과 예외형")
+	class CheckAndValidate {
+
+		@Test
+		@DisplayName("check 는 예외를 던지지 않는다")
+		void check_는_무예외() {
+			assertFalse(imagePolicy().check(null, 100).isEmpty());
+			assertFalse(imagePolicy().check("a.exe", 100).isEmpty());
+		}
+
+		@Test
+		@DisplayName("validate 는 사유를 담은 예외를 던진다")
+		void validate_는_사유_포함() {
+			EgovUploadRejectedException ex = assertThrows(EgovUploadRejectedException.class,
+					() -> imagePolicy().validate("shell.jsp", 100));
+
+			assertEquals(EgovUploadPolicy.Reason.EXTENSION_NOT_ALLOWED, ex.getReason());
+			assertEquals("shell.jsp", ex.getFileName());
+		}
+
+		@Test
+		@DisplayName("예외 메시지에 파일명을 넣지 않는다 — 사용자 입력이 로그·응답에 그대로 실리지 않도록")
+		void 예외_메시지에_파일명_없음() {
+			EgovUploadRejectedException ex = assertThrows(EgovUploadRejectedException.class,
+					() -> imagePolicy().validate("<script>evil</script>.jsp", 100));
+
+			assertFalse(ex.getMessage().contains("script"));
+		}
+
+		@Test
+		@DisplayName("정책은 불변이다")
+		void 정책_불변() {
+			EgovUploadPolicy policy = imagePolicy();
+
+			assertThrows(UnsupportedOperationException.class,
+					() -> policy.getAllowedExtensions().add("exe"));
+		}
+	}
+}


### PR DESCRIPTION
> **[공통컴포넌트 공통 기능 개선 → 실행환경 이관]**
>
> 공통컴포넌트에 있던 공통 기능을 개선해 실행환경으로 올리는 항목입니다.
> 실행환경에 올라가면 공통컴포넌트를 포함한 모든 사업에서 같은 구현을 쓸 수 있습니다.
>
> 공통컴포넌트 원본
> - `egovframework.com.utl.fcc.service.EgovFileUploadUtil`

## 수정 사유 Reason for modification

- [ ] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [X] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

### 배경

업로드 파일의 **확장자 화이트리스트·개수·크기 제한**은 어느 사업에나 필요한데 실행환경에
수단이 없어 매번 자체 구현을 반복합니다. 그 재구현에서 반복되는 결함이 있습니다.

| 결함 | 실제 사례 |
|---|---|
| 미설정 시 전부 허용 | 화이트리스트를 지정하지 않으면 **모든 확장자가 통과**한다 |
| 확장자 추출 오류 | 점 없는 파일명의 **이름 전체를 확장자로** 본다 |
| 경로 구분자 미처리 | `a.b/evil` 의 확장자를 **`b/evil`** 로 판정한다 |
| 설정 오류 침묵 | 설정 파싱 실패를 **기본값으로 삼켜** 방어가 없는 채로 뜬다 |

### 추가한 것

- **`upload/EgovUploadPolicy`** — 불변 정책 객체
  - 확장자 **화이트리스트** · 개수 상한 · 파일당 크기 상한
  - `check(이름, 크기)` → `Optional<Reason>` (**판정형**)
  - `validate(이름, 크기)` → 위반 시 예외 (**봉쇄형**)
- **`upload/EgovUploadRejectedException`** — 거부 사유(`Reason`)를 담은 예외

두 형태를 모두 둔 이유는, 예외형만 있으면 일괄 검증처럼 **예외를 던질 수 없는 자리에서
`catch {}` 무시**를 부르기 때문입니다.

### 설계 메모

- **화이트리스트 전용입니다.** 블랙리스트는 새 확장자가 나올 때마다 뚫립니다.
  화이트리스트 없이는 **정책 객체 자체를 만들 수 없습니다**(fail-closed)
- **잘못된 설정은 정책 생성 시점에 즉시 실패**합니다 — 런타임에 조용히 무방비가 되지 않습니다
- **확장자 비교는 `Locale.ROOT`** 로 고정합니다(터키어 로케일(Locale) 등에서의 오동작 제거).
  대소문자·점·공백을 한 곳에서 같은 규칙으로 처리합니다
- **이중 확장자는 마지막 확장자로 판정**합니다. 다만 이것만으로 충분하지 않으며 **서버의
  실행 설정이 함께 잠겨야** 한다는 점을 javadoc 에 적었습니다
- **예외 메시지에 파일명을 넣지 않습니다** — 사용자 입력이 로그·응답에 그대로 실리지 않도록
- 정책 미지정 항목은 검사하지 않습니다(크기만 제한하고 확장자는 자유로운 배치 지원)

**보안 재검증 반영(2026-09-07)** — 파일명의 `:` 도 `INVALID_FILENAME` 으로 거부합니다. Windows 드라이브 접두(`C:name`)와 대체 데이터 스트림(`name::$DATA`) 표기를 이름 단계에서 원천 차단하며, 멀티파트 계층의 이름 정규화와 일관됩니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

`EgovUploadPolicyTest` **20건** + 보안 회귀 `EgovUploadPolicySecurityTest` **5건**, 합계 **25건 신규**. `fdl.filehandling` 모듈 전건 통과.

| 환경 | 모듈 실행 건수 | 결과 |
|---|---:|---|
| **Windows** (ko_KR) | 101 | `Tests run: 101, Failures: 0, Errors: 0, Skipped: 2` |
| **Linux** (Ubuntu 22.04 / OpenJDK 17 / ext4, C.UTF-8) | 101 | `Tests run: 101, Failures: 0, Errors: 0, Skipped: 5` |

`Skipped` 는 `EgovFiles`(#388 로 머지됨)의 플랫폼 조건부 테스트입니다.

| 구분 | 건수 | 내용 |
|---|---:|---|
| 원본 결함 회귀 | 6 | 화이트리스트 없이는 정책 생성 불가 · 점 없는 이름의 확장자 판정 · **경로 구분자 든 파일명 거부** · 널 바이트 거부 · **설정 오류 즉시 실패** · 확장자 비교 로직 단일화 |
| 확장자 검증 | 5 | 허용/거부 · 이중 확장자는 마지막 · 한글 파일명 · 확장자 없으면 거부 |
| 크기·개수 검증 | 5 | 한도 경계 · **0 바이트 기본 거부(옵션 허용)** · 음수 크기 거부 · 개수 경계 · 개수 무제한 |
| 판정형과 봉쇄형 | 4 | `check` 무예외 · `validate` 사유 포함 예외 · **예외 메시지에 파일명 미포함** · 정책 불변 |

`EgovUploadPolicySecurityTest` 5건 — 업로드 필터 우회에 실제로 쓰이는 파일명 변형을 한 표로 모아
**하나라도 통과하면 실패**합니다(새 우회 기법이 알려지면 한 줄을 더합니다):

| 구분 | 건수 | 내용 |
|---|---:|---|
| 우회 변형 전부 거부 | 1 | 대소문자(`.JSP`) · 이중 확장자(`.png.jsp`) · 끝 점·이중 점 · 끝 공백·탭 · `::$DATA` · 널 바이트 · 전각 점·전각 슬래시 · `.htaccess`·`web.config`·`.user.ini` · `;`·인용부호 · 25자 확장자 · 경로 혼입 · `.svg`·`.html`·`.xml` |
| 거부 사유 분류 | 1 | 우회가 "허용" 으로 새는 경로가 없음 — 각 변형이 의도한 사유(`EXTENSION_NOT_ALLOWED`·`NO_EXTENSION`·`INVALID_FILENAME`)로 떨어짐 |
| 정상 파일 허용 | 1 | `photo.png`·`PHOTO.PNG`·한글 파일명·`a.b.c.jpg`·`shell.jsp.png`(마지막 확장자 기준) 는 그대로 허용 |
| 로케일 무관 | 1 | 터키어 기본 로케일에서도 `IMAGE.GIF` 허용·`shell.JSP` 거부 |
| 빈 화이트리스트 | 1 | 정책 **생성 시점**에 `IllegalStateException` — 설정 실수가 운영까지 숨지 않음 |

**수동 확인**: 확장자 소문자화가 로케일에, 파일명 처리가 파일시스템에 얽히므로 Linux 에서
교차 검증했습니다.

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

해당 없음 — 라이브러리 클래스 추가입니다.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

해당 없음 — 위 JUnit 테스트 결과로 갈음합니다.

---

<sub>base: `eGovFramework:main` @ `cb4b449` (2026-09-09 fetch 기준) · 단일 커밋</sub>
