### PR TITLE
feat: 압축·해제 지원 EgovArchives 추가 (commons-compress optional)

### DIFF
--- a/Foundation/org.egovframe.rte.fdl.filehandling/pom.xml
+++ b/Foundation/org.egovframe.rte.fdl.filehandling/pom.xml
@@ -28,6 +28,7 @@
         <jakarta.annotation.version>3.0.0</jakarta.annotation.version>
         <commons.io.version>2.18.0</commons.io.version>
         <commons.lang3.version>3.18.0</commons.lang3.version>
+        <commons.compress.version>1.28.0</commons.compress.version>
         <commons.vfs2.version>2.10.0</commons.vfs2.version>
     </properties>
 
@@ -65,6 +66,14 @@
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
             <version>${commons.lang3.version}</version>
+        </dependency>
+        <!-- EgovArchives 의 tar 처리 전용 - optional 이므로 전이되지 않는다.
+             zip 은 JDK 표준(java.util.zip)만 쓰므로 이 의존 없이도 동작한다. -->
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-compress</artifactId>
+            <version>${commons.compress.version}</version>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/Foundation/org.egovframe.rte.fdl.filehandling/src/main/java/org/egovframe/rte/fdl/filehandling/archive/EgovArchives.java
+++ b/Foundation/org.egovframe.rte.fdl.filehandling/src/main/java/org/egovframe/rte/fdl/filehandling/archive/EgovArchives.java
@@ -1,0 +1,419 @@
+/*
+ * Copyright 2009-2026 MOIS(Ministry of the Interior and Safety).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.egovframe.rte.fdl.filehandling.archive;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.UncheckedIOException;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.InvalidPathException;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+import java.util.zip.ZipOutputStream;
+
+import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
+import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
+import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
+
+import org.egovframe.rte.fdl.filehandling.EgovFiles;
+
+/**
+ * 디렉터리 아카이브 생성·해제(zip/tar) — 경로 조작(Zip Slip)과 압축 폭탄을 봉쇄한 표준 구현.
+ *
+ * <p><b>NOTE:</b> 아카이브 해제는 <b>아카이브 안의 문자열이 파일시스템 경로가 되는</b> 지점이라
+ * 경로 조작 공격(Zip Slip, CWE-22)의 표적이 된다. 모든 엔트리는
+ * {@link EgovFiles#resolveSecurely(Path, String)}로 대상 디렉터리 내부임이 확정된 뒤에만
+ * 만들어지며, 탈출·절대 경로·널 바이트 엔트리는 {@link IllegalArgumentException}으로 거부된다.
+ * 엔트리 수·누적 크기는 {@link EgovExtractLimits}로 제한한다(기본 한도 적용).</p>
+ *
+ * <pre>
+ * long entries = EgovArchives.zipDirectory(dataDir, backupDir.resolve("data.zip"));
+ *
+ * EgovArchives.unzip(zipFile, restoreDir);                                  // UTF-8·기본 한도
+ * EgovArchives.unzip(zipFile, restoreDir, Charset.forName("MS949"));        // 구형 윈도우 zip
+ * EgovArchives.untar(tarFile, restoreDir, EgovExtractLimits.unlimited());   // 신뢰 가능한 대용량 백업
+ * </pre>
+ *
+ * <p><b>형식.</b> zip 은 JDK 표준({@code java.util.zip})만 쓰므로 추가 의존이 없다. 엔트리 이름은
+ * 쓰기 시 UTF-8 로 기록하고, 읽기는 UTF-8 기본에 문자셋 오버로드를 제공한다(구형 윈도우·알집이
+ * 만든 zip 은 엔트리 이름이 MS949 인 경우가 많다). tar 는 Apache commons-compress 를 쓰며 이
+ * 모듈에 <b>optional</b> 의존으로 선언되어 있다 — tar 메서드를 쓰는 모듈은 자기 pom 에
+ * {@code org.apache.commons:commons-compress} 를 직접 선언해야 한다(zip 만 쓰면 불필요).
+ * tar 쓰기는 POSIX(pax) 확장 헤더를 켜서 긴 이름·비ASCII 이름을 표준 방식으로 기록한다.</p>
+ *
+ * <p><b>계약.</b> 생성 대상이 빈 디렉터리이면 조용히 빈 결과를 만드는 대신
+ * {@link IllegalArgumentException}으로 정직하게 실패한다. 해제는 기존 파일을 대체하며, 실패
+ * 시점까지 만든 파일은 남는다 — 신뢰 경계를 넘는 아카이브는 임시 디렉터리에 풀어 검증 후
+ * {@link EgovFiles#move}로 옮기는 구성을 권장한다. tar 의 링크·디바이스 엔트리는 거부한다
+ * (링크를 따라 대상 디렉터리 밖에 쓰는 고전적 우회 차단). zip·tar 모두 쓰기 직전에 실경로를
+ * 재확인하므로, 대상 디렉터리에 미리 심긴 심볼릭 링크를 거치는 엔트리도 거부한다.</p>
+ *
+ * <p>공통컴포넌트 {@code EgovFileCmprs}·{@code BackupJob}의 결함을 해소한 재구성이다 —
+ * 원본은 ① Zip Slip 방어가 블랙리스트 문자열 치환({@code filePathBlackList}) 한 줄이고
+ * ② 이름과 달리 압축 생성 기능이 없으며({@code EgovFileCmprs}) ③ 아카이브 엔트리 이름에
+ * <b>서버 절대 경로를 그대로 기록</b>하고({@code BackupJob}) ④ 빈 디렉터리를 만나면 예외 없이
+ * {@code false}를 반환했다. 설계 목적만 차용하고 구현은 전량 재작성했다(코드 이식 아님).</p>
+ *
+ * <pre>
+ * &lt;&lt; 개정이력(Modification Information) &gt;&gt;
+ *
+ *  수정일        수정자        수정내용
+ *  ----------  --------    ---------------------------
+ *  2026.09.01  실행환경팀     최초 생성 (압축·해제 표준 구현 —
+ *                            Zip Slip 방어를 EgovFiles 안전 경로 해석 기반으로 재작성)
+ * </pre>
+ *
+ * @author 실행환경 개발팀
+ * @since 5.1
+ */
+public final class EgovArchives {
+
+	private static final int COPY_BUFFER_SIZE = 64 * 1024;
+
+	private EgovArchives() {
+	}
+
+	// ---------------------------------------------------------------- 생성
+
+	/**
+	 * 디렉터리 하위 전체(빈 하위 디렉터리 포함)를 zip 으로 만든다. 엔트리 이름은 원본 디렉터리
+	 * 기준 <b>상대 경로</b>이며 UTF-8 로 기록한다.
+	 *
+	 * @param sourceDir 아카이브할 디렉터리
+	 * @param zipFile   만들 zip 파일(부모 디렉터리는 자동 생성, 원본 디렉터리 밖이어야 함)
+	 * @return 기록한 엔트리 수
+	 * @throws IllegalArgumentException 원본이 디렉터리가 아니거나 비었거나, zip 파일이 원본 내부인 경우
+	 * @throws UncheckedIOException     입출력 실패(부분 생성된 zip 파일은 삭제 시도)
+	 */
+	public static long zipDirectory(Path sourceDir, Path zipFile) {
+		Path source = requireSourceDirectory(sourceDir, zipFile);
+		List<Path> entries = collectEntries(source);
+		try {
+			createParentDirectories(zipFile);
+			try (ZipOutputStream zos = new ZipOutputStream(Files.newOutputStream(zipFile), StandardCharsets.UTF_8)) {
+				for (Path path : entries) {
+					boolean directory = Files.isDirectory(path);
+					zos.putNextEntry(new ZipEntry(entryName(source, path, directory)));
+					if (!directory) {
+						Files.copy(path, zos);
+					}
+					zos.closeEntry();
+				}
+			}
+			return entries.size();
+		} catch (IOException e) {
+			throw cleanupAndWrap("Failed to create zip archive: " + zipFile, zipFile, e);
+		}
+	}
+
+	/**
+	 * 디렉터리 하위 전체(빈 하위 디렉터리 포함)를 tar 로 만든다. POSIX(pax) 확장 헤더로
+	 * 긴 이름·비ASCII 이름을 기록한다.
+	 *
+	 * <p>commons-compress(optional 의존)가 클래스패스에 있어야 한다.</p>
+	 *
+	 * @param sourceDir 아카이브할 디렉터리
+	 * @param tarFile   만들 tar 파일(부모 디렉터리는 자동 생성, 원본 디렉터리 밖이어야 함)
+	 * @return 기록한 엔트리 수
+	 * @throws IllegalArgumentException 원본이 디렉터리가 아니거나 비었거나, tar 파일이 원본 내부인 경우
+	 * @throws UncheckedIOException     입출력 실패(부분 생성된 tar 파일은 삭제 시도)
+	 */
+	public static long tarDirectory(Path sourceDir, Path tarFile) {
+		Path source = requireSourceDirectory(sourceDir, tarFile);
+		List<Path> entries = collectEntries(source);
+		try {
+			createParentDirectories(tarFile);
+			try (TarArchiveOutputStream tos =
+					new TarArchiveOutputStream(Files.newOutputStream(tarFile), StandardCharsets.UTF_8.name())) {
+				tos.setLongFileMode(TarArchiveOutputStream.LONGFILE_POSIX);
+				tos.setBigNumberMode(TarArchiveOutputStream.BIGNUMBER_POSIX);
+				tos.setAddPaxHeadersForNonAsciiNames(true);
+				for (Path path : entries) {
+					boolean directory = Files.isDirectory(path);
+					TarArchiveEntry entry = new TarArchiveEntry(path, entryName(source, path, directory));
+					tos.putArchiveEntry(entry);
+					if (!directory) {
+						Files.copy(path, tos);
+					}
+					tos.closeArchiveEntry();
+				}
+			}
+			return entries.size();
+		} catch (IOException e) {
+			throw cleanupAndWrap("Failed to create tar archive: " + tarFile, tarFile, e);
+		}
+	}
+
+	// ---------------------------------------------------------------- 해제
+
+	/**
+	 * zip 을 대상 디렉터리에 해제한다(UTF-8 엔트리 이름·기본 한도).
+	 *
+	 * @return 처리한 엔트리 수
+	 * @see #unzip(Path, Path, Charset, EgovExtractLimits)
+	 */
+	public static long unzip(Path zipFile, Path targetDir) {
+		return unzip(zipFile, targetDir, StandardCharsets.UTF_8, EgovExtractLimits.defaults());
+	}
+
+	/**
+	 * 엔트리 이름 문자셋을 지정해 zip 을 해제한다(기본 한도). 구형 윈도우·알집이 만든 zip 은
+	 * {@code Charset.forName("MS949")} 를 지정해야 한글 파일명이 깨지지 않는다.
+	 *
+	 * @return 처리한 엔트리 수
+	 * @see #unzip(Path, Path, Charset, EgovExtractLimits)
+	 */
+	public static long unzip(Path zipFile, Path targetDir, Charset entryNameCharset) {
+		return unzip(zipFile, targetDir, entryNameCharset, EgovExtractLimits.defaults());
+	}
+
+	/**
+	 * zip 을 대상 디렉터리에 해제한다 — 모든 엔트리는 대상 디렉터리 내부로 확정된 뒤에만
+	 * 만들어지고(Zip Slip 봉쇄), 실제 엔트리 수·실제 기록 바이트가 한도를 넘으면 쓰던 파일을 지우고 즉시 중단한다.
+	 * 쓰기 직전에는 실경로를 재확인해, 대상 디렉터리 안에 미리 심긴 심볼릭 링크를 따라 밖에 쓰는 일을 막는다.
+	 * 기존 파일은 대체한다.
+	 *
+	 * @param zipFile          해제할 zip 파일
+	 * @param targetDir        해제 대상 디렉터리(없으면 생성)
+	 * @param entryNameCharset 엔트리 이름 문자셋(쓰기 표준은 UTF-8)
+	 * @param limits           해제 한도
+	 * @return 처리한 엔트리 수(빈 아카이브는 0)
+	 * @throws IllegalArgumentException 탈출·절대 경로 엔트리, 링크를 거치는 경로, 한도 초과, 해석 불가 엔트리 이름
+	 * @throws UncheckedIOException     입출력 실패·zip 형식 오류
+	 */
+	public static long unzip(Path zipFile, Path targetDir, Charset entryNameCharset, EgovExtractLimits limits) {
+		Objects.requireNonNull(zipFile, "zipFile must not be null");
+		Objects.requireNonNull(targetDir, "targetDir must not be null");
+		Objects.requireNonNull(entryNameCharset, "entryNameCharset must not be null");
+		Objects.requireNonNull(limits, "limits must not be null");
+		long entryCount = 0;
+		long totalBytes = 0;
+		try (ZipInputStream zis = new ZipInputStream(Files.newInputStream(zipFile), entryNameCharset)) {
+			Files.createDirectories(targetDir);
+			Path targetDirReal = targetDir.toRealPath();
+			ZipEntry entry;
+			while ((entry = zis.getNextEntry()) != null) {
+				entryCount++;
+				checkEntryCount(entryCount, limits, zipFile);
+				Path target = resolveEntryTarget(targetDir, entry.getName(), zipFile);
+				requireRealPathInside(target, targetDir, targetDirReal, entry.getName(), zipFile);
+				if (entry.isDirectory()) {
+					Files.createDirectories(target);
+				} else {
+					Files.createDirectories(target.getParent());
+					totalBytes = copyLimited(zis, target, totalBytes, limits, zipFile);
+				}
+			}
+		} catch (IOException e) {
+			throw new UncheckedIOException("Failed to extract zip archive: " + zipFile, e);
+		}
+		return entryCount;
+	}
+
+	/**
+	 * tar 를 대상 디렉터리에 해제한다(기본 한도).
+	 *
+	 * @return 처리한 엔트리 수
+	 * @see #untar(Path, Path, EgovExtractLimits)
+	 */
+	public static long untar(Path tarFile, Path targetDir) {
+		return untar(tarFile, targetDir, EgovExtractLimits.defaults());
+	}
+
+	/**
+	 * tar 를 대상 디렉터리에 해제한다 — Zip Slip 봉쇄·한도 적용은 {@code unzip} 과 같고,
+	 * 심볼릭 링크·하드 링크·디바이스 엔트리는 거부한다(링크를 따라 대상 밖에 쓰는 우회 차단).
+	 *
+	 * <p>commons-compress(optional 의존)가 클래스패스에 있어야 한다.</p>
+	 *
+	 * @param tarFile   해제할 tar 파일
+	 * @param targetDir 해제 대상 디렉터리(없으면 생성)
+	 * @param limits    해제 한도
+	 * @return 처리한 엔트리 수(빈 아카이브는 0)
+	 * @throws IllegalArgumentException 탈출·절대 경로 엔트리, 링크·디바이스 엔트리, 링크를 거치는 경로, 한도 초과
+	 * @throws UncheckedIOException     입출력 실패·tar 형식 오류
+	 */
+	public static long untar(Path tarFile, Path targetDir, EgovExtractLimits limits) {
+		Objects.requireNonNull(tarFile, "tarFile must not be null");
+		Objects.requireNonNull(targetDir, "targetDir must not be null");
+		Objects.requireNonNull(limits, "limits must not be null");
+		long entryCount = 0;
+		long totalBytes = 0;
+		try (TarArchiveInputStream tis =
+				new TarArchiveInputStream(Files.newInputStream(tarFile), StandardCharsets.UTF_8.name())) {
+			Files.createDirectories(targetDir);
+			Path targetDirReal = targetDir.toRealPath();
+			TarArchiveEntry entry;
+			while ((entry = tis.getNextEntry()) != null) {
+				entryCount++;
+				checkEntryCount(entryCount, limits, tarFile);
+				if (entry.isSymbolicLink() || entry.isLink()) {
+					throw new IllegalArgumentException(
+							"link entry is not allowed (link extraction blocked): " + entry.getName() + " in " + tarFile);
+				}
+				if (entry.isCharacterDevice() || entry.isBlockDevice() || entry.isFIFO()) {
+					throw new IllegalArgumentException(
+							"device/fifo entry is not allowed: " + entry.getName() + " in " + tarFile);
+				}
+				Path target = resolveEntryTarget(targetDir, entry.getName(), tarFile);
+				requireRealPathInside(target, targetDir, targetDirReal, entry.getName(), tarFile);
+				if (entry.isDirectory()) {
+					Files.createDirectories(target);
+				} else {
+					Files.createDirectories(target.getParent());
+					totalBytes = copyLimited(tis, target, totalBytes, limits, tarFile);
+				}
+			}
+		} catch (IOException e) {
+			throw new UncheckedIOException("Failed to extract tar archive: " + tarFile, e);
+		}
+		return entryCount;
+	}
+
+	// ---------------------------------------------------------------- 내부
+
+	private static Path requireSourceDirectory(Path sourceDir, Path archiveFile) {
+		Objects.requireNonNull(sourceDir, "sourceDir must not be null");
+		Objects.requireNonNull(archiveFile, "archiveFile must not be null");
+		Path source = sourceDir.toAbsolutePath().normalize();
+		if (!Files.isDirectory(source)) {
+			throw new IllegalArgumentException("source is not an existing directory: " + sourceDir);
+		}
+		if (EgovFiles.isContainedIn(archiveFile, source)) {
+			throw new IllegalArgumentException(
+					"archive file must not be inside the source directory: " + archiveFile);
+		}
+		return source;
+	}
+
+	/**
+	 * 아카이브할 엔트리를 수집한다 — 파일과 <b>모든 하위 디렉터리</b>(빈 디렉터리 보존).
+	 * 빈 원본은 조용한 빈 결과 대신 예외로 정직하게 실패한다.
+	 */
+	private static List<Path> collectEntries(Path source) {
+		List<Path> entries;
+		try (Stream<Path> walk = Files.walk(source)) {
+			entries = walk.filter(path -> !path.equals(source)).sorted().collect(Collectors.toList());
+		} catch (IOException e) {
+			throw new UncheckedIOException("Failed to scan source directory: " + source, e);
+		}
+		if (entries.isEmpty()) {
+			throw new IllegalArgumentException("source directory is empty, nothing to archive: " + source);
+		}
+		return entries;
+	}
+
+	/** 원본 디렉터리 기준 상대 경로 엔트리 이름 — 구분자는 {@code /}, 디렉터리는 {@code /} 접미. */
+	private static String entryName(Path source, Path path, boolean directory) {
+		String relative = source.relativize(path).toString().replace('\\', '/');
+		return directory ? relative + "/" : relative;
+	}
+
+	/** 엔트리 이름을 대상 디렉터리 내부로 확정한다 — Zip Slip 봉쇄 지점. */
+	private static Path resolveEntryTarget(Path targetDir, String rawEntryName, Path archive) {
+		String name = rawEntryName.replace('\\', '/');
+		try {
+			return EgovFiles.resolveSecurely(targetDir, name);
+		} catch (InvalidPathException e) {
+			throw new IllegalArgumentException(
+					"archive entry name is not a valid path: " + rawEntryName + " in " + archive, e);
+		}
+	}
+
+	/**
+	 * 쓰기 직전 <b>실경로</b> 재확인 — 어휘적 봉쇄를 통과한 경로라도 대상 디렉터리 안에 미리 심긴 심볼릭 링크를
+	 * 거치면 밖에 쓰게 된다. 이미 존재하는 가장 깊은 구성요소가 링크이거나 그 실경로가 대상 디렉터리 실경로
+	 * 밖이면 거부한다. 아직 없는 구성요소는 이 확인 뒤에 직접 만들므로 링크일 수 없다.
+	 */
+	private static void requireRealPathInside(Path target, Path targetDir, Path targetDirReal,
+			String entryName, Path archive) throws IOException {
+		Path base = targetDir.toAbsolutePath().normalize();
+		Path probe = target;
+		while (probe != null && !probe.equals(base) && !Files.exists(probe, LinkOption.NOFOLLOW_LINKS)) {
+			probe = probe.getParent();
+		}
+		if (probe == null || probe.equals(base)) {
+			return;
+		}
+		if (Files.isSymbolicLink(probe)) {
+			throw new IllegalArgumentException("archive entry path goes through a symbolic link "
+					+ "(link traversal blocked): " + entryName + " in " + archive);
+		}
+		if (!probe.toRealPath().startsWith(targetDirReal)) {
+			throw new IllegalArgumentException("archive entry resolves outside the target directory "
+					+ "(link traversal blocked): " + entryName + " in " + archive);
+		}
+	}
+
+	private static void checkEntryCount(long entryCount, EgovExtractLimits limits, Path archive) {
+		if (entryCount > limits.getMaxEntries()) {
+			throw new IllegalArgumentException("archive exceeds the entry count limit ("
+					+ limits.getMaxEntries() + " entries): " + archive);
+		}
+	}
+
+	/**
+	 * 현재 엔트리 내용을 복사한다 — 헤더의 크기 선언이 아니라 <b>실제 기록 바이트</b>에 한도를 적용한다.
+	 * 한도를 넘으면 쓰던 파일을 지우고 예외를 던진다(거부한 엔트리의 부분 파일을 남기지 않는다).
+	 */
+	private static long copyLimited(InputStream in, Path target, long totalSoFar,
+			EgovExtractLimits limits, Path archive) throws IOException {
+		long total = totalSoFar;
+		byte[] buffer = new byte[COPY_BUFFER_SIZE];
+		try (OutputStream out = Files.newOutputStream(target)) {
+			int read;
+			while ((read = in.read(buffer)) != -1) {
+				total += read;
+				if (total > limits.getMaxTotalBytes()) {
+					throw new IllegalArgumentException("archive exceeds the total extracted size limit ("
+							+ limits.getMaxTotalBytes() + " bytes): " + archive);
+				}
+				out.write(buffer, 0, read);
+			}
+		} catch (IllegalArgumentException limitExceeded) {
+			// 한도 초과로 거부한 엔트리의 부분 파일은 남기지 않는다(앞서 정상 해제된 항목은 그대로 둔다)
+			Files.deleteIfExists(target);
+			throw limitExceeded;
+		}
+		return total;
+	}
+
+	private static void createParentDirectories(Path file) throws IOException {
+		Path parent = file.toAbsolutePath().getParent();
+		if (parent != null) {
+			Files.createDirectories(parent);
+		}
+	}
+
+	private static UncheckedIOException cleanupAndWrap(String message, Path archiveFile, IOException cause) {
+		try {
+			Files.deleteIfExists(archiveFile);
+		} catch (IOException cleanupFailure) {
+			cause.addSuppressed(cleanupFailure);
+		}
+		return new UncheckedIOException(message, cause);
+	}
+
+}

