### PR TITLE
feat: 안전 경로 부품을 조립한 참조 구현 EgovFileStore 추가

### DIFF
--- a/Foundation/org.egovframe.rte.fdl.filehandling/src/main/java/org/egovframe/rte/fdl/filehandling/upload/EgovFileStore.java
+++ b/Foundation/org.egovframe.rte.fdl.filehandling/src/main/java/org/egovframe/rte/fdl/filehandling/upload/EgovFileStore.java
@@ -1,0 +1,364 @@
+/*
+ * Copyright 2009-2026 MOIS(Ministry of the Interior and Safety).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.egovframe.rte.fdl.filehandling.upload;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+
+import org.egovframe.rte.fdl.filehandling.EgovFiles;
+
+/**
+ * 신뢰 루트 위에서 업로드 파일의 <b>저장·재검증·삭제</b>를 한 번에 맡는 참조 구현.
+ *
+ * <p><b>NOTE:</b> 안전 경로 부품(저장명 {@link EgovStoredFileNames}, 경로 확정
+ * {@link EgovFiles#resolveSecurely(Path, String)}·{@link EgovFiles#requireContainedIn(String, Path...)},
+ * 정책 {@link EgovUploadPolicy})을 <b>올바른 순서로 조립</b>한 것이며 새 규칙을 두지 않는다.
+ * 개발자가 매번 네 부품을 직접 엮지 않도록 하는 것이 목적이다. 웹 타입에 의존하지 않으므로
+ * 컨트롤러·서비스·배치·리액티브 어디서나 같은 조립을 쓴다.</p>
+ *
+ * <pre>
+ * EgovFileStore store = EgovFileStore.builder()
+ *         .root("store", Paths.get("/data/upload"))        // 첫 루트 = 기본 루트
+ *         .root("image", Paths.get("/data/image"))
+ *         .policy(uploadPolicy)                             // 선택 — 이름·크기 검증 위임
+ *         .build();
+ *
+ * // 업로드
+ * EgovStoredFile stored = store.store(file.getInputStream(), file.getOriginalFilename());
+ * // → DB 에는 stored.getRootKey()·getStoredName()·getOriginalName() 을 보관
+ *
+ * // 다운로드 — 읽는 시점에 다시 검증한다
+ * Path verified = store.resolve(attach.getRootKey(), attach.getStoredName());
+ * response.setHeader("Content-Disposition", EgovContentDispositions.attachment(attach.getOriginalName()));
+ * Files.copy(verified, response.getOutputStream());
+ * </pre>
+ *
+ * <p><b>허용 루트는 설정에서 오는 신뢰 값이어야 한다.</b> 루트가 하나도 없으면 만들 수 없다
+ * (fail-closed). 저장·해석·삭제의 모든 경로는 루트 중 하나의 내부여야 하며, 벗어나면
+ * {@link IllegalArgumentException} 이다.</p>
+ *
+ * <p><b>원본 이름은 경로에 쓰이지 않는다.</b> 저장명은 새로 만들고(확장자만 보존) 원본 이름은
+ * 결과 값으로 돌려줄 뿐이다. 따라서 {@code ../../etc/passwd.txt} 같은 이름이 와도 루트 바로
+ * 아래에 {@code <무작위>.txt} 로 놓인다.</p>
+ *
+ * <p><b>정책은 선택이며, 지정하지 않으면 이름·크기를 검증하지 않는다.</b> 웹 계층에서
+ * {@code ptl.mvc} 어댑터로 이미 검증했다면 생략할 수 있지만, 서비스 계층 스토어에도 정책을
+ * 붙여 두면 두 번 검증되어도 무해하고 우회 경로가 막힌다. 정책이 있으면 크기는 <b>실제로 기록된
+ * 바이트 수</b>로 검증하며(선언 크기는 믿지 않는다), 위반이면 방금 쓴 파일을 지우고
+ * {@link EgovUploadRejectedException} 을 던진다 — 부분 저장물은 남지 않는다.</p>
+ *
+ * <p><b>재검증 두 형태.</b> {@link #resolve(String, String)}(루트 키 + 저장명)가 권장 형태이고,
+ * {@link #resolve(String)}(보관된 전체 경로)는 전체 경로를 DB 컬럼에 보관해 온 관행을 이전 기간
+ * 동안 수용하기 위한 것이다. 두 형태 모두 루트 밖이면 거부한다. 재검증은 경로 포함 여부만
+ * 판정하며 파일 존재 여부는 호출자가 본다.</p>
+ *
+ * <p><b>한계.</b> 저장 시점의 경로 검증은 어휘적(lexical) 정규화 기반이지만 저장명이 무작위라 링크를 미리 심을
+ * 자리가 없고, 읽기·삭제 시점에는 실재하는 경로의 <b>실경로</b>가 루트 안인지 다시 확인하므로 루트 안에
+ * 심긴 심볼릭 링크를 따라 밖을 읽거나 지우지 않는다. 저장은 루트 바로 아래 평면 배치이며, 하위
+ * 디렉터리 단위로 나누려면 그 디렉터리를 별도 루트로 등록한다.</p>
+ *
+ * <pre>
+ * &lt;&lt; 개정이력(Modification Information) &gt;&gt;
+ *
+ *  수정일        수정자        수정내용
+ *  ----------  --------    ---------------------------
+ *  2026.09.02  실행환경팀     최초 생성 (공통컴포넌트
+ *                            EgovFileMngUtil.parseFileInf 의 조립 역할을 차용하되
+ *                            문자 삭제형 경로 방어·시각 기반 저장명·다운로드 시 DB 경로
+ *                            무검증을 부품 위임으로 재구성 — 코드 이식 아님)
+ * </pre>
+ *
+ * @author 실행환경 개발팀
+ * @since 5.1
+ */
+public final class EgovFileStore {
+
+	/** 이름·확장자만으로 판정되는 정책 사유 — 크기를 모르는 시점의 선행 검사에 쓴다. */
+	private static final Set<EgovUploadPolicy.Reason> NAME_REASONS = Collections.unmodifiableSet(EnumSet.of(
+			EgovUploadPolicy.Reason.NO_FILENAME, EgovUploadPolicy.Reason.INVALID_FILENAME,
+			EgovUploadPolicy.Reason.NO_EXTENSION, EgovUploadPolicy.Reason.EXTENSION_NOT_ALLOWED));
+
+	private final Map<String, Path> roots;
+	private final String defaultRootKey;
+	private final EgovUploadPolicy policy;
+	private final boolean keepExtension;
+
+	private EgovFileStore(Builder builder) {
+		if (builder.roots.isEmpty()) {
+			throw new IllegalArgumentException("at least one root directory is required (fail-closed)");
+		}
+		this.roots = Collections.unmodifiableMap(new LinkedHashMap<>(builder.roots));
+		this.defaultRootKey = roots.keySet().iterator().next();
+		this.policy = builder.policy;
+		this.keepExtension = builder.keepExtension;
+	}
+
+	public static Builder builder() {
+		return new Builder();
+	}
+
+	// ------------------------------------------------------------------ store
+
+	/** 기본(첫 번째) 루트에 저장한다. 스트림은 끝까지 읽되 닫지 않는다(호출자 소유). */
+	public EgovStoredFile store(InputStream source, String originalName) {
+		return store(defaultRootKey, source, originalName);
+	}
+
+	/** 지정 루트에 저장한다. 스트림은 끝까지 읽되 닫지 않는다(호출자 소유). */
+	public EgovStoredFile store(String rootKey, InputStream source, String originalName) {
+		Objects.requireNonNull(source, "source must not be null");
+		Path root = rootOf(rootKey);
+		precheckName(originalName);
+		Path target = prepareTarget(root, originalName);
+		long size;
+		try {
+			size = Files.copy(source, target);
+		} catch (IOException e) {
+			throw new UncheckedIOException("Failed to store uploaded file into " + root, e);
+		}
+		validateSizeOrDelete(originalName, size, target);
+		return new EgovStoredFile(rootKey, target.getFileName().toString(), target, originalName, size);
+	}
+
+	/** 기본(첫 번째) 루트에 기존 파일을 복사해 저장한다. 원본 파일은 그대로 둔다. */
+	public EgovStoredFile store(Path source, String originalName) {
+		return store(defaultRootKey, source, originalName);
+	}
+
+	/** 지정 루트에 기존 파일을 복사해 저장한다. 크기는 복사 전에 정책으로 거른다. */
+	public EgovStoredFile store(String rootKey, Path source, String originalName) {
+		Objects.requireNonNull(source, "source must not be null");
+		Path root = rootOf(rootKey);
+		long declared;
+		try {
+			declared = Files.size(source);
+		} catch (IOException e) {
+			throw new UncheckedIOException("Failed to read size of " + source, e);
+		}
+		if (policy != null) {
+			policy.validate(originalName, declared);
+		}
+		Path target = prepareTarget(root, originalName);
+		long size;
+		try {
+			Files.copy(source, target);
+			size = Files.size(target);
+		} catch (IOException e) {
+			throw new UncheckedIOException("Failed to store file " + source + " into " + root, e);
+		}
+		validateSizeOrDelete(originalName, size, target);
+		return new EgovStoredFile(rootKey, target.getFileName().toString(), target, originalName, size);
+	}
+
+	// ---------------------------------------------------------------- resolve
+
+	/**
+	 * 루트 키 + 저장명으로 읽기 경로를 확정한다(권장 형태). 루트 밖이거나, 실재하는 경로가 심볼릭 링크를
+	 * 거쳐 루트 밖을 가리키면 {@link IllegalArgumentException}.
+	 */
+	public Path resolve(String rootKey, String storedName) {
+		return requireRealPathInside(EgovFiles.resolveSecurely(rootOf(rootKey), storedName));
+	}
+
+	/**
+	 * 보관된 전체 경로 문자열을 허용 루트 전체에 대해 재검증한다(이전 기간 호환 형태).
+	 * 루트 밖·해석 불가·널 바이트이거나, 실재하는 경로가 심볼릭 링크를 거쳐 루트 밖을 가리키면
+	 * {@link IllegalArgumentException}.
+	 */
+	public Path resolve(String storedPath) {
+		return requireRealPathInside(EgovFiles.requireContainedIn(storedPath, rootArray()));
+	}
+
+	/** 저장 결과의 경로가 여전히 허용 루트 안인지(실경로 포함) 확인해 돌려준다. */
+	public Path resolve(EgovStoredFile stored) {
+		Objects.requireNonNull(stored, "stored must not be null");
+		return requireRealPathInside(EgovFiles.requireContainedIn(stored.getPath(), rootArray()));
+	}
+
+	// ----------------------------------------------------------------- delete
+
+	/** 검증 뒤 삭제한다. 지운 파일이 있으면 true, 이미 없으면 false. 루트 밖이거나 링크를 거치면 예외. */
+	public boolean delete(String rootKey, String storedName) {
+		return deleteVerified(resolve(rootKey, storedName));
+	}
+
+	/** 보관된 전체 경로를 검증 뒤 삭제한다. 루트 밖이면 예외이며 파일시스템에 영향이 없다. */
+	public boolean delete(String storedPath) {
+		return deleteVerified(resolve(storedPath));
+	}
+
+	/** 저장 결과를 검증 뒤 삭제한다. */
+	public boolean delete(EgovStoredFile stored) {
+		return deleteVerified(resolve(stored));
+	}
+
+	// ------------------------------------------------------------------ query
+
+	/** 등록된 허용 루트(키 → 정규화된 절대 경로, 등록 순서). */
+	public Map<String, Path> roots() {
+		return roots;
+	}
+
+	/** 기본 루트 키(첫 번째로 등록한 루트). */
+	public String defaultRootKey() {
+		return defaultRootKey;
+	}
+
+	/** 지정된 정책(없으면 빈 값). */
+	public Optional<EgovUploadPolicy> policy() {
+		return Optional.ofNullable(policy);
+	}
+
+	// --------------------------------------------------------------- internal
+
+	/**
+	 * 어휘적 봉쇄를 통과한 경로가 <b>실재</b>하면 실경로로도 허용 루트 안인지 재확인한다 — 루트 안에 미리 심긴
+	 * 심볼릭 링크를 따라 밖을 읽거나 지우는 일을 막는다. 아직 없는 경로는 어휘적 검사로 충분하다.
+	 */
+	private Path requireRealPathInside(Path lexical) {
+		if (!Files.exists(lexical, LinkOption.NOFOLLOW_LINKS)) {
+			return lexical;
+		}
+		if (Files.isSymbolicLink(lexical)) {
+			throw new IllegalArgumentException(
+					"stored path is a symbolic link (link traversal blocked): " + lexical.getFileName());
+		}
+		try {
+			Path real = lexical.toRealPath();
+			for (Path root : roots.values()) {
+				if (Files.isDirectory(root) && real.startsWith(root.toRealPath())) {
+					return lexical;
+				}
+			}
+		} catch (IOException e) {
+			throw new UncheckedIOException("Failed to resolve the real path of " + lexical.getFileName(), e);
+		}
+		throw new IllegalArgumentException(
+				"stored path resolves outside the allowed roots (link traversal blocked): " + lexical.getFileName());
+	}
+
+	private Path rootOf(String rootKey) {
+		Path root = roots.get(rootKey);
+		if (root == null) {
+			throw new IllegalArgumentException(
+					"unknown root key: " + rootKey + " (registered: " + roots.keySet() + ")");
+		}
+		return root;
+	}
+
+	private Path[] rootArray() {
+		return roots.values().toArray(new Path[0]);
+	}
+
+	/** 크기를 모르는 시점의 선행 검사 — 이름·확장자 사유만 정책에 묻는다(크기 사유는 기록 후 판정). */
+	private void precheckName(String originalName) {
+		if (policy == null) {
+			return;
+		}
+		policy.check(originalName, 1L).filter(NAME_REASONS::contains).ifPresent(reason -> {
+			throw new EgovUploadRejectedException(reason, originalName);
+		});
+	}
+
+	private Path prepareTarget(Path root, String originalName) {
+		String storedName = keepExtension
+				? EgovStoredFileNames.generate(originalName)
+				: EgovStoredFileNames.generateWithoutExtension();
+		Path target = EgovFiles.resolveSecurely(root, storedName);
+		try {
+			Files.createDirectories(root);
+		} catch (IOException e) {
+			throw new UncheckedIOException("Failed to prepare root directory " + root, e);
+		}
+		return target;
+	}
+
+	private void validateSizeOrDelete(String originalName, long size, Path target) {
+		if (policy == null) {
+			return;
+		}
+		Optional<EgovUploadPolicy.Reason> reason = policy.check(originalName, size);
+		if (reason.isPresent()) {
+			try {
+				Files.deleteIfExists(target);
+			} catch (IOException e) {
+				throw new UncheckedIOException("Rejected by policy (" + reason.get()
+						+ ") but failed to remove partial file " + target, e);
+			}
+			throw new EgovUploadRejectedException(reason.get(), originalName);
+		}
+	}
+
+	private static boolean deleteVerified(Path verified) {
+		try {
+			return Files.deleteIfExists(verified);
+		} catch (IOException e) {
+			throw new UncheckedIOException("Failed to delete " + verified, e);
+		}
+	}
+
+	// ---------------------------------------------------------------- builder
+
+	/** {@link EgovFileStore} 빌더. 루트는 등록 순서를 유지하며 첫 번째가 기본 루트다. */
+	public static final class Builder {
+		private final Map<String, Path> roots = new LinkedHashMap<>();
+		private EgovUploadPolicy policy;
+		private boolean keepExtension = true;
+
+		private Builder() {
+		}
+
+		/** 허용 루트를 등록한다. 같은 키를 다시 등록하면 예외(설정 중복은 실수다). */
+		public Builder root(String key, Path directory) {
+			if (key == null || key.trim().isEmpty()) {
+				throw new IllegalArgumentException("root key must not be null or empty");
+			}
+			Objects.requireNonNull(directory, "root directory must not be null");
+			if (roots.containsKey(key)) {
+				throw new IllegalArgumentException("duplicate root key: " + key);
+			}
+			roots.put(key, directory.toAbsolutePath().normalize());
+			return this;
+		}
+
+		/** 이름·크기 검증을 위임할 정책(선택). 미지정이면 검증하지 않는다. */
+		public Builder policy(EgovUploadPolicy policy) {
+			this.policy = policy;
+			return this;
+		}
+
+		/** 저장명에 원본 확장자를 보존할지(기본 true). false 면 확장자 없는 저장명. */
+		public Builder keepExtension(boolean keepExtension) {
+			this.keepExtension = keepExtension;
+			return this;
+		}
+
+		public EgovFileStore build() {
+			return new EgovFileStore(this);
+		}
+	}
+}

