### PR TITLE
fix: EgovWebServiceClassLoaderImpl.loadClass(Type) 의 디버그 로그가 다른 메서드 이름을 알리는 문제 수정

### DIFF
--- a/Integration/org.egovframe.rte.itl.webservice/src/main/java/org/egovframe/rte/itl/webservice/service/impl/EgovWebServiceClassLoaderImpl.java
+++ b/Integration/org.egovframe.rte.itl.webservice/src/main/java/org/egovframe/rte/itl/webservice/service/impl/EgovWebServiceClassLoaderImpl.java
@@ -171,41 +171,41 @@ public class EgovWebServiceClassLoaderImpl extends ClassLoader implements EgovWe
     }
 
     public Class<?> loadClass(final Type type) throws ClassNotFoundException {
-        LOGGER.debug("### EgovWebServiceClassLoaderImpl getFieldNameOfServiceBridge() loadClass of Type ({})", type);
+        LOGGER.debug("### EgovWebServiceClassLoaderImpl loadClass() loadClass of Type ({})", type);
 
         if (type == EgovWebServiceMessageHeader.TYPE) {
-            LOGGER.debug("### EgovWebServiceClassLoaderImpl getFieldNameOfServiceBridge() Type is EgovWebServiceMessageHeader.");
+            LOGGER.debug("### EgovWebServiceClassLoaderImpl loadClass() Type is EgovWebServiceMessageHeader.");
             return EgovWebServiceMessageHeader.class;
         }
 
         if (type instanceof PrimitiveType) {
-            LOGGER.debug("### EgovWebServiceClassLoaderImpl getFieldNameOfServiceBridge() Type is a Primitive Type");
+            LOGGER.debug("### EgovWebServiceClassLoaderImpl loadClass() Type is a Primitive Type");
             Class<?> clazz = primitiveClasses.get((PrimitiveType) type);
             if (clazz == null) {
-                LOGGER.debug("### EgovWebServiceClassLoaderImpl getFieldNameOfServiceBridge() No such primitive type");
+                LOGGER.debug("### EgovWebServiceClassLoaderImpl loadClass() No such primitive type");
                 throw new ClassNotFoundException();
             }
             return clazz;
         } else if (type instanceof ListType) {
-            LOGGER.debug("### EgovWebServiceClassLoaderImpl getFieldNameOfServiceBridge() Type is a List Type");
+            LOGGER.debug("### EgovWebServiceClassLoaderImpl loadClass() Type is a List Type");
             ListType listType = (ListType) type;
             Class<?> elementClass = loadClass(listType.getElementType());
             return Array.newInstance(elementClass, 0).getClass();
         } else if (type instanceof RecordType) {
-            LOGGER.debug("### EgovWebServiceClassLoaderImpl getFieldNameOfServiceBridge() Type is a Record Type");
+            LOGGER.debug("### EgovWebServiceClassLoaderImpl loadClass() Type is a Record Type");
             RecordType recordType = (RecordType) type;
             String className = getRecordTypeClassName(recordType.getName());
             try {
-                LOGGER.debug("### EgovWebServiceClassLoaderImpl getFieldNameOfServiceBridge() Check the class \"{}\" is already loaded.", className);
+                LOGGER.debug("### EgovWebServiceClassLoaderImpl loadClass() Check the class \"{}\" is already loaded.", className);
                 return loadClass(className);
             } catch (ClassNotFoundException e) {
-                LOGGER.debug("### EgovWebServiceClassLoaderImpl getFieldNameOfServiceBridge() Create a new class \"{}\"", className);
+                LOGGER.debug("### EgovWebServiceClassLoaderImpl loadClass() Create a new class \"{}\"", className);
                 byte[] byteCode = createRecordClass(className, recordType);
                 return defineClass(className, byteCode, 0, byteCode.length);
             }
         }
 
-        LOGGER.debug("### EgovWebServiceClassLoaderImpl getFieldNameOfServiceBridge() Type is invalid");
+        LOGGER.debug("### EgovWebServiceClassLoaderImpl loadClass() Type is invalid");
         throw new ClassNotFoundException();
     }
 


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

`EgovWebServiceClassLoaderImpl` 의 DEBUG 로그는 `### <클래스명> <메서드명>() <내용>` 형식입니다. 로거 이름은 클래스까지만 알려주므로, 어느 메서드가 찍은 줄인지는 메시지 안의 메서드 이름으로만 알 수 있습니다.

그런데 `loadClass(Type)`(선언 173행) 본문의 로그 9줄(174·177·182·185·190·195·199·202·208)이 자기 이름 대신 `getFieldNameOfServiceBridge()` 를 씁니다. 같은 파일의 `loadClass(ServiceEndpointInfo)`(212)·`loadClass(ServiceEndpointInterfaceInfo)`(230) 는 10줄 모두 `loadClass()` 로 자기 이름을 씁니다.

이름 자리에만 잘못 들어갔다는 흔적이 174행에 그대로 남아 있습니다.

```java
LOGGER.debug("### EgovWebServiceClassLoaderImpl getFieldNameOfServiceBridge() loadClass of Type ({})", type);
```