--- a/Foundation/org.egovframe.rte.fdl.filehandling/src/main/java/org/egovframe/rte/fdl/filehandling/archive/EgovExtractLimits.java
+++ b/Foundation/org.egovframe.rte.fdl.filehandling/src/main/java/org/egovframe/rte/fdl/filehandling/archive/EgovExtractLimits.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2009-2026 MOIS(Ministry of the Interior and Safety).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.egovframe.rte.fdl.filehandling.archive;
+
+/**
+ * 아카이브 해제 한도 — 압축 폭탄(zip bomb)형 자원 고갈을 봉쇄하는 상한 값.
+ *
+ * <p><b>NOTE:</b> 아카이브의 엔트리 수·압축 해제 후 크기는 <b>파일 안에 적힌 값을 믿을 수 없다</b>
+ * (조작 가능). {@link EgovArchives}는 이 한도를 실제로 만든 엔트리 수·실제로 쓴 바이트 수에
+ * 적용한다. 기본값({@link #defaults()})은 일반 업무 아카이브가 걸리지 않는 수준의 안전망이며,
+ * 사용자 업로드 zip 해제처럼 신뢰 경계를 넘는 자리는 {@link #of(long, long)}로 훨씬 낮게 잡고,
+ * 운영자가 직접 만든 대용량 백업 복원은 {@link #unlimited()}를 명시해 푼다.</p>
+ *
+ * <pre>
+ * EgovArchives.unzip(uploaded, workDir, StandardCharsets.UTF_8,
+ *         EgovExtractLimits.of(1_000, 100L * 1024 * 1024));   // 1,000개·100MB 상한
+ * </pre>
+ *
+ * <pre>
+ * &lt;&lt; 개정이력(Modification Information) &gt;&gt;
+ *
+ *  수정일        수정자        수정내용
+ *  ----------  --------    ---------------------------
+ *  2026.09.01  실행환경팀     최초 생성 (원본 EgovFileCmprs 에 없던 해제 한도 신설)
+ * </pre>
+ *
+ * @author 실행환경 개발팀
+ * @since 5.1
+ */
+public final class EgovExtractLimits {
+
+	/** 기본 최대 엔트리 수. */
+	public static final long DEFAULT_MAX_ENTRIES = 100_000L;
+
+	/** 기본 최대 누적 해제 바이트(10 GiB). */
+	public static final long DEFAULT_MAX_TOTAL_BYTES = 10L * 1024 * 1024 * 1024;
+
+	private static final EgovExtractLimits DEFAULTS =
+			new EgovExtractLimits(DEFAULT_MAX_ENTRIES, DEFAULT_MAX_TOTAL_BYTES);
+
+	private static final EgovExtractLimits UNLIMITED =
+			new EgovExtractLimits(Long.MAX_VALUE, Long.MAX_VALUE);
+
+	private final long maxEntries;
+	private final long maxTotalBytes;
+
+	private EgovExtractLimits(long maxEntries, long maxTotalBytes) {
+		this.maxEntries = maxEntries;
+		this.maxTotalBytes = maxTotalBytes;
+	}
+
+	/**
+	 * 기본 한도 — 엔트리 {@value #DEFAULT_MAX_ENTRIES}개, 누적 10 GiB.
+	 */
+	public static EgovExtractLimits defaults() {
+		return DEFAULTS;
+	}
+
+	/**
+	 * 한도를 직접 지정한다(둘 다 양수).
+	 *
+	 * @param maxEntries    최대 엔트리 수
+	 * @param maxTotalBytes 최대 누적 해제 바이트
+	 * @throws IllegalArgumentException 0 이하 값이 있는 경우
+	 */
+	public static EgovExtractLimits of(long maxEntries, long maxTotalBytes) {
+		if (maxEntries <= 0 || maxTotalBytes <= 0) {
+			throw new IllegalArgumentException(
+					"limits must be positive: maxEntries=" + maxEntries + ", maxTotalBytes=" + maxTotalBytes);
+		}
+		return new EgovExtractLimits(maxEntries, maxTotalBytes);
+	}
+
+	/**
+	 * 한도 없음 — 운영자가 직접 만든 대용량 백업 복원처럼 <b>출처를 신뢰할 수 있는 경우에만</b> 쓴다.
+	 */
+	public static EgovExtractLimits unlimited() {
+		return UNLIMITED;
+	}
+
+	/** 최대 엔트리 수. */
+	public long getMaxEntries() {
+		return maxEntries;
+	}
+
+	/** 최대 누적 해제 바이트. */
+	public long getMaxTotalBytes() {
+		return maxTotalBytes;
+	}
+
+}

