### PR TITLE
feat: 엑셀 다운로드 파일명 헤더를 공용 API 로 위임

### DIFF
--- a/Foundation/org.egovframe.rte.fdl.excel/src/main/java/org/egovframe/rte/fdl/excel/util/AbstractExcelView.java
+++ b/Foundation/org.egovframe.rte.fdl.excel/src/main/java/org/egovframe/rte/fdl/excel/util/AbstractExcelView.java
@@ -23,6 +23,7 @@ import org.apache.poi.hssf.usermodel.HSSFRow;
 import org.apache.poi.hssf.usermodel.HSSFSheet;
 import org.apache.poi.hssf.usermodel.HSSFWorkbook;
 import org.apache.poi.ss.usermodel.CellType;
+import org.egovframe.rte.fdl.filehandling.EgovContentDispositions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.util.ObjectUtils;
@@ -85,7 +86,9 @@ public abstract class AbstractExcelView extends AbstractView {
 
         // 응답 설정
         response.setContentType(getContentType());
-        response.setHeader("Content-Disposition", "attachment; filename=\"" + sFilename + ".xls\"");
+        // RFC 6266/5987 준수 파일명 인코딩 — 한글 등 비ASCII 파일명은 filename*=UTF-8'' 로
+        // 인코딩되어 브라우저에서 깨지지 않는다(ASCII 파일명은 기존 filename="..." 형식 유지).
+        response.setHeader("Content-Disposition", buildContentDisposition(sFilename + ".xls"));
 
         // 스트림 처리
         ServletOutputStream out = response.getOutputStream();
@@ -102,6 +105,16 @@ public abstract class AbstractExcelView extends AbstractView {
             HSSFWorkbook workbook,
             HttpServletRequest request,
             HttpServletResponse response);
+
+    /**
+     * Content-Disposition 값 생성 — ASCII 파일명은 기존 {@code filename="..."} 형식을 유지하고,
+     * 비ASCII(한글 등) 파일명은 RFC 5987 {@code filename*=UTF-8''} 인코딩에 구형 에이전트용
+     * ASCII 폴백을 병기한다 ({@link EgovContentDispositions} 공용
+     * API로 승격되어 위임).
+     */
+    static String buildContentDisposition(String filename) {
+        return EgovContentDispositions.attachment(filename);
+    }
 
     protected HSSFCell getCell(HSSFSheet sheet, int row, int col) {
         HSSFRow sheetRow = sheet.getRow(row);

--- a/Foundation/org.egovframe.rte.fdl.excel/src/main/java/org/egovframe/rte/fdl/excel/util/AbstractPOIExcelView.java
+++ b/Foundation/org.egovframe.rte.fdl.excel/src/main/java/org/egovframe/rte/fdl/excel/util/AbstractPOIExcelView.java
@@ -85,7 +85,9 @@ public abstract class AbstractPOIExcelView extends AbstractView {
 
         // 응답 설정
         response.setContentType(getContentType());
-        response.setHeader("Content-Disposition", "attachment; filename=\"" + sFilename + ".xlsx\"");
+        // RFC 6266/5987 준수 파일명 인코딩 — 한글 등 비ASCII 파일명은 filename*=UTF-8'' 로
+        // 인코딩되어 브라우저에서 깨지지 않는다(ASCII 파일명은 기존 filename="..." 형식 유지).
+        response.setHeader("Content-Disposition", AbstractExcelView.buildContentDisposition(sFilename + ".xlsx"));
 
         // 스트림 처리
         ServletOutputStream out = response.getOutputStream();

--- a/Foundation/org.egovframe.rte.fdl.excel/src/test/java/org/egovframe/rte/fdl/excel/EgovExcelViewFilenameSecurityTest.java
+++ b/Foundation/org.egovframe.rte.fdl.excel/src/test/java/org/egovframe/rte/fdl/excel/EgovExcelViewFilenameSecurityTest.java
@@ -1,0 +1,101 @@
+package org.egovframe.rte.fdl.excel;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.apache.poi.hssf.usermodel.HSSFWorkbook;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import org.egovframe.rte.fdl.excel.util.AbstractExcelView;
+import org.egovframe.rte.fdl.excel.util.AbstractPOIExcelView;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.web.servlet.view.AbstractView;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * 엑셀 뷰 다운로드 파일명의 <b>헤더 인젝션(CWE-113)</b> 회귀 검증.
+ *
+ * <p>파일명은 모델 속성 {@code filename} 또는 요청 속성에서 오므로 신뢰할 수 없다. 값 생성 규칙 자체는
+ * {@code EgovContentDispositions} 가 담당하고 그쪽 테스트가 입력 변형 배터리를 맡는다 — 여기서는
+ * 두 뷰(xls·xlsx)와 두 입력 경로(모델·요청 속성)가 실제로 그 규칙을 타는지, 헤더가 정확히 한 번만
+ * 설정되는지를 고정한다.</p>
+ */
+public class EgovExcelViewFilenameSecurityTest {
+
+    private static final String BS = String.valueOf((char) 92);
+
+    private static final class XlsView extends AbstractExcelView {
+        @Override
+        protected void buildExcelDocument(Map<String, Object> model, HSSFWorkbook workbook,
+                                          HttpServletRequest request, HttpServletResponse response) {
+            workbook.createSheet("s");
+        }
+    }
+
+    private static final class XlsxView extends AbstractPOIExcelView {
+        @Override
+        protected void buildExcelDocument(Map<String, Object> model, XSSFWorkbook workbook,
+                                          HttpServletRequest request, HttpServletResponse response) {
+            workbook.createSheet("s");
+        }
+    }
+
+    @Test
+    public void 파일명의_CR_LF는_헤더에_남지_않는다() throws Exception {
+        for (AbstractView view : List.of(new XlsView(), new XlsxView())) {
+            for (boolean viaRequestAttribute : new boolean[] {false, true}) {
+                MockHttpServletResponse response = render(view, "evil\r\nSet-Cookie: a=b\rX: y\n", viaRequestAttribute);
+                String header = response.getHeader("Content-Disposition");
+                assertFalse(header.contains("\r") || header.contains("\n"), "CR/LF 잔존: " + header);
+                assertEquals(1, response.getHeaders("Content-Disposition").size(), "헤더는 한 번만 설정된다");
+            }
+        }
+    }
+
+    @Test
+    public void 경로가_섞인_파일명은_이름만_남는다() throws Exception {
+        assertTrue(render(new XlsView(), "../../etc/passwd", false).getHeader("Content-Disposition")
+                .contains("filename=\"passwd.xls\""));
+        String backslash = render(new XlsxView(), ".." + BS + ".." + BS + "win.ini", false).getHeader("Content-Disposition");
+        assertTrue(backslash.contains("filename=\"win.ini.xlsx\""), backslash);
+        assertFalse(backslash.contains("..") || backslash.contains(BS), backslash);
+    }
+
+    @Test
+    public void 인용부호는_이스케이프되어_파라미터_경계가_유지된다() throws Exception {
+        String header = render(new XlsView(), "a\"; filename=\"b.exe", false).getHeader("Content-Disposition");
+        // 이스케이프된 \" 와 \\ 를 걷어내면 quoted-string 을 감싸는 인용부호 2개만 남아야 한다
+        String stripped = header.replace(BS + BS, "").replace(BS + "\"", "");
+        assertEquals(2, stripped.length() - stripped.replace("\"", "").length(), "인용부호 경계가 깨짐: " + header);
+        assertTrue(header.startsWith("attachment; filename=\""), header);
+    }
+
+    @Test
+    public void 파일명이_없어도_헤더는_한_번_유효하게_설정된다() throws Exception {
+        MockHttpServletResponse response = render(new XlsView(), null, false);
+        assertEquals(1, response.getHeaders("Content-Disposition").size());
+        assertTrue(response.getHeader("Content-Disposition").startsWith("attachment; filename=\""));
+    }
+
+    private static MockHttpServletResponse render(AbstractView view, String filename, boolean viaRequestAttribute) throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        Map<String, Object> model = new HashMap<>();
+        if (filename != null) {
+            if (viaRequestAttribute) {
+                request.setAttribute("filename", filename);
+            } else {
+                model.put("filename", filename);
+            }
+        }
+        view.render(model, request, response);
+        return response;
+    }
+}

--- a/Foundation/org.egovframe.rte.fdl.excel/src/test/java/org/egovframe/rte/fdl/excel/EgovExcelViewFilenameTest.java
+++ b/Foundation/org.egovframe.rte.fdl.excel/src/test/java/org/egovframe/rte/fdl/excel/EgovExcelViewFilenameTest.java
@@ -1,0 +1,79 @@
+package org.egovframe.rte.fdl.excel;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.apache.poi.hssf.usermodel.HSSFWorkbook;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import org.egovframe.rte.fdl.excel.util.AbstractExcelView;
+import org.egovframe.rte.fdl.excel.util.AbstractPOIExcelView;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * 다운로드 파일명 RFC 6266/5987 인코딩 검증 — 한글 파일명 filename*=UTF-8'' 처리.
+ */
+public class EgovExcelViewFilenameTest {
+
+    private static final class TestXlsView extends AbstractExcelView {
+        @Override
+        protected void buildExcelDocument(Map<String, Object> model, HSSFWorkbook workbook,
+                                          HttpServletRequest request, HttpServletResponse response) {
+            workbook.createSheet("s");
+        }
+    }
+
+    private static final class TestXlsxView extends AbstractPOIExcelView {
+        @Override
+        protected void buildExcelDocument(Map<String, Object> model, XSSFWorkbook workbook,
+                                          HttpServletRequest request, HttpServletResponse response) {
+            workbook.createSheet("s");
+        }
+    }
+
+    private String renderAndGetDisposition(Object view, String filename) throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        Map<String, Object> model = new HashMap<>();
+        model.put("filename", filename);
+        if (view instanceof TestXlsView) {
+            ((TestXlsView) view).render(model, request, response);
+        } else {
+            ((TestXlsxView) view).render(model, request, response);
+        }
+        return response.getHeader("Content-Disposition");
+    }
+
+    @Test
+    public void 한글_파일명은_RFC5987로_인코딩된다_xls() throws Exception {
+        String header = renderAndGetDisposition(new TestXlsView(), "연차보고서");
+        assertNotNull(header);
+        assertTrue(header.contains("filename*=UTF-8''"), "비ASCII 파일명은 filename* 확장 파라미터 사용: " + header);
+        assertFalse(header.contains("연차보고서"), "헤더에 원시 한글이 그대로 실리면 안 된다: " + header);
+        // EgovContentDispositions 위임으로 구형 에이전트용 ASCII 폴백(filename=)이 병기된다(RFC 6266 부록 D)
+        assertTrue(header.contains("filename=\""), "ASCII 폴백 filename= 병기: " + header);
+    }
+
+    @Test
+    public void 한글_파일명은_RFC5987로_인코딩된다_xlsx() throws Exception {
+        String header = renderAndGetDisposition(new TestXlsxView(), "정산내역");
+        assertNotNull(header);
+        assertTrue(header.contains("filename*=UTF-8''"));
+        assertTrue(header.toLowerCase().startsWith("attachment"));
+    }
+
+    @Test
+    public void ASCII_파일명은_기존_형식을_유지한다() throws Exception {
+        String header = renderAndGetDisposition(new TestXlsView(), "report");
+        assertNotNull(header);
+        assertTrue(header.contains("filename=\"report.xls\""), header);
+    }
+
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [ ] 버그수정 Bug fixes
- [X] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

### 배경

`AbstractExcelView`(xls)와 `AbstractPOIExcelView`(xlsx)가 `Content-Disposition` 을 직접
조립합니다.

```java
response.setHeader("Content-Disposition", "attachment; filename=\"" + sFilename + ".xls\"");
```

**한글 파일명이 그대로 실려 브라우저·에이전트에 따라 깨집니다.** 게다가 **같은 조립이 두
클래스에 각각 있어 한쪽만 고치면 다른 쪽이 남습니다.**

### 변경 내용

두 뷰 모두 `EgovContentDispositions.attachment(파일명)` 에 위임합니다.

- **ASCII 파일명은 기존 `filename="..."` 형식을 그대로 유지**합니다
- 비ASCII(한글 등) 파일명은 RFC 5987 `filename*=UTF-8''` 로 인코딩하고,
  구형 에이전트를 위해 **ASCII 폴백을 병기**합니다(RFC 6266 부록 D)

### 동작 변경 고지

- **ASCII 파일명의 헤더 값은 종전과 완전히 같습니다**
- **한글 파일명의 헤더 값이 바뀝니다.** 종전에는 원시 한글이 그대로 실렸고, 이제는
  `filename*=` 인코딩 + ASCII 폴백이 병기됩니다. **파일명이 깨지던 것을 고치는 변경**입니다

`fdl.excel` 은 이미 `fdl-filehandling` 에 의존하므로 **pom 변경이 없습니다.**

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

`EgovExcelViewFilenameTest` **3건** + 보안 회귀 `EgovExcelViewFilenameSecurityTest` **4건**, 합계 **7건 신규**. `fdl.excel` 모듈 전건 통과.

| 환경 | 기본 로케일(Locale) | 모듈 실행 건수 | 결과 |
|---|---|---:|---|
| **Windows** | ko_KR | **40** | `Tests run: 40, Failures: 0, Errors: 0, Skipped: 0` |
| **Linux** (Ubuntu 22.04 / OpenJDK 17) | C.UTF-8 | **40** | `Tests run: 40, Failures: 0, Errors: 0, Skipped: 0` |

| 구분 | 건수 | 내용 |
|---|---:|---|
| 한글 파일명 | 2 | **xls·xlsx 양쪽** 모두 `filename*=UTF-8''` 인코딩 · 원시 한글 미포함 · ASCII 폴백 병기 |
| ASCII 파일명 | 1 | **기존 `filename="..."` 형식 유지**(회귀 방어) |

xls·xlsx 를 각각 검증하는 것이 핵심입니다 — 같은 조립이 두 클래스에 있어 **한쪽만 고치는
실수를 테스트가 잡습니다.**

`EgovExcelViewFilenameSecurityTest` 4건 — 모델·요청 속성으로 들어온 파일명의 **CR/LF·경로·인용부호가 헤더에 실리지 않고** `Content-Disposition` 이 정확히 한 번만 설정됨.

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

해당 없음 — 응답 헤더 값 생성 변경이며, 검증은 위 JUnit(`MockHttpServletResponse`)으로
수행했습니다.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

해당 없음 — 위 JUnit 테스트 결과로 갈음합니다.

---

<sub>base: `eGovFramework:main` @ `cb4b449` (2026-09-09 fetch 기준) · 단일 커밋</sub>
