### PR TITLE
fix: MappingInfo.toString() 의 argumentName 라벨 오타 수정

### DIFF
--- a/Integration/org.egovframe.rte.itl.webservice/src/main/java/org/egovframe/rte/itl/webservice/data/MappingInfo.java
+++ b/Integration/org.egovframe.rte.itl.webservice/src/main/java/org/egovframe/rte/itl/webservice/data/MappingInfo.java
@@ -178,7 +178,7 @@ public class MappingInfo implements Validatable {
         StringBuilder sb = new StringBuilder();
         sb.append(this.getClass().getName()).append(" {").append("\n\ttype = ")
                 .append(StringUtils.quote(type)).append("\n\tindex = ")
-                .append(index).append("\n\targumentNAme = ")
+                .append(index).append("\n\targumentName = ")
                 .append(StringUtils.quote(argumentName))
                 .append("\n\theader = ").append(header).append("\n}");
         return sb.toString();

--- a/Integration/org.egovframe.rte.itl.webservice/src/test/java/org/egovframe/rte/itl/webservice/data/MappingInfoTest.java
+++ b/Integration/org.egovframe.rte.itl.webservice/src/test/java/org/egovframe/rte/itl/webservice/data/MappingInfoTest.java
@@ -1,0 +1,25 @@
+package org.egovframe.rte.itl.webservice.data;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * MappingInfo.toString() 이 필드 이름을 그대로 라벨로 쓰는지 확인한다.
+ *
+ * <p>같은 패키지의 Definition 들은 toString() 라벨을 필드 이름과 똑같이 적는다.
+ * 라벨이 어긋나면 로그를 필드 이름으로 검색할 수 없다.</p>
+ */
+public class MappingInfoTest {
+
+    @Test
+    public void testToStringUsesFieldNameAsLabel() {
+        MappingInfo mappingInfo = new MappingInfo();
+        mappingInfo.setArgumentName("sampleArgument");
+
+        String printed = mappingInfo.toString();
+
+        assertTrue(printed.contains("argumentName = "),
+                "필드 이름과 같은 라벨이어야 한다 : " + printed);
+    }
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

`MappingInfo.toString()` 이 찍는 라벨만 `argumentNAme` 이고, 다음 줄에서 꺼내는 필드는 `argumentName`(`:54`)입니다. 게터(`:137`)와 세터(`:146`)도 같은 표기입니다. 같은 메서드의 다른 라벨 `type`·`index`·`header` 는 모두 자기 필드 이름 그대로입니다.

AS-IS (`:181~182`)

```java
                .append(index).append("\n\targumentNAme = ")
                .append(StringUtils.quote(argumentName))
```

TO-BE

```java
                .append(index).append("\n\targumentName = ")
                .append(StringUtils.quote(argumentName))
```

### 영향 범위

`data` 패키지 세 클래스가 `toString()` 에서 쓰는 필드 라벨 20개를 전부 대조했습니다. 나머지 19개는 모두 자기 필드 이름과 같고 이 하나만 어긋납니다. 형제인 `WebServiceServerDefinition.toString()`(`:268~283`)의 라벨 일곱 개가 전부 필드 이름 그대로입니다. `WebServiceClientDefinition.hbm.xml`(`:36`, `:50`)이 매핑하는 property name 도 `argumentName` 입니다.

```
$ git grep -n "argumentNAme" origin/main
origin/main:Integration/org.egovframe.rte.itl.webservice/src/main/java/org/egovframe/rte/itl/webservice/data/MappingInfo.java:181:                .append(index).append("\n\targumentNAme = ")
```

이 저장소에는 이 문자열을 파싱하거나 소비하는 코드가 없습니다. 출력 라벨 한 글자만 바뀌고 동작은 그대로입니다.

다만 찍히지 않는 자리는 아닙니다. `WebServiceClientDefinition.toString()`(`:333~372`)이 request/responseMappingInfos 의 값으로 `MappingInfo` 를 그대로 붙이고, `EgovWebServiceContext:458` 이 그 결과를 로그 메시지에 문자열로 연결합니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

이 모듈에 `data` 패키지의 `toString()` 테스트가 없어 `MappingInfoTest` 를 새로 만들었습니다. 세터로 `argumentName` 을 넣고 출력에 같은 이름의 라벨이 있는지 봅니다.

수정 전(RED, 라벨만 되돌려 실행)

```
$ mvn -pl Integration/org.egovframe.rte.itl.webservice test -Dtest=MappingInfoTest
[ERROR] Failures: 
[ERROR]   MappingInfoTest.testToStringUsesFieldNameAsLabel:22 필드 이름과 같은 라벨이어야 한다 : org.egovframe.rte.itl.webservice.data.MappingInfo {
	type = null
	index = 0
	argumentNAme = 'sampleArgument'
	header = false
} ==> expected: <true> but was: <false>
[INFO] 
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0
```

수정 후 모듈 전체입니다. 원래 22건이었고 추가한 한 건을 포함해 23건이 되었습니다.

```
$ mvn -pl Integration/org.egovframe.rte.itl.webservice test
[INFO] Tests run: 23, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

화면이 없는 실행환경 모듈이라 첨부하지 않았습니다.