--- a/Foundation/org.egovframe.rte.fdl.filehandling/src/test/java/org/egovframe/rte/fdl/filehandling/archive/EgovArchivesSecurityTest.java
+++ b/Foundation/org.egovframe.rte.fdl.filehandling/src/test/java/org/egovframe/rte/fdl/filehandling/archive/EgovArchivesSecurityTest.java
@@ -1,0 +1,243 @@
+package org.egovframe.rte.fdl.filehandling.archive;
+
+import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
+import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.stream.Stream;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+/**
+ * EgovArchives 해제의 <b>공격 아카이브</b> 회귀 검증 — Zip Slip(CWE-22)·링크(CWE-59)·
+ * 압축 폭탄(CWE-400) 에 실제로 쓰이는 엔트리 변형을 모아 두고, 판정은 하나로 한다:
+ * <b>대상 디렉터리 밖에 파일이 생기는가.</b>
+ *
+ * <p>기능 테스트({@link EgovArchivesTest})가 대표 사례를 다루고, 이 클래스는 변형 배터리를 맡는다.</p>
+ */
+public class EgovArchivesSecurityTest {
+
+    private static final String BS = String.valueOf((char) 92);
+
+    @TempDir
+    Path tempDir;
+
+    private Path outside;
+    private Path target;
+
+    private void arrange() throws IOException {
+        outside = Files.createDirectories(tempDir.resolve("outside"));
+        target = Files.createDirectories(tempDir.resolve("target"));
+    }
+
+    // ------------------------------------------------------------ Zip Slip 변형
+
+    @Test
+    public void 절대_경로_엔트리는_차단되고_밖에_아무것도_생기지_않는다() throws IOException {
+        arrange();
+        for (String name : List.of("/abs/pwn.txt", "//srv/share/pwn.txt")) {
+            Path zip = zip(tempDir.resolve("abs.zip"), name);
+            assertThrows(IllegalArgumentException.class, () -> EgovArchives.unzip(zip, target), name);
+            assertEquals(0, filesUnder(outside), "밖에 생기면 안 된다: " + name);
+            assertEquals(0, filesUnder(target), "대상에도 생기면 안 된다: " + name);
+        }
+    }
+
+    @Test
+    public void 드라이브_문자_엔트리는_어느_OS에서도_밖에_생기지_않는다() throws IOException {
+        // Windows: 드라이브 절대 경로라 차단(IAE). POSIX: 정규화 후 "C:/pwn.txt" 는 "C:" 라는 이름의
+        // 하위 디렉터리일 뿐이라 대상 안에 풀린다. 보안 속성은 양쪽 모두 "경계 밖에 없음" 이다.
+        arrange();
+        Path zip = zip(tempDir.resolve("drive.zip"), "C:" + BS + "pwn.txt");
+        try {
+            EgovArchives.unzip(zip, target);
+            assertFalse(System.getProperty("os.name").toLowerCase().contains("win"),
+                    "Windows 에서는 드라이브 절대 경로가 차단돼야 한다");
+            assertTrue(Files.exists(target.resolve("C:").resolve("pwn.txt")), "POSIX 에서는 대상 안의 중첩 이름");
+        } catch (IllegalArgumentException blocked) {
+            assertTrue(System.getProperty("os.name").toLowerCase().contains("win"), "차단은 Windows 의 동작");
+        }
+        assertEquals(0, filesUnder(outside));
+    }
+
+    @Test
+    public void 역슬래시_상위_이동_엔트리는_POSIX에서도_차단된다() throws IOException {
+        // EgovArchives 는 엔트리 이름의 역슬래시를 / 로 정규화한 뒤 검사한다 — POSIX 에서
+        // "..\..\x" 가 이름 하나로 남아 통과하는 일이 없다(EgovFiles 단독 계약보다 엄격)
+        arrange();
+        Path zip = zip(tempDir.resolve("bs.zip"), ".." + BS + ".." + BS + "pwn.txt");
+        assertThrows(IllegalArgumentException.class, () -> EgovArchives.unzip(zip, target));
+        assertEquals(0, filesUnder(outside) + filesUnder(target));
+    }
+
+    @Test
+    public void 중첩_상위_이동은_정규화_후_차단된다() throws IOException {
+        arrange();
+        for (String name : List.of("sub/../../pwn.txt", "a/b/../../../pwn.txt", "..")) {
+            Path zip = zip(tempDir.resolve("nest.zip"), name);
+            assertThrows(IllegalArgumentException.class, () -> EgovArchives.unzip(zip, target), name);
+            assertEquals(0, filesUnder(outside), name);
+        }
+    }
+
+    @Test
+    public void 기준_자신으로_정규화되는_파일_엔트리는_실패로_닫힌다() throws IOException {
+        // "sub/.." 는 정규화하면 대상 디렉터리 자신이라 탈출은 아니지만, 파일 엔트리로 디렉터리에
+        // 쓰려는 셈이라 입출력 실패로 닫힌다 — 어느 쪽이든 밖에는 아무것도 생기지 않는다
+        arrange();
+        Path zip = zip(tempDir.resolve("self.zip"), "sub/..");
+        assertThrows(RuntimeException.class, () -> EgovArchives.unzip(zip, target));
+        assertEquals(0, filesUnder(outside) + filesUnder(target));
+    }
+
+    // ------------------------------------------------------------ tar 링크·장치
+
+    @Test
+    public void tar_하드_링크_엔트리는_거부한다() throws IOException {
+        arrange();
+        Path tar = tar(tempDir.resolve("hard.tar"), "evil-hard", "../../outside/secret", TarArchiveEntry.LF_LINK);
+        IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> EgovArchives.untar(tar, target));
+        assertTrue(e.getMessage().contains("link"), e.getMessage());
+        assertEquals(0, filesUnder(outside) + filesUnder(target));
+    }
+
+    @Test
+    public void tar_FIFO_장치_엔트리는_거부한다() throws IOException {
+        arrange();
+        Path tar = tar(tempDir.resolve("fifo.tar"), "evil-fifo", null, TarArchiveEntry.LF_FIFO);
+        assertThrows(IllegalArgumentException.class, () -> EgovArchives.untar(tar, target));
+        assertEquals(0, filesUnder(target));
+    }
+
+    // ------------------------------------------------------------ 충돌·한도
+
+    @Test
+    public void 파일과_같은_이름의_디렉터리_엔트리는_실패로_닫힌다() throws IOException {
+        arrange();
+        Path zip = zip(tempDir.resolve("clash.zip"), "a.txt", "a.txt/b.txt");
+        assertThrows(UncheckedIOException.class, () -> EgovArchives.unzip(zip, target));
+        assertEquals(0, filesUnder(outside));
+    }
+
+    @Test
+    public void 한도_초과로_중단돼도_경계_밖은_그대로다() throws IOException {
+        arrange();
+        String[] many = new String[150];
+        for (int i = 0; i < many.length; i++) {
+            many[i] = "f" + i + ".txt";
+        }
+        Path zip = zip(tempDir.resolve("many.zip"), many);
+        assertThrows(IllegalArgumentException.class,
+                () -> EgovArchives.unzip(zip, target, StandardCharsets.UTF_8, EgovExtractLimits.of(100, 1_000_000)));
+        assertEquals(0, filesUnder(outside));
+        assertTrue(filesUnder(target) <= 100, "한도까지만 풀린다");
+    }
+
+    /** 한도 초과로 거부한 엔트리의 부분 파일은 남지 않는다. */
+    @Test
+    public void 바이트_한도_초과_시_부분_파일이_남지_않는다() throws IOException {
+        arrange();
+        Path zip = zipBig(tempDir.resolve("bomb.zip"), "big.bin", 5 * 1024 * 1024);
+        assertThrows(IllegalArgumentException.class,
+                () -> EgovArchives.unzip(zip, target, StandardCharsets.UTF_8, EgovExtractLimits.of(10, 1024 * 1024)));
+        assertFalse(Files.exists(target.resolve("big.bin")), "거부된 엔트리의 부분 파일은 남지 않아야 한다");
+    }
+
+    // ------------------------------------------------------------ 미리 심긴 링크
+
+    /**
+     * 대상 디렉터리에 밖을 가리키는 링크가 <b>미리</b> 있어도 링크를 따라 밖에 쓰지 않는다 — 어휘적 봉쇄를
+     * 통과한 뒤 쓰기 직전에 실경로를 재확인해 거부한다. 이 API 군으로는 링크를 심을 수 없지만(링크 엔트리 거부),
+     * 다른 경로로 심긴 링크와 결합되는 방어 심도를 고정한다.
+     */
+    @Test
+    @DisabledOnOs(OS.WINDOWS)
+    public void 대상_디렉터리의_기존_심볼릭_링크_아래로는_해제되지_않는다() throws IOException {
+        arrange();
+        plantLink(target.resolve("dlink"), outside);
+        Path zip = zip(tempDir.resolve("via-link.zip"), "dlink/pwn.txt");
+        IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> EgovArchives.unzip(zip, target));
+        assertTrue(e.getMessage().contains("link"), e.getMessage());
+        assertFalse(Files.exists(outside.resolve("pwn.txt")), "링크를 따라 경계 밖에 쓰면 안 된다");
+    }
+
+    @Test
+    @DisabledOnOs(OS.WINDOWS)
+    public void 대상_디렉터리의_기존_파일_링크를_엔트리가_덮어쓰지_않는다() throws IOException {
+        // 엔트리 이름과 같은 자리에 밖의 파일을 가리키는 링크가 있으면, 열어서 쓰는 순간 밖의 파일이 덮어써진다
+        arrange();
+        Path secret = Files.writeString(outside.resolve("secret.txt"), "TOP-SECRET");
+        plantLink(target.resolve("flink.txt"), secret);
+        Path zip = zip(tempDir.resolve("via-file-link.zip"), "flink.txt");
+        assertThrows(IllegalArgumentException.class, () -> EgovArchives.unzip(zip, target));
+        assertEquals("TOP-SECRET", Files.readString(secret), "링크 대상(경계 밖)은 그대로다");
+    }
+
+    // ------------------------------------------------------------ helpers
+
+    private static Path zip(Path file, String... names) throws IOException {
+        Files.deleteIfExists(file);
+        try (ZipOutputStream z = new ZipOutputStream(Files.newOutputStream(file), StandardCharsets.UTF_8)) {
+            for (String n : names) {
+                z.putNextEntry(new ZipEntry(n));
+                if (!n.endsWith("/")) {
+                    z.write("payload".getBytes(StandardCharsets.UTF_8));
+                }
+                z.closeEntry();
+            }
+        }
+        return file;
+    }
+
+    private static Path zipBig(Path file, String name, int bytes) throws IOException {
+        try (ZipOutputStream z = new ZipOutputStream(Files.newOutputStream(file), StandardCharsets.UTF_8)) {
+            z.putNextEntry(new ZipEntry(name));
+            z.write(new byte[bytes]);
+            z.closeEntry();
+        }
+        return file;
+    }
+
+    private static Path tar(Path file, String name, String linkName, byte type) throws IOException {
+        try (TarArchiveOutputStream t = new TarArchiveOutputStream(Files.newOutputStream(file), "UTF-8")) {
+            t.setLongFileMode(TarArchiveOutputStream.LONGFILE_POSIX);
+            TarArchiveEntry e = new TarArchiveEntry(name, type);
+            if (linkName != null) {
+                e.setLinkName(linkName);
+            }
+            e.setSize(0);
+            t.putArchiveEntry(e);
+            t.closeArchiveEntry();
+        }
+        return file;
+    }
+
+    private static void plantLink(Path link, Path to) {
+        try {
+            Files.createSymbolicLink(link, to);
+        } catch (UnsupportedOperationException | IOException e) {
+            assumeTrue(false, "이 파일시스템에서는 심볼릭 링크를 만들 수 없다: " + e);
+        }
+    }
+
+    private static long filesUnder(Path dir) throws IOException {
+        try (Stream<Path> s = Files.walk(dir)) {
+            return s.filter(Files::isRegularFile).count();
+        }
+    }
+}