--- a/Foundation/org.egovframe.rte.fdl.filehandling/src/main/java/org/egovframe/rte/fdl/filehandling/upload/EgovStoredFile.java
+++ b/Foundation/org.egovframe.rte.fdl.filehandling/src/main/java/org/egovframe/rte/fdl/filehandling/upload/EgovStoredFile.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2009-2026 MOIS(Ministry of the Interior and Safety).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.egovframe.rte.fdl.filehandling.upload;
+
+import java.nio.file.Path;
+import java.util.Objects;
+
+/**
+ * {@link EgovFileStore} 가 파일을 저장한 결과를 담는 <b>불변 값</b>.
+ *
+ * <p><b>NOTE:</b> 애플리케이션은 이 값에서 <b>루트 키와 저장명</b>을 보관해 두었다가
+ * 다운로드 시 {@link EgovFileStore#resolve(String, String)} 로 경로를 다시 확정한다.
+ * 원본 이름은 화면 표시·{@code Content-Disposition} 용도로만 보관하고 경로에는 쓰지
+ * 않는다(저장 경로에는 확장자 외에 원본 이름의 어떤 부분도 들어가지 않는다).</p>
+ *
+ * <pre>
+ * EgovStoredFile stored = store.store(in, file.getOriginalFilename());
+ * attachRepository.save(new Attach(stored.getRootKey(), stored.getStoredName(),
+ *                                  stored.getOriginalName(), stored.getSize()));
+ * </pre>
+ *
+ * <pre>
+ * &lt;&lt; 개정이력(Modification Information) &gt;&gt;
+ *
+ *  수정일        수정자        수정내용
+ *  ----------  --------    ---------------------------
+ *  2026.09.02  실행환경팀     최초 생성 (저장 결과 값 객체)
+ * </pre>
+ *
+ * @author 실행환경 개발팀
+ * @since 5.1
+ */
+public final class EgovStoredFile {
+
+	private final String rootKey;
+	private final String storedName;
+	private final Path path;
+	private final String originalName;
+	private final long size;
+
+	EgovStoredFile(String rootKey, String storedName, Path path, String originalName, long size) {
+		this.rootKey = Objects.requireNonNull(rootKey, "rootKey must not be null");
+		this.storedName = Objects.requireNonNull(storedName, "storedName must not be null");
+		this.path = Objects.requireNonNull(path, "path must not be null");
+		this.originalName = originalName;
+		this.size = size;
+	}
+
+	/** 저장된 허용 루트의 키. */
+	public String getRootKey() {
+		return rootKey;
+	}
+
+	/** 새로 만든 저장 파일명(루트 바로 아래, 확장자 보존). DB 에 보관하는 값이다. */
+	public String getStoredName() {
+		return storedName;
+	}
+
+	/** 저장 시점에 확정된 절대 경로(정규화됨). */
+	public Path getPath() {
+		return path;
+	}
+
+	/** 호출자가 준 원본 이름 그대로(null 가능). 경로에는 쓰이지 않는다. */
+	public String getOriginalName() {
+		return originalName;
+	}
+
+	/** 실제로 기록된 바이트 수. */
+	public long getSize() {
+		return size;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (!(o instanceof EgovStoredFile)) {
+			return false;
+		}
+		EgovStoredFile that = (EgovStoredFile) o;
+		return size == that.size && rootKey.equals(that.rootKey) && storedName.equals(that.storedName)
+				&& path.equals(that.path) && Objects.equals(originalName, that.originalName);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(rootKey, storedName, path, originalName, size);
+	}
+
+	@Override
+	public String toString() {
+		return "EgovStoredFile[root=" + rootKey + ", storedName=" + storedName + ", path=" + path
+				+ ", originalName=" + originalName + ", size=" + size + "]";
+	}
+}