메서드 이름 자리는 `getFieldNameOfServiceBridge()` 인데 뒤따르는 내용이 `loadClass of Type` 이라, 한 줄이 두 이름을 겹쳐 부릅니다. v4.3.0 까지 이 줄은 접두사 없이 `LOGGER.debug("loadClass of Type ({})", type);` 였습니다. v5.0.0 에서 접두사를 붙이면서 이름만 어긋났습니다.

`getFieldNameOfServiceBridge()`(169행)는 상수 하나를 돌려주고 로그를 한 줄도 남기지 않습니다. 그래서 콘솔에 찍힌 이름으로 코드를 찾으면 그 줄을 찍은 적 없는 메서드로 갑니다.

### AS-IS / TO-BE

```diff
-        LOGGER.debug("### EgovWebServiceClassLoaderImpl getFieldNameOfServiceBridge() Type is a Primitive Type");
+        LOGGER.debug("### EgovWebServiceClassLoaderImpl loadClass() Type is a Primitive Type");
```

나머지 8줄도 메서드 이름 자리만 같은 방식으로 바꿨습니다.

### 영향 범위

문자열 리터럴 9줄뿐입니다. 동작 경로·시그니처·로그 레벨은 그대로이고 `1 file changed, 9 insertions(+), 9 deletions(-)` 입니다.

이 메서드는 `MessageConverterImpl:85`·`:100`·`:139`, `EgovWebServiceClientImpl:193`, 그리고 같은 파일 안의 재귀 호출로 진입합니다.

## JUnit 테스트 JUnit tests

- [ ] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

기존 `EgovWebServiceClassLoaderImplTest` 3건이 `loadClass(ServiceEndpointInfo)` 를 거쳐 `loadClass(Type)` 에 실제로 들어가므로, 모듈 테스트 로그 레벨만 올려 콘솔에 찍히는 줄을 수정 전후로 대조했습니다. 이 모듈의 `src/test/resources/log4j2.xml` 은 `<Root level="ERROR">` 라 그대로는 DEBUG 줄이 나오지 않습니다.

```
cd Integration/org.egovframe.rte.itl.webservice
sed -i.bak 's|<Root level="ERROR">|<Root level="DEBUG">|' src/test/resources/log4j2.xml
mvn -pl . -am test -Dtest=EgovWebServiceClassLoaderImplTest -Dsurefire.failIfNoSpecifiedTests=false \
  | grep 'EgovWebServiceClassLoaderImpl\]' | head -9
mv src/test/resources/log4j2.xml.bak src/test/resources/log4j2.xml
```

수정 전 출력의 6~8행입니다. 같은 호출 사슬인데 한 줄 넘어가면서 메서드 이름이 바뀝니다.

```
[...]
2026-09-09 13:04:03,026 DEBUG [org.egovframe.rte.itl.webservice.service.impl.EgovWebServiceClassLoaderImpl] ### EgovWebServiceClassLoaderImpl loadClass() Load param type (org.egovframe.rte.itl.integration.type.RecordType {id = '__egovWebServiceMessageHeader__'})
2026-09-09 13:04:03,026 DEBUG [org.egovframe.rte.itl.webservice.service.impl.EgovWebServiceClassLoaderImpl] ### EgovWebServiceClassLoaderImpl getFieldNameOfServiceBridge() loadClass of Type (org.egovframe.rte.itl.integration.type.RecordType {id = '__egovWebServiceMessageHeader__'})
2026-09-09 13:04:03,026 DEBUG [org.egovframe.rte.itl.webservice.service.impl.EgovWebServiceClassLoaderImpl] ### EgovWebServiceClassLoaderImpl getFieldNameOfServiceBridge() Type is EgovWebServiceMessageHeader.
[...]
```

수정 후 같은 자리입니다.

```
[...]
2026-09-09 13:04:39,009 DEBUG [org.egovframe.rte.itl.webservice.service.impl.EgovWebServiceClassLoaderImpl] ### EgovWebServiceClassLoaderImpl loadClass() Load param type (org.egovframe.rte.itl.integration.type.RecordType {id = '__egovWebServiceMessageHeader__'})
2026-09-09 13:04:39,009 DEBUG [org.egovframe.rte.itl.webservice.service.impl.EgovWebServiceClassLoaderImpl] ### EgovWebServiceClassLoaderImpl loadClass() loadClass of Type (org.egovframe.rte.itl.integration.type.RecordType {id = '__egovWebServiceMessageHeader__'})
2026-09-09 13:04:39,009 DEBUG [org.egovframe.rte.itl.webservice.service.impl.EgovWebServiceClassLoaderImpl] ### EgovWebServiceClassLoaderImpl loadClass() Type is EgovWebServiceMessageHeader.
[...]
```

같은 실행에서 잘못된 이름으로 찍히던 줄은 54줄에서 0줄이 됩니다.

모듈 전체는 수정 전후가 같습니다.

```
$ mvn -pl Integration/org.egovframe.rte.itl.webservice test
[...]
[INFO] Tests run: 22, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```

로그 문구를 단언하는 테스트는 추가하지 않았습니다. 이 모듈에는 로그 캡처 어펜더 의존이 없어 하네스를 새로 들여야 합니다. 그 비용이 문자열 9줄 수정보다 큽니다.

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

화면이 없는 연계통합 모듈이라 첨부하지 않았습니다.