--- a/Foundation/org.egovframe.rte.fdl.filehandling/src/test/java/org/egovframe/rte/fdl/filehandling/archive/EgovArchivesTest.java
+++ b/Foundation/org.egovframe.rte.fdl.filehandling/src/test/java/org/egovframe/rte/fdl/filehandling/archive/EgovArchivesTest.java
@@ -1,0 +1,243 @@
+package org.egovframe.rte.fdl.filehandling.archive;
+
+import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
+import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
+import org.apache.commons.compress.archivers.tar.TarConstants;
+import org.egovframe.rte.fdl.filehandling.EgovFiles;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+import java.util.zip.ZipOutputStream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * EgovArchives(디렉터리 아카이브 생성·해제) 검증 — Zip Slip 봉쇄·한도·형식 왕복.
+ */
+public class EgovArchivesTest {
+
+    @TempDir
+    Path tempDir;
+
+    private Path sampleTree() throws IOException {
+        Path src = tempDir.resolve("src");
+        Files.createDirectories(src.resolve("sub/깊은"));
+        Files.createDirectories(src.resolve("빈디렉터리"));
+        EgovFiles.writeString(src.resolve("루트.txt"), "가");
+        EgovFiles.writeString(src.resolve("sub/깊은/파일.txt"), "나");
+        return src;
+    }
+
+    private void craftZip(Path zip, int files, int bytesPerFile) throws IOException {
+        try (ZipOutputStream zos = new ZipOutputStream(Files.newOutputStream(zip), StandardCharsets.UTF_8)) {
+            byte[] content = new byte[bytesPerFile];
+            for (int i = 0; i < files; i++) {
+                zos.putNextEntry(new ZipEntry("f" + i + ".bin"));
+                zos.write(content);
+                zos.closeEntry();
+            }
+        }
+    }
+
+    // ---------------------------------------------------------------- zip
+
+    @Test
+    public void zip_왕복은_한글_파일명과_빈_하위_디렉터리를_보존한다() throws Exception {
+        Path src = sampleTree();
+        Path zip = tempDir.resolve("out/아카이브.zip");
+
+        long written = EgovArchives.zipDirectory(src, zip);
+        assertEquals(5, written); // 루트.txt, sub, sub/깊은, sub/깊은/파일.txt, 빈디렉터리
+
+        Path restored = tempDir.resolve("restored");
+        long read = EgovArchives.unzip(zip, restored);
+
+        assertEquals(5, read);
+        assertEquals("가", EgovFiles.readString(restored.resolve("루트.txt")));
+        assertEquals("나", EgovFiles.readString(restored.resolve("sub/깊은/파일.txt")));
+        assertTrue(Files.isDirectory(restored.resolve("빈디렉터리")),
+                "빈 하위 디렉터리 보존 — 원본 BackupJob 은 파일만 수집해 소실");
+    }
+
+    @Test
+    public void 엔트리_이름은_상대_경로다_원본_BackupJob의_절대경로_기록_결함_회귀() throws Exception {
+        Path src = sampleTree();
+        Path zip = tempDir.resolve("relative.zip");
+        EgovArchives.zipDirectory(src, zip);
+
+        try (ZipInputStream zis = new ZipInputStream(Files.newInputStream(zip), StandardCharsets.UTF_8)) {
+            ZipEntry entry;
+            int seen = 0;
+            while ((entry = zis.getNextEntry()) != null) {
+                seen++;
+                assertFalse(entry.getName().startsWith("/"), "절대 경로 금지: " + entry.getName());
+                assertFalse(entry.getName().contains(":"), "드라이브 문자 금지: " + entry.getName());
+                assertFalse(entry.getName().contains("\\"), "구분자는 / 통일: " + entry.getName());
+            }
+            assertEquals(5, seen);
+        }
+    }
+
+    @Test
+    public void 빈_원본_디렉터리는_침묵_실패_대신_예외다() throws Exception {
+        Path empty = tempDir.resolve("empty");
+        Files.createDirectories(empty);
+        assertThrows(IllegalArgumentException.class,
+                () -> EgovArchives.zipDirectory(empty, tempDir.resolve("e.zip")),
+                "원본 BackupJob 은 빈 디렉터리에서 예외 없이 false 를 반환했다");
+    }
+
+    @Test
+    public void 아카이브_파일이_원본_디렉터리_안이면_거부한다() throws Exception {
+        Path src = sampleTree();
+        assertThrows(IllegalArgumentException.class,
+                () -> EgovArchives.zipDirectory(src, src.resolve("self.zip")));
+    }
+
+    @Test
+    public void Zip_Slip_탈출_엔트리는_차단되고_파일이_만들어지지_않는다() throws Exception {
+        Path evil = tempDir.resolve("evil.zip");
+        try (ZipOutputStream zos = new ZipOutputStream(Files.newOutputStream(evil), StandardCharsets.UTF_8)) {
+            zos.putNextEntry(new ZipEntry("ok.txt"));
+            zos.write("x".getBytes(StandardCharsets.UTF_8));
+            zos.closeEntry();
+            zos.putNextEntry(new ZipEntry("../escaped.txt"));
+            zos.write("y".getBytes(StandardCharsets.UTF_8));
+            zos.closeEntry();
+        }
+
+        Path target = tempDir.resolve("slip/target");
+        assertThrows(IllegalArgumentException.class, () -> EgovArchives.unzip(evil, target));
+        assertFalse(Files.exists(tempDir.resolve("slip/escaped.txt")),
+                "탈출 파일이 대상 디렉터리 밖에 만들어지면 안 된다");
+    }
+
+    @Test
+    public void 구형_윈도우_zip은_MS949_문자셋_지정으로_한글_파일명이_보존된다() throws Exception {
+        Charset ms949 = Charset.forName("MS949");
+        Path legacy = tempDir.resolve("legacy.zip");
+        try (ZipOutputStream zos = new ZipOutputStream(Files.newOutputStream(legacy), ms949)) {
+            zos.putNextEntry(new ZipEntry("한글문서.txt"));
+            zos.write("내용".getBytes(StandardCharsets.UTF_8));
+            zos.closeEntry();
+        }
+
+        Path out = tempDir.resolve("legacy-out");
+        assertEquals(1, EgovArchives.unzip(legacy, out, ms949));
+        assertEquals("내용", EgovFiles.readString(out.resolve("한글문서.txt")));
+    }
+
+    @Test
+    public void 해제는_기존_파일을_대체한다() throws Exception {
+        Path src = sampleTree();
+        Path zip = tempDir.resolve("replace.zip");
+        EgovArchives.zipDirectory(src, zip);
+
+        Path out = tempDir.resolve("replace-out");
+        EgovFiles.writeString(out.resolve("루트.txt"), "이전 내용");
+        EgovArchives.unzip(zip, out);
+        assertEquals("가", EgovFiles.readString(out.resolve("루트.txt")));
+    }
+
+    // ---------------------------------------------------------------- tar
+
+    @Test
+    public void tar_왕복은_100바이트_초과_긴_이름을_POSIX_확장으로_보존한다() throws Exception {
+        // tar 기본 헤더의 name 필드는 100바이트다. 그것을 넘기되 파일시스템 한계 안에 들어야 한다 —
+        // ext4 등은 파일명 상한이 255"바이트"라 한글(UTF-8 3바이트)로는 85자를 넘길 수 없다.
+        // 36자 = 108바이트: tar 의 100바이트는 넘고 255바이트에는 못 미친다.
+        String longName = "긴이름".repeat(12) + ".txt";
+        Path src = tempDir.resolve("tarsrc");
+        Files.createDirectories(src.resolve("sub"));
+        EgovFiles.writeString(src.resolve(longName), "긴 이름 내용");
+        EgovFiles.writeString(src.resolve("sub/일반.txt"), "일반");
+
+        Path tar = tempDir.resolve("아카이브.tar");
+        long written = EgovArchives.tarDirectory(src, tar);
+        assertEquals(3, written); // longName, sub, sub/일반.txt
+
+        Path out = tempDir.resolve("tar-out");
+        long read = EgovArchives.untar(tar, out);
+        assertEquals(3, read);
+        assertEquals("긴 이름 내용", EgovFiles.readString(out.resolve(longName)));
+        assertEquals("일반", EgovFiles.readString(out.resolve("sub/일반.txt")));
+    }
+
+    @Test
+    public void tar_심볼릭_링크_엔트리는_거부한다() throws Exception {
+        Path evil = tempDir.resolve("link.tar");
+        try (TarArchiveOutputStream tos =
+                new TarArchiveOutputStream(Files.newOutputStream(evil), StandardCharsets.UTF_8.name())) {
+            TarArchiveEntry link = new TarArchiveEntry("evil-link", TarConstants.LF_SYMLINK);
+            link.setLinkName("../../outside");
+            tos.putArchiveEntry(link);
+            tos.closeArchiveEntry();
+        }
+
+        assertThrows(IllegalArgumentException.class,
+                () -> EgovArchives.untar(evil, tempDir.resolve("link-out")),
+                "링크를 따라 대상 밖에 쓰는 우회 차단");
+    }
+
+    @Test
+    public void tar_탈출_엔트리도_차단된다() throws Exception {
+        Path evil = tempDir.resolve("escape.tar");
+        try (TarArchiveOutputStream tos =
+                new TarArchiveOutputStream(Files.newOutputStream(evil), StandardCharsets.UTF_8.name())) {
+            TarArchiveEntry entry = new TarArchiveEntry("../tar-escaped.txt");
+            byte[] content = "y".getBytes(StandardCharsets.UTF_8);
+            entry.setSize(content.length);
+            tos.putArchiveEntry(entry);
+            tos.write(content);
+            tos.closeArchiveEntry();
+        }
+
+        Path target = tempDir.resolve("tarslip/target");
+        assertThrows(IllegalArgumentException.class, () -> EgovArchives.untar(evil, target));
+        assertFalse(Files.exists(tempDir.resolve("tarslip/tar-escaped.txt")));
+    }
+
+    // ---------------------------------------------------------------- 한도
+
+    @Test
+    public void 엔트리_수_한도를_넘으면_즉시_중단한다() throws Exception {
+        Path zip = tempDir.resolve("count.zip");
+        craftZip(zip, 3, 10);
+
+        assertThrows(IllegalArgumentException.class,
+                () -> EgovArchives.unzip(zip, tempDir.resolve("count-out"),
+                        StandardCharsets.UTF_8, EgovExtractLimits.of(2, 1024)));
+    }
+
+    @Test
+    public void 누적_해제_크기_한도는_헤더_선언이_아니라_실제_기록_바이트에_적용된다() throws Exception {
+        Path zip = tempDir.resolve("bytes.zip");
+        craftZip(zip, 3, 10); // 총 30바이트
+
+        assertThrows(IllegalArgumentException.class,
+                () -> EgovArchives.unzip(zip, tempDir.resolve("bytes-out"),
+                        StandardCharsets.UTF_8, EgovExtractLimits.of(100, 15)));
+
+        // 한도를 명시적으로 풀면 통과한다
+        assertEquals(3, EgovArchives.unzip(zip, tempDir.resolve("bytes-ok"),
+                StandardCharsets.UTF_8, EgovExtractLimits.unlimited()));
+    }
+
+    @Test
+    public void 한도_값은_양수만_허용한다() {
+        assertThrows(IllegalArgumentException.class, () -> EgovExtractLimits.of(0, 10));
+        assertThrows(IllegalArgumentException.class, () -> EgovExtractLimits.of(10, -1));
+        assertEquals(EgovExtractLimits.DEFAULT_MAX_ENTRIES, EgovExtractLimits.defaults().getMaxEntries());
+    }
+
+}


