### PR TITLE
fix: trace 매니저 2개의 진입 로그가 다른 클래스의 다른 메소드 이름을 알리는 문제 수정

### DIFF
--- a/Foundation/org.egovframe.rte.fdl.cmmn/src/main/java/org/egovframe/rte/fdl/cmmn/trace/manager/AbstractTraceHandleManager.java
+++ b/Foundation/org.egovframe.rte.fdl.cmmn/src/main/java/org/egovframe/rte/fdl/cmmn/trace/manager/AbstractTraceHandleManager.java
@@ -118,7 +118,7 @@ public abstract class AbstractTraceHandleManager {
      * @return boolean true|false
      */
     public boolean trace(Class<?> clazz, String message) {
-        LOGGER.debug(" DefaultExceptionHandleManager.run() ");
+        LOGGER.debug(" AbstractTraceHandleManager.trace() ");
         // 매칭조건이 false 인 경우
         if (!enableMatcher()) {
             return false;

--- a/Foundation/org.egovframe.rte.fdl.cmmn/src/main/java/org/egovframe/rte/fdl/cmmn/trace/manager/DefaultTraceHandleManager.java
+++ b/Foundation/org.egovframe.rte.fdl.cmmn/src/main/java/org/egovframe/rte/fdl/cmmn/trace/manager/DefaultTraceHandleManager.java
@@ -51,7 +51,7 @@ public class DefaultTraceHandleManager extends AbstractTraceHandleManager implem
      */
     @Override
     public boolean trace(Class<?> clazz, String message) {
-        LOGGER.debug(" DefaultExceptionHandleManager.run() ");
+        LOGGER.debug(" DefaultTraceHandleManager.trace() ");
         // 매칭조건이 false 인 경우
         if (!enableMatcher()) {
             return false;

--- a/Foundation/org.egovframe.rte.fdl.cmmn/src/test/java/org/egovframe/rte/fdl/cmmn/trace/manager/TraceHandleManagerLogMessageTest.java
+++ b/Foundation/org.egovframe.rte.fdl.cmmn/src/test/java/org/egovframe/rte/fdl/cmmn/trace/manager/TraceHandleManagerLogMessageTest.java
@@ -1,0 +1,59 @@
+package org.egovframe.rte.fdl.cmmn.trace.manager;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.Logger;
+import org.apache.logging.log4j.core.appender.AbstractAppender;
+import org.apache.logging.log4j.core.config.Property;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class TraceHandleManagerLogMessageTest {
+
+    // 진입 로그는 로거가 달린 클래스와 실행 중인 메소드를 가리켜야 한다.
+    @Test
+    public void testDefaultManagerLogsItsOwnEntry() {
+        List<String> messages = capture(DefaultTraceHandleManager.class,
+                () -> new DefaultTraceHandleManager().trace(TraceHandleManagerLogMessageTest.class, "message"));
+
+        assertTrue(messages.contains(" DefaultTraceHandleManager.trace() "),
+                "DefaultTraceHandleManager 로거가 남긴 진입 로그가 자기 클래스·메소드를 가리켜야 한다. 실제 = " + messages);
+    }
+
+    // 사용자가 상속하는 확장점의 기본 구현도 같은 규칙을 따라야 한다.
+    @Test
+    public void testAbstractManagerLogsItsOwnEntry() {
+        List<String> messages = capture(AbstractTraceHandleManager.class,
+                () -> new AbstractTraceHandleManager() {
+                }.trace(TraceHandleManagerLogMessageTest.class, "message"));
+
+        assertTrue(messages.contains(" AbstractTraceHandleManager.trace() "),
+                "AbstractTraceHandleManager 로거가 남긴 진입 로그가 자기 클래스·메소드를 가리켜야 한다. 실제 = " + messages);
+    }
+
+    private List<String> capture(Class<?> loggerOwner, Runnable action) {
+        List<String> messages = new ArrayList<>();
+        AbstractAppender appender = new AbstractAppender("capture", null, null, true, Property.EMPTY_ARRAY) {
+            @Override
+            public void append(LogEvent event) {
+                messages.add(event.getMessage().getFormattedMessage());
+            }
+        };
+        appender.start();
+
+        Logger logger = (Logger) LogManager.getLogger(loggerOwner);
+        logger.addAppender(appender);
+        try {
+            action.run();
+        } finally {
+            logger.removeAppender(appender);
+            appender.stop();
+        }
+        return messages;
+    }
+
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

`DefaultTraceHandleManager` 와 `AbstractTraceHandleManager` 의 `trace()` 는 진입 로그에 다른 클래스의 다른 메소드 이름을 남깁니다.

```java
// DefaultTraceHandleManager.java
private static final Logger LOGGER = LoggerFactory.getLogger(DefaultTraceHandleManager.class);   // :43

public boolean trace(Class<?> clazz, String message) {
    LOGGER.debug(" DefaultExceptionHandleManager.run() ");                                       // :54

// AbstractTraceHandleManager.java
private static final Logger LOGGER = LoggerFactory.getLogger(AbstractTraceHandleManager.class);  // :46

public boolean trace(Class<?> clazz, String message) {
    LOGGER.debug(" DefaultExceptionHandleManager.run() ");                                       // :121
```

두 로거가 각자 자기 클래스로 만들어져 있으므로 출력 한 줄 안에서 로거 이름과 메시지 본문이 서로 다른 클래스를 가리킵니다. 기존 `LeaveaTraceMatcherInjectionTest` 를 돌렸을 때 실제로 찍히는 줄입니다.

```
2026-09-09 13:01:54,305 DEBUG [org.egovframe.rte.fdl.cmmn.trace.manager.DefaultTraceHandleManager]  DefaultExceptionHandleManager.run() 
2026-09-09 13:01:54,310 DEBUG [org.egovframe.rte.fdl.cmmn.trace.manager.DefaultTraceHandleManager] pattern = **, thisPackageName = org.egovframe.rte.fdl.cmmn.trace.LeaveaTraceMatcherInjectionTest
2026-09-09 13:01:54,314 DEBUG [org.egovframe.rte.fdl.cmmn.trace.manager.DefaultTraceHandleManager] pm.match(pattern, getPackageName()) = true
2026-09-09 13:01:54,314 DEBUG [org.egovframe.rte.fdl.cmmn.trace.manager.DefaultTraceHandleManager] trace end?
```

같은 형태의 진입 로그를 쓰는 형제 경로는 자기 클래스·자기 메소드를 적습니다.

```java
// DefaultExceptionHandleManager.java
private static final Logger LOGGER = LoggerFactory.getLogger(DefaultExceptionHandleManager.class);  // :42

public boolean run(Exception exception) throws Exception {
    LOGGER.debug(" DefaultExceptionHandleManager.run() ");                                          // :46
```

복사 흔적도 남아 있습니다. 뒤따르는 매칭 로그는 인자를 trace 쪽으로 바꿔 적었지만(`DefaultTraceHandleManager:60`·`:61` 은 `getPackageName()`, `AbstractTraceHandleManager:127`·`:128` 은 `packageName`) 메시지 문구까지 고친 것은 `DefaultTraceHandleManager:61` 하나뿐입니다. 나머지 세 줄은 예외 쪽 문구를 그대로 두었고, 첫 줄은 인자도 문구도 그대로입니다.

### AS-IS / TO-BE

형제 경로의 형태에 맞춰 문자열 두 줄만 바꿨습니다.

```diff
 // DefaultTraceHandleManager.java
 public boolean trace(Class<?> clazz, String message) {
-    LOGGER.debug(" DefaultExceptionHandleManager.run() ");
+    LOGGER.debug(" DefaultTraceHandleManager.trace() ");
```

```diff
 // AbstractTraceHandleManager.java
 public boolean trace(Class<?> clazz, String message) {
-    LOGGER.debug(" DefaultExceptionHandleManager.run() ");
+    LOGGER.debug(" AbstractTraceHandleManager.trace() ");
```

### 영향 범위

`org.egovframe.rte.fdl.cmmn` 의 trace 매니저 두 곳, 문자열 리터럴 두 줄입니다. 동작·시그니처·로그 레벨은 그대로입니다.

`DefaultTraceHandleManager:54` 는 `LeaveaTrace:146` 이 도달하는 경로라 DEBUG 설정에서 위 출력처럼 찍힙니다. `AbstractTraceHandleManager:121` 은 저장소 안 하위 클래스가 하나뿐이고 그것이 `trace()` 를 재정의하므로 저장소 안에서는 도달하지 않습니다 — 사용자가 상속하는 확장점의 기본 구현이라 함께 맞췄습니다.

예외 쪽 `DefaultExceptionHandleManager:46` 은 자기 클래스·자기 메소드를 적고 있어 손대지 않았습니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

진입 로그가 로거가 달린 클래스와 실행 중인 메소드를 가리키는지 확인하려고 `TraceHandleManagerLogMessageTest` 를 더했습니다. 대상 로거에만 appender 를 잠깐 붙였다 `finally` 에서 뗍니다. `log4j-core` 는 이미 이 모듈의 compile 스코프에 있어 새로 추가한 의존은 없습니다. `AbstractTraceHandleManager` 는 익명 하위 클래스로 기본 구현을 직접 호출해 확인합니다.

수정을 포함한 모듈 전체 실행입니다.

```
$ mvn -pl Foundation/org.egovframe.rte.fdl.cmmn test
[...]
[INFO] Tests run: 44, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
```

문자열 두 줄만 되돌리면 같은 44건 중 두 건이 실패합니다.

```
$ sed -i.bak 's/" DefaultTraceHandleManager.trace() "/" DefaultExceptionHandleManager.run() "/' \
    Foundation/org.egovframe.rte.fdl.cmmn/src/main/java/org/egovframe/rte/fdl/cmmn/trace/manager/DefaultTraceHandleManager.java
$ sed -i.bak 's/" AbstractTraceHandleManager.trace() "/" DefaultExceptionHandleManager.run() "/' \
    Foundation/org.egovframe.rte.fdl.cmmn/src/main/java/org/egovframe/rte/fdl/cmmn/trace/manager/AbstractTraceHandleManager.java
$ mvn -pl Foundation/org.egovframe.rte.fdl.cmmn test
[...]
[ERROR] Failures: 
[ERROR]   TraceHandleManagerLogMessageTest.testAbstractManagerLogsItsOwnEntry:34 AbstractTraceHandleManager 로거가 남긴 진입 로그가 자기 클래스·메소드를 가리켜야 한다. 실제 = [ DefaultExceptionHandleManager.run() ] ==> expected: <true> but was: <false>
[ERROR]   TraceHandleManagerLogMessageTest.testDefaultManagerLogsItsOwnEntry:23 DefaultTraceHandleManager 로거가 남긴 진입 로그가 자기 클래스·메소드를 가리켜야 한다. 실제 = [ DefaultExceptionHandleManager.run() ] ==> expected: <true> but was: <false>
[ERROR] Tests run: 44, Failures: 2, Errors: 0, Skipped: 0
```

실패한 두 건은 이번에 더한 테스트이고 나머지 42건은 그대로 통과합니다.

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

해당 없음 — 화면이 아닌 라이브러리 클래스입니다.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

해당 없음 — 위 로그 출력과 JUnit 결과로 갈음합니다.