--- a/Foundation/org.egovframe.rte.fdl.filehandling/src/test/java/org/egovframe/rte/fdl/filehandling/upload/EgovFileStoreSecurityTest.java
+++ b/Foundation/org.egovframe.rte.fdl.filehandling/src/test/java/org/egovframe/rte/fdl/filehandling/upload/EgovFileStoreSecurityTest.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2009-2026 MOIS(Ministry of the Interior and Safety).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.egovframe.rte.fdl.filehandling.upload;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * EgovFileStore 의 <b>심볼릭 링크</b> 경계 검증(CWE-59).
+ *
+ * <p>루트 안에 밖을 가리키는 링크가 <b>미리 심겨 있다</b>는 전제(운영 규칙 위반)에서 저장·읽기·삭제가
+ * 경계 밖을 건드리지 않음을 고정한다. 저장은 무작위 저장명이라 링크를 심을 자리가 없고, 읽기·삭제는
+ * 실재하는 경로의 실경로를 루트와 대조해 링크를 거부한다. 링크 생성은 Windows 에서 권한이 필요하므로
+ * 링크 테스트는 POSIX 계열에서만 실행한다.</p>
+ *
+ * <pre>
+ * &lt;&lt; 개정이력(Modification Information) &gt;&gt;
+ *
+ *  수정일        수정자        수정내용
+ *  ----------  --------    ---------------------------
+ *  2026.09.07  실행환경팀     최초 생성
+ * </pre>
+ *
+ * @author 실행환경 개발팀
+ * @since 5.1
+ */
+class EgovFileStoreSecurityTest {
+
+	@TempDir
+	Path tempDir;
+
+	private Path root;
+	private Path outside;
+	private Path secret;
+
+	private void plant() throws IOException {
+		root = Files.createDirectories(tempDir.resolve("root"));
+		outside = Files.createDirectories(tempDir.resolve("outside"));
+		secret = Files.write(outside.resolve("secret.txt"), "TOP-SECRET".getBytes(StandardCharsets.UTF_8));
+		link(root.resolve("flink"), secret);
+		link(root.resolve("dlink"), outside);
+	}
+
+	private static void link(Path at, Path to) {
+		try {
+			Files.createSymbolicLink(at, to);
+		} catch (UnsupportedOperationException | IOException e) {
+			assumeTrue(false, "이 파일시스템에서는 심볼릭 링크를 만들 수 없다: " + e);
+		}
+	}
+
+	@Test
+	@DisplayName("store 는 무작위 저장명이라 링크를 미리 심을 자리가 없고, 저장 결과는 루트 실경로 안이다")
+	void store_는_무작위_저장명이라_링크를_미리_심을_자리가_없다() throws IOException {
+		root = Files.createDirectories(tempDir.resolve("root"));
+		EgovFileStore store = EgovFileStore.builder().root("up", root).build();
+
+		EgovStoredFile a = store.store(new ByteArrayInputStream("a".getBytes(StandardCharsets.UTF_8)), "x.txt");
+		EgovStoredFile b = store.store(new ByteArrayInputStream("b".getBytes(StandardCharsets.UTF_8)), "x.txt");
+
+		assertFalse(a.getStoredName().equals(b.getStoredName()), "같은 원본명도 다른 저장명");
+		assertTrue(a.getPath().toRealPath().startsWith(root.toRealPath()));
+		assertTrue(a.getStoredName().matches("[0-9a-f]{32}\\.txt"), "예측 불가 UUID 저장명");
+	}
+
+	@Test
+	@DisabledOnOs(OS.WINDOWS)
+	@DisplayName("resolve 는 루트 안의 링크가 밖을 가리키면 거부한다 — 파일 링크와 디렉터리 링크 모두")
+	void resolve_는_밖을_가리키는_링크를_거부한다() throws IOException {
+		plant();
+		EgovFileStore store = EgovFileStore.builder().root("up", root).build();
+
+		assertThrows(IllegalArgumentException.class, () -> store.resolve("up", "flink"));
+		assertThrows(IllegalArgumentException.class, () -> store.resolve("up", "dlink/secret.txt"));
+		assertThrows(IllegalArgumentException.class, () -> store.resolve(root.resolve("flink").toString()));
+	}
+
+	@Test
+	@DisabledOnOs(OS.WINDOWS)
+	@DisplayName("delete 는 밖을 가리키는 링크를 거부하고, 링크도 링크 대상도 건드리지 않는다")
+	void delete_는_링크를_거부하고_링크_대상을_지우지_않는다() throws IOException {
+		plant();
+		EgovFileStore store = EgovFileStore.builder().root("up", root).build();
+
+		assertThrows(IllegalArgumentException.class, () -> store.delete("up", "flink"));
+
+		assertTrue(Files.exists(root.resolve("flink"), LinkOption.NOFOLLOW_LINKS), "링크는 그대로 남는다(정리는 운영자 몫)");
+		assertTrue(Files.exists(secret), "링크 대상(경계 밖)은 생존");
+		assertEquals("TOP-SECRET", new String(Files.readAllBytes(secret), StandardCharsets.UTF_8));
+	}
+
+	@Test
+	@DisabledOnOs(OS.WINDOWS)
+	@DisplayName("루트 자체가 링크로 마운트된 정상 배치는 실경로 재확인에 걸리지 않는다 — 오탐 방지")
+	void 루트가_링크인_정상_배치는_통과한다() throws IOException {
+		Path realRoot = Files.createDirectories(tempDir.resolve("volume").resolve("upload"));
+		Path linkedRoot = tempDir.resolve("root-link");
+		link(linkedRoot, realRoot);
+		EgovFileStore store = EgovFileStore.builder().root("up", linkedRoot).build();
+
+		EgovStoredFile saved = store.store(new ByteArrayInputStream("ok".getBytes(StandardCharsets.UTF_8)), "ok.txt");
+
+		Path resolved = store.resolve("up", saved.getStoredName());
+		assertEquals("ok", new String(Files.readAllBytes(resolved), StandardCharsets.UTF_8));
+		assertTrue(store.delete("up", saved.getStoredName()));
+	}
+}