### PR DESCRIPTION
> **[공통컴포넌트 공통 기능 개선 → 실행환경 이관]**
>
> 공통컴포넌트에 있던 공통 기능을 개선해 실행환경으로 올리는 항목입니다.
> 실행환경에 올라가면 공통컴포넌트를 포함한 모든 사업에서 같은 구현을 쓸 수 있습니다.
>
> 공통컴포넌트 원본
> - `egovframework.com.utl.sim.service.EgovFileCmprs`

## 수정 사유 Reason for modification

- [ ] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [X] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

### 배경

디렉터리를 묶어 내려주거나 업로드된 아카이브를 푸는 일은 흔한데 실행환경에 수단이 없습니다.
자체 구현 시 가장 자주 빠지는 것이 **Zip Slip 방어**이고, 그 방어가 `".." 문자 삭제 한 줄`인
경우가 많습니다. 문자 삭제는 **결과가 대상 디렉터리 밖인지 판정하지 않으므로** 절대 경로
엔트리를 그대로 통과시킵니다. 해제 크기 한도(zip bomb 방어)도 대개 없습니다.

### 추가한 것

- **`archive/EgovArchives`** — 디렉터리 ↔ 아카이브 변환
  - **zip 은 JDK 표준(`java.util.zip`)만** 씁니다
  - **tar 는 `commons-compress`** 를 쓰며 **`optional`** 이라 전이되지 않습니다
    (tar 를 쓰지 않으면 이 의존 없이도 zip 이 동작합니다)
  - 해제 시 각 엔트리 경로를 `EgovFiles` 의 **안전 경로 해석**으로 확정합니다.
    문자 삭제가 아니라 **정규화 후 대상 디렉터리 봉쇄 검증**입니다
  - 쓰기 직전 **실경로를 재확인**해, 대상 디렉터리 안에 미리 심긴 심볼릭 링크를 거치는 엔트리
    (디렉터리 링크 아래 해제·파일 링크 덮어쓰기)를 거부합니다
- **`archive/EgovExtractLimits`** — 해제 한도(항목 수 · 총 해제 크기). 기본 100,000개 · 10 GiB.
  한도를 넘으면 쓰던 파일을 지우고 예외로 해제를 **중단**합니다 — 앞서 정상 해제된 항목은 남으므로,
  전체 정리는 호출자 몫입니다

### 설계 메모

- **누적 해제 크기 한도는 헤더 선언이 아니라 실제 기록 바이트에 적용**합니다.
  헤더의 크기 값은 공격자가 위조할 수 있습니다
- **한도를 지정하지 않으면 기본 한도**가 적용됩니다. 무제한이 기본이면 방어가 없는 것과 같습니다
- **tar 의 심볼릭 링크 엔트리는 거부**합니다. 링크 대상이 대상 디렉터리 밖을 가리킬 수 있습니다
- 아카이브 자신을 대상 디렉터리 안에 두고 압축하면 무한 중첩이 되므로 **거부**합니다
- 빈 원본 디렉터리는 침묵 실패 대신 **예외**입니다
- 구형 Windows zip 의 한글 파일명을 위해 **문자셋 지정 오버로드**(MS949 등)를 제공합니다

### 추가되는 의존성

| 좌표 | 버전 | 라이선스 | 크기 | 스코프 |
|---|---|---|---:|---|
| `org.apache.commons:commons-compress` | 1.28.0 | **Apache-2.0** | 1,091 KB | **`optional`** |