--- a/Foundation/org.egovframe.rte.fdl.filehandling/src/test/java/org/egovframe/rte/fdl/filehandling/upload/EgovFileStoreTest.java
+++ b/Foundation/org.egovframe.rte.fdl.filehandling/src/test/java/org/egovframe/rte/fdl/filehandling/upload/EgovFileStoreTest.java
@@ -1,0 +1,262 @@
+package org.egovframe.rte.fdl.filehandling.upload;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * {@link EgovFileStore} 흐름 통합 테스트 — 저장 → 재검증 → 읽기 → 삭제를 실제 파일시스템으로 왕복한다.
+ *
+ */
+class EgovFileStoreTest {
+
+	@TempDir
+	Path tmp;
+
+	private static ByteArrayInputStream bytes(String s) {
+		return new ByteArrayInputStream(s.getBytes(StandardCharsets.UTF_8));
+	}
+
+	private static long countFiles(Path dir) throws IOException {
+		if (!Files.isDirectory(dir)) {
+			return 0;
+		}
+		try (Stream<Path> s = Files.list(dir)) {
+			return s.count();
+		}
+	}
+
+	// ---------------------------------------------------------------- 루트
+
+	@Test
+	@DisplayName("① 루트 없이 만들 수 없다 (fail-closed)")
+	void cannotBuildWithoutRoots() {
+		assertThrows(IllegalArgumentException.class, () -> EgovFileStore.builder().build());
+	}
+
+	@Test
+	@DisplayName("② 여러 루트 중 키로 고르고, 키 없으면 첫 루트가 기본")
+	void selectsRootByKey() throws IOException {
+		Path storeRoot = tmp.resolve("store");
+		Path imageRoot = tmp.resolve("image");
+		EgovFileStore store = EgovFileStore.builder().root("store", storeRoot).root("image", imageRoot).build();
+
+		EgovStoredFile img = store.store("image", bytes("png"), "logo.png");
+		EgovStoredFile doc = store.store(bytes("doc"), "report.hwp");
+
+		assertTrue(img.getPath().startsWith(imageRoot.toAbsolutePath().normalize()));
+		assertEquals("image", img.getRootKey());
+		assertTrue(doc.getPath().startsWith(storeRoot.toAbsolutePath().normalize()));
+		assertEquals("store", doc.getRootKey());
+		assertEquals("store", store.defaultRootKey());
+		assertThrows(IllegalArgumentException.class, () -> store.store("pdf", bytes("x"), "a.pdf"));
+	}
+
+	// ---------------------------------------------------------------- 저장
+
+	@Test
+	@DisplayName("③ 경로가 섞인 원본명도 루트 바로 아래 새 저장명으로 놓이고 원본명은 보존된다")
+	void originalNameNeverReachesPath() throws IOException {
+		Path root = tmp.resolve("store");
+		EgovFileStore store = EgovFileStore.builder().root("store", root).build();
+
+		EgovStoredFile stored = store.store(bytes("secret"), "../../etc/passwd.txt");
+
+		assertEquals(root.toAbsolutePath().normalize(), stored.getPath().getParent());
+		assertTrue(stored.getStoredName().endsWith(".txt"));
+		assertFalse(stored.getStoredName().contains("passwd"));
+		assertEquals("../../etc/passwd.txt", stored.getOriginalName());
+		assertEquals(6, stored.getSize());
+		assertEquals(1, countFiles(root));
+		assertFalse(Files.exists(tmp.resolve("etc/passwd.txt")));
+	}
+
+	@Test
+	@DisplayName("④ 같은 원본명을 두 번 저장해도 덮어쓰지 않는다")
+	void noOverwriteOnSameOriginalName() throws IOException {
+		Path root = tmp.resolve("store");
+		EgovFileStore store = EgovFileStore.builder().root("store", root).build();
+
+		EgovStoredFile a = store.store(bytes("first"), "same.txt");
+		EgovStoredFile b = store.store(bytes("second"), "same.txt");
+
+		assertNotEquals(a.getStoredName(), b.getStoredName());
+		assertEquals("first", Files.readString(a.getPath()));
+		assertEquals("second", Files.readString(b.getPath()));
+		assertEquals(2, countFiles(root));
+	}
+
+	@Test
+	@DisplayName("⑤ 루트 디렉터리가 아직 없으면 저장 시 만들어진다")
+	void createsMissingRoot() throws IOException {
+		Path root = tmp.resolve("not/yet/there");
+		assertFalse(Files.exists(root));
+		EgovFileStore store = EgovFileStore.builder().root("store", root).build();
+
+		EgovStoredFile stored = store.store(bytes("x"), "a.txt");
+
+		assertTrue(Files.isDirectory(root));
+		assertTrue(Files.exists(stored.getPath()));
+	}
+
+	// ---------------------------------------------------------------- 정책
+
+	@Test
+	@DisplayName("⑥ 정책 확장자 위반이면 실패하고 파일이 생기지 않는다")
+	void policyExtensionRejectedLeavesNothing() throws IOException {
+		Path root = tmp.resolve("store");
+		EgovUploadPolicy pdfOnly = EgovUploadPolicy.builder().allowExtensions("pdf").build();
+		EgovFileStore store = EgovFileStore.builder().root("store", root).policy(pdfOnly).build();
+
+		EgovUploadRejectedException ex = assertThrows(EgovUploadRejectedException.class,
+				() -> store.store(bytes("MZ"), "evil.exe"));
+
+		assertEquals(EgovUploadPolicy.Reason.EXTENSION_NOT_ALLOWED, ex.getReason());
+		assertEquals(0, countFiles(root));
+	}
+
+	@Test
+	@DisplayName("⑦ 크기 초과는 기록 후 드러나도 부분 파일을 남기지 않는다")
+	void policySizeExceededRemovesPartial() throws IOException {
+		Path root = tmp.resolve("store");
+		EgovUploadPolicy small = EgovUploadPolicy.builder().allowExtensions("bin").maxFileSize(1024).build();
+		EgovFileStore store = EgovFileStore.builder().root("store", root).policy(small).build();
+		byte[] twoKb = new byte[2048];
+
+		EgovUploadRejectedException ex = assertThrows(EgovUploadRejectedException.class,
+				() -> store.store(new ByteArrayInputStream(twoKb), "big.bin"));
+
+		assertEquals(EgovUploadPolicy.Reason.SIZE_EXCEEDED, ex.getReason());
+		assertEquals(0, countFiles(root));
+
+		// Path 입력은 복사 전에 걸러진다
+		Path src = tmp.resolve("src.bin");
+		Files.write(src, twoKb);
+		assertThrows(EgovUploadRejectedException.class, () -> store.store(src, "big.bin"));
+		assertEquals(0, countFiles(root));
+	}
+
+	@Test
+	@DisplayName("정책 통과 시 Path 입력도 저장되고 원본은 그대로 남는다")
+	void pathSourceStoredWhenPolicyPasses() throws IOException {
+		Path root = tmp.resolve("store");
+		EgovUploadPolicy policy = EgovUploadPolicy.builder().allowExtensions("txt").maxFileSize(1024).build();
+		EgovFileStore store = EgovFileStore.builder().root("store", root).policy(policy).build();
+		Path src = tmp.resolve("src.txt");
+		Files.writeString(src, "hello");
+
+		EgovStoredFile stored = store.store(src, "hello.txt");
+
+		assertEquals("hello", Files.readString(stored.getPath()));
+		assertTrue(Files.exists(src));
+		assertEquals(5, stored.getSize());
+	}
+
+	// ---------------------------------------------------------------- 재검증
+
+	@Test
+	@DisplayName("⑧ 변조된 보관 전체 경로(루트 밖)는 거부된다")
+	void tamperedStoredPathRejected() throws IOException {
+		Path root = tmp.resolve("store");
+		Path outside = tmp.resolve("outside.txt");
+		Files.writeString(outside, "x");
+		EgovFileStore store = EgovFileStore.builder().root("store", root).build();
+
+		assertThrows(IllegalArgumentException.class, () -> store.resolve(outside.toString()));
+		assertThrows(IllegalArgumentException.class, () -> store.resolve("/etc/passwd"));
+	}
+
+	@Test
+	@DisplayName("⑨ 저장명에 상위 이동이 섞이면 거부된다")
+	void traversalInStoredNameRejected() {
+		EgovFileStore store = EgovFileStore.builder().root("store", tmp.resolve("store")).build();
+
+		assertThrows(IllegalArgumentException.class, () -> store.resolve("store", "../secret.txt"));
+		assertThrows(IllegalArgumentException.class, () -> store.resolve("store", "/abs/secret.txt"));
+	}
+
+	@Test
+	@DisplayName("⑩ 정상 왕복 — 루트 키 형태와 전체 경로 형태가 같은 경로·내용")
+	void roundTripBothForms() throws IOException {
+		Path root = tmp.resolve("store");
+		EgovFileStore store = EgovFileStore.builder().root("store", root).root("image", tmp.resolve("image")).build();
+		EgovStoredFile stored = store.store(bytes("payload"), "보고서.hwp");
+
+		Path byKey = store.resolve(stored.getRootKey(), stored.getStoredName());
+		Path byPath = store.resolve(stored.getPath().toString());
+		Path byValue = store.resolve(stored);
+
+		assertEquals(stored.getPath(), byKey);
+		assertEquals(stored.getPath(), byPath);
+		assertEquals(stored.getPath(), byValue);
+		assertEquals("payload", Files.readString(byKey));
+		assertTrue(stored.getStoredName().endsWith(".hwp"));
+	}
+
+	@Test
+	@DisplayName("⑬ 널 바이트가 섞인 저장명·경로는 거부된다")
+	void nullByteRejected() {
+		EgovFileStore store = EgovFileStore.builder().root("store", tmp.resolve("store")).build();
+
+		assertThrows(IllegalArgumentException.class, () -> store.resolve("store", "a\0.txt"));
+		assertThrows(IllegalArgumentException.class, () -> store.resolve(tmp.resolve("store").toString() + "/a\0.txt"));
+	}
+
+	// ---------------------------------------------------------------- 삭제
+
+	@Test
+	@DisplayName("⑪ 루트 밖 실재 파일 삭제 요청은 거부되고 파일은 남는다")
+	void deleteOutsideRootRejected() throws IOException {
+		Path root = tmp.resolve("store");
+		Path outside = tmp.resolve("keep-me.txt");
+		Files.writeString(outside, "x");
+		EgovFileStore store = EgovFileStore.builder().root("store", root).build();
+
+		assertThrows(IllegalArgumentException.class, () -> store.delete(outside.toString()));
+		assertThrows(IllegalArgumentException.class, () -> store.delete("store", "../keep-me.txt"));
+		assertTrue(Files.exists(outside));
+	}
+
+	@Test
+	@DisplayName("⑫ 이미 없는 파일 삭제는 false, 있으면 true")
+	void deleteReportsWhetherRemoved() throws IOException {
+		Path root = tmp.resolve("store");
+		EgovFileStore store = EgovFileStore.builder().root("store", root).build();
+		EgovStoredFile stored = store.store(bytes("x"), "a.txt");
+
+		assertTrue(store.delete(stored));
+		assertFalse(Files.exists(stored.getPath()));
+		assertFalse(store.delete(stored));
+		assertFalse(store.delete(stored.getRootKey(), stored.getStoredName()));
+	}
+
+	// ---------------------------------------------------------------- 기타
+
+	@Test
+	@DisplayName("keepExtension(false) 면 확장자 없는 저장명, 중복 루트 키는 거부")
+	void builderOptions() throws IOException {
+		Path root = tmp.resolve("store");
+		EgovFileStore store = EgovFileStore.builder().root("store", root).keepExtension(false).build();
+
+		EgovStoredFile stored = store.store(bytes("x"), "a.txt");
+		assertFalse(stored.getStoredName().contains("."));
+
+		assertThrows(IllegalArgumentException.class,
+				() -> EgovFileStore.builder().root("store", root).root("store", tmp.resolve("other")));
+		assertEquals(1, store.roots().size());
+		assertFalse(store.policy().isPresent());
+	}
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [ ] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [X] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

### 배경

앞서 추가한 부품들은 각각 옳습니다.

| 부품 | 역할 |
|---|---|
| `EgovFiles` | 경로 봉쇄 검증 |
| `EgovStoredFileNames` | 유일한 저장명 생성 |
| `EgovUploadPolicy` | 확장자·크기·개수 검증 |

**그러나 조립 순서를 틀리면 방어가 무너집니다.** 검증 전에 저장하거나, 다운로드 시 DB 에
보관된 경로를 그대로 믿으면 부품이 있어도 소용이 없습니다. 공통컴포넌트
`EgovFileMngUtil.parseFileInf` 가 그 예로, 문자 삭제형 경로 방어·시각 기반 저장명·**다운로드
시 DB 경로 무검증**이 한 흐름에 섞여 있습니다.

조립 순서를 코드로 고정한 **참조 구현**이 필요합니다.

### 추가한 것

- **`upload/EgovFileStore`** — 저장 → 재검증 → 읽기 → 삭제 흐름
- **`upload/EgovStoredFile`** — 저장 결과 값 객체(원본명·저장명·경로·크기)

```java
EgovFileStore store = EgovFileStore.builder()
        .root("attach", attachRoot)
        .root("image", imageRoot)
        .policy(uploadPolicy)
        .build();

EgovStoredFile saved = store.store("attach", inputStream, originalName);
// 다운로드 시 — 루트 키 + 저장명(권장) 또는 DB 에 보관한 전체 경로를 다시 검증한다
Path verified = store.resolve("attach", saved.getStoredName());
Path legacy   = store.resolve(saved.getPath().toString());
```

### 설계 메모

- **새 규칙을 두지 않습니다.** 기존 부품을 올바른 순서로 조립한 것이며, 사업이 자체 흐름을
  쓰고 싶으면 부품을 직접 조합하면 됩니다
- **저장 시점의 검증만으로는 부족합니다.** 다운로드·삭제 시 DB 등에 보관된 경로를
  `requireContainedIn` 으로 **다시 검증**합니다 — 이것이 원본 구현에 없던 부분입니다
- **부분 저장물을 남기지 않습니다.** 정책 위반이 기록 도중 드러나도 파일이 남지 않습니다
- **허용 루트를 여러 개** 등록할 수 있습니다(업로드·이미지·변환 디렉터리 분리).
  루트 없이는 생성할 수 없습니다(fail-closed)
- **정책은 선택 사항**입니다. 지정하지 않으면 검증 없이 저장합니다
- **링크 방어**: 저장 시점 검증은 어휘적이지만 저장명이 무작위라 링크를 미리 심을 자리가 없고, 읽기·삭제 시점(`resolve`/`delete`)에는 실재하는 경로의 **실경로**가 루트 안인지 다시 확인합니다 — 루트 안에 심긴 심볼릭 링크를 따라 밖을 읽거나 지우지 않습니다(루트 자체가 링크로 마운트된 배치는 정상 통과)

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

`EgovFileStoreTest` **15건** + 보안 회귀 `EgovFileStoreSecurityTest` **4건**, 합계 **19건 신규** — 실제 파일시스템으로 저장→재검증→읽기→삭제를 왕복합니다.

| 환경 | 모듈 실행 건수 | 결과 |
|---|---:|---|
| **Windows** (ko_KR) | 141 | `Tests run: 141, Failures: 0, Errors: 0, Skipped: 5` |
| **Linux** (Ubuntu 22.04 / OpenJDK 17 / ext4, C.UTF-8) | 141 | `Tests run: 141, Failures: 0, Errors: 0, Skipped: 5` |

`Skipped` 는 플랫폼 조건부 테스트입니다 — Windows 에서는 POSIX 전용 5건(`EgovFiles`(#388 로 머지됨)의 2 · 이 PR 의 링크 테스트 3)이,
Linux 에서는 `EgovFiles` 의 Windows 전용 5건이 건너뛰어집니다.

| 구분 | 건수 | 내용 |
|---|---:|---|
| 구성·루트 | 4 | 루트 없이 생성 불가(fail-closed) · 루트 키 선택과 기본 루트 · 루트 자동 생성 · 중복 루트 키 거부 |
| 저장 | 4 | **경로 섞인 원본명도 루트 바로 아래 배치**(원본명은 보존) · 같은 이름 두 번 저장해도 미덮어쓰기 · `Path` 입력 저장 · `keepExtension(false)` |
| 정책 연동 | 2 | 확장자 위반 시 **파일이 생기지 않음** · 크기 초과 시 **부분 파일 미잔존** |
| **보관 경로 재검증** | 4 | **변조된 전체 경로(루트 밖) 거부** · 저장명에 상위 이동 섞이면 거부 · 널 바이트 거부 · 루트 키/전체 경로 형태의 정상 왕복 일치 |
| 삭제 | 1 | **루트 밖 실재 파일 삭제 거부**(파일은 남는다) · 없는 파일은 `false` |

`EgovFileStoreSecurityTest` 4건 — 루트 안에 **밖을 가리키는 심볼릭 링크가 미리 심겨 있다**는 전제
(운영 규칙 위반)에서 동작별 안전 여부를 고정합니다. 링크 생성에 권한이 필요한 Windows 에서는
POSIX 전용 3건이 건너뛰어집니다.

| 구분 | 건수 | 내용 |
|---|---:|---|
| 저장 | 1 | 무작위 저장명이라 링크를 미리 심을 자리가 없고, 저장 결과의 실경로는 루트 안 |
| 삭제 | 1 | 밖을 가리키는 링크는 `delete` 가 거부 — **링크도 링크 대상(경계 밖)도 건드리지 않음** |
| 읽기 경로 | 1 | 밖을 가리키는 **파일 링크·디렉터리 링크 모두 `resolve` 가 거부**(루트 키 + 저장명 형태와 전체 경로 형태 모두) |
| 오탐 방지 | 1 | 루트 자체가 링크로 마운트된 정상 배치는 저장·읽기·삭제가 그대로 동작 |

**수동 확인**: 실제 파일시스템 왕복이라 경로 의미론에 직접 좌우됩니다. 대소문자를 구분하는
Linux(ext4)에서 교차 검증했습니다.

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

해당 없음 — 라이브러리 클래스 추가입니다.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

해당 없음 — 위 JUnit 테스트 결과로 갈음합니다.

---

<sub>base: `eGovFramework:main` @ `7ab591b` (2026-09-09 fetch 기준, #399·#400 머지 후) · 단일 커밋</sub>