`mvn dependency:tree` 실측 결과 **전이 의존이 0건**이며 `(optional)` 로 표시됩니다.

```
[INFO] +- org.apache.commons:commons-compress:jar:1.28.0:compile (optional)
```

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

`EgovArchivesTest` **13건** + 보안 회귀 `EgovArchivesSecurityTest` **12건**, 합계 **25건 신규**. `fdl.filehandling` 모듈 전건 통과.

| 환경 | 모듈 실행 건수 | 결과 |
|---|---:|---|
| **Windows** (ko_KR) | 101 | `Tests run: 101, Failures: 0, Errors: 0, Skipped: 4` |
| **Linux** (Ubuntu 22.04 / OpenJDK 17 / ext4, C.UTF-8) | 101 | `Tests run: 101, Failures: 0, Errors: 0, Skipped: 5` |

`Skipped` 는 플랫폼 조건부 테스트입니다 — Windows 4건 = `EgovFiles`(#388 로 머지됨)의 POSIX 전용 2 + 이 PR 의 POSIX 전용 링크 테스트 2,
Linux 5건 = `EgovFiles` 의 Windows 전용 5.

| 구분 | 건수 | 내용 |
|---|---:|---|
| **탈출 방어** | 3 | **Zip Slip 엔트리 차단**(파일이 만들어지지 않음) · **tar 탈출 엔트리 차단** · **tar 심볼릭 링크 엔트리 거부** |
| 해제 한도 | 3 | 항목 수 한도 즉시 중단 · **누적 크기는 헤더가 아닌 실제 기록 바이트 기준** · 한도 값은 양수만 |
| zip 왕복 | 4 | 한글 파일명·빈 하위 디렉터리 보존 · **엔트리 이름이 상대 경로**(원본의 절대경로 기록 결함 회귀) · MS949 문자셋 지정 · 해제 시 기존 파일 대체 |
| tar 왕복 | 1 | **100바이트 초과 이름을 POSIX 확장으로 보존** |
| 계약 | 2 | 빈 원본 디렉터리는 예외 · 아카이브가 원본 디렉터리 안이면 거부 |

`EgovArchivesSecurityTest` 12건 — Zip Slip·링크·압축 폭탄에 실제로 쓰이는 엔트리 변형을 모아 두고
판정은 하나로 합니다: **대상 디렉터리 밖에 파일이 생기는가.**

| 구분 | 건수 | 내용 |
|---|---:|---|
| 절대 경로·드라이브 | 2 | `/abs/…`·`//srv/share/…` 차단 · 드라이브 문자 엔트리는 **Windows 에서는 차단, POSIX 에서는 `C:` 라는 이름의 하위 디렉터리**로 대상 안에 풀림 — 어느 쪽도 밖에 생기지 않음 |
| 상위 이동 변형 | 3 | 역슬래시 상위 이동은 **POSIX 에서도 차단**(엔트리 이름을 `/` 로 정규화한 뒤 검사) · 중첩 상위 이동(`sub/../../`·`a/b/../../../`·`..`) · 대상 자신으로 정규화되는 파일 엔트리(`sub/..`)는 실패로 닫힘 |
| tar 링크·장치 | 2 | 하드 링크 엔트리 거부 · FIFO 엔트리 거부 |
| 충돌·한도 | 2 | 파일과 같은 이름의 디렉터리 엔트리는 실패로 닫힘 · 항목 수 한도 초과로 중단돼도 경계 밖은 그대로 |
| 부분 파일 | 1 | 바이트 한도 초과로 거부한 엔트리의 부분 파일이 남지 않음 |
| 미리 심긴 링크 | 2 | 대상 안의 기존 **디렉터리 링크 아래로는 해제되지 않음** · 기존 **파일 링크를 엔트리가 덮어쓰지 않음**(링크 대상 보존) |

**수동 확인**: 압축 해제는 경로 의미론·파일명 인코딩·파일시스템 한계에 직접 좌우되므로
Linux(ext4, `C.UTF-8`)에서 교차 검증했습니다. 그 과정에서 **파일명 상한이 Windows 는
255 UTF-16 단위, Linux 는 255 바이트**라는 차이를 확인하고 테스트 픽스처를 양쪽에서 성립하도록
조정했습니다.

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

해당 없음 — 라이브러리 클래스 추가입니다.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

해당 없음 — 위 JUnit 테스트 결과로 갈음합니다.

---

<sub>base: `eGovFramework:main` @ `cb4b449` (2026-09-09 fetch 기준) · 단일 커밋</sub>
