### PR TITLE
feat: 업로드 검증을 MVC 계층에 연결하는 EgovMultipartFiles 추가

### DIFF
--- a/Presentation/org.egovframe.rte.ptl.mvc/pom.xml
+++ b/Presentation/org.egovframe.rte.ptl.mvc/pom.xml
@@ -57,6 +57,12 @@
             <artifactId>egovframe-rte-fdl-cmmn</artifactId>
             <version>${org.egovframe.rte.version}</version>
         </dependency>
+        <!-- 업로드 검증 정책(EgovUploadPolicy)과 안전 경로 해석(EgovFiles)을 쓴다. -->
+        <dependency>
+            <groupId>org.egovframe.rte</groupId>
+            <artifactId>egovframe-rte-fdl-filehandling</artifactId>
+            <version>${org.egovframe.rte.version}</version>
+        </dependency>
 
         <!-- Spring -->
         <dependency>

--- a/Presentation/org.egovframe.rte.ptl.mvc/src/main/java/org/egovframe/rte/ptl/mvc/upload/EgovMultipartFiles.java
+++ b/Presentation/org.egovframe.rte.ptl.mvc/src/main/java/org/egovframe/rte/ptl/mvc/upload/EgovMultipartFiles.java
@@ -1,0 +1,191 @@
+/*
+ * Copyright 2009-2026 MOIS(Ministry of the Interior and Safety).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.egovframe.rte.ptl.mvc.upload;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.egovframe.rte.fdl.filehandling.EgovFiles;
+import org.egovframe.rte.fdl.filehandling.upload.EgovUploadPolicy;
+import org.springframework.web.multipart.MultipartFile;
+
+/**
+ * {@link MultipartFile} 을 {@link EgovUploadPolicy} 로 검증하는 얇은 어댑터.
+ *
+ * <p><b>NOTE:</b> 검증 규칙 자체는 {@code fdl.filehandling} 의 정책 객체에 있다. 이 클래스는
+ * 서블릿 자료형에서 <b>파일명과 크기를 꺼내 정책에 넘기는 일</b>만 한다 — 규칙을 웹 계층에
+ * 복제하지 않기 위해서다(공통컴포넌트 원본은 같은 화이트리스트 로직을 유틸과 리졸버에
+ * 두 벌 두고 있었다).</p>
+ *
+ * <pre>
+ * &#64;PostMapping("/upload")
+ * public String upload(&#64;RequestParam("files") List&lt;MultipartFile&gt; files) {
+ *     EgovMultipartFiles.validate(POLICY, files);      // 하나라도 위반하면 예외
+ *     ...
+ * }
+ * </pre>
+ *
+ * <p>브라우저가 파일명에 경로를 붙여 보내는 경우가 있어(구형 클라이언트) <b>이름만 추출해서</b>
+ * 정책에 넘긴다. 따라서 정상 업로드가 경로 구분자 때문에 거부되지 않는다.</p>
+ *
+ * <pre>
+ * &lt;&lt; 개정이력(Modification Information) &gt;&gt;
+ *
+ *  수정일        수정자        수정내용
+ *  ----------  --------    ---------------------------
+ *  2026.09.01  실행환경팀     최초 생성
+ * </pre>
+ *
+ * @author 실행환경 개발팀
+ * @since 5.1
+ */
+public final class EgovMultipartFiles {
+
+	private EgovMultipartFiles() {
+	}
+
+	/**
+	 * 파일 하나를 검증하고 위반 사유를 반환한다. <b>예외를 던지지 않는다.</b>
+	 *
+	 * @param policy 적용할 정책
+	 * @param file   검증할 파일({@code null} 이면 {@code NO_FILENAME})
+	 * @return 위반 사유. 통과하면 {@link Optional#empty()}
+	 */
+	public static Optional<EgovUploadPolicy.Reason> check(EgovUploadPolicy policy, MultipartFile file) {
+		if (file == null) {
+			return Optional.of(EgovUploadPolicy.Reason.NO_FILENAME);
+		}
+		return policy.check(fileNameOf(file), file.getSize());
+	}
+
+	/**
+	 * 파일 하나를 검증하고, 위반이면 예외를 던진다.
+	 *
+	 * @param policy 적용할 정책
+	 * @param file   검증할 파일
+	 * @throws org.egovframe.rte.fdl.filehandling.upload.EgovUploadRejectedException 정책 위반인 경우
+	 */
+	public static void validate(EgovUploadPolicy policy, MultipartFile file) {
+		if (file == null) {
+			policy.validate(null, 0L);
+			return;
+		}
+		policy.validate(fileNameOf(file), file.getSize());
+	}
+
+	/**
+	 * 여러 파일을 검증하고, 하나라도 위반이면 예외를 던진다(개수 제한 포함).
+	 *
+	 * <p><b>채우지 않은 입력칸(파일명 없음·0 바이트)은 개수에서 제외</b>한다 — 화면이 파일
+	 * 입력칸을 여러 개 두고 일부만 채워 보내는 것이 보통이기 때문이다. 반면 <b>파일명이 있는
+	 * 0 바이트 파일은 제출된 것</b>이라 정책이 판정한다(기본 거부, {@code allowEmptyFile} 로
+	 * 허용하면 확장자 검사를 받는다). 크기가 0 이라는 이유로 정책을 건너뛰면 확장자
+	 * 화이트리스트와 개수 상한이 빈 파일로 우회된다.</p>
+	 *
+	 * @param policy 적용할 정책
+	 * @param files  검증할 파일 목록({@code null} 허용)
+	 * @throws org.egovframe.rte.fdl.filehandling.upload.EgovUploadRejectedException 정책 위반인 경우
+	 */
+	public static void validateAll(EgovUploadPolicy policy, Collection<MultipartFile> files) {
+		List<MultipartFile> submitted = submittedOnly(files);
+		policy.validateCount(submitted.size());
+		for (MultipartFile file : submitted) {
+			validate(policy, file);
+		}
+	}
+
+	/**
+	 * 여러 파일을 검증하고 <b>위반한 것만</b> 골라 반환한다. 예외를 던지지 않는다.
+	 *
+	 * <p>화면에서 파일별로 오류를 표시해야 할 때 쓴다. 개수 초과는 키가 {@code null} 인
+	 * 항목으로 담긴다.</p>
+	 *
+	 * @param policy 적용할 정책
+	 * @param files  검증할 파일 목록({@code null} 허용)
+	 * @return 위반한 파일과 사유(입력 순서 유지). 전부 통과하면 빈 맵
+	 */
+	public static Map<MultipartFile, EgovUploadPolicy.Reason> checkAll(
+			EgovUploadPolicy policy, Collection<MultipartFile> files) {
+
+		Map<MultipartFile, EgovUploadPolicy.Reason> violations = new LinkedHashMap<>();
+		List<MultipartFile> submitted = submittedOnly(files);
+
+		policy.checkCount(submitted.size()).ifPresent(reason -> violations.put(null, reason));
+
+		for (MultipartFile file : submitted) {
+			check(policy, file).ifPresent(reason -> violations.put(file, reason));
+		}
+		return violations;
+	}
+
+	/**
+	 * 실제로 제출된 파일만 골라낸다 — 내용이 있거나 <b>파일명이 있는</b> 항목. 파일명도 내용도
+	 * 없는 항목은 채우지 않은 입력칸이므로 제외한다.
+	 *
+	 * @param files 원본 목록({@code null} 허용)
+	 * @return 제출된 파일 목록
+	 */
+	public static List<MultipartFile> submittedOnly(Collection<MultipartFile> files) {
+		List<MultipartFile> submitted = new ArrayList<>();
+		if (files == null) {
+			return submitted;
+		}
+		for (MultipartFile file : files) {
+			if (file != null && (!file.isEmpty() || hasFileName(file))) {
+				submitted.add(file);
+			}
+		}
+		return submitted;
+	}
+
+	/** 파일명이 있는 항목인가 — 크기가 0 이어도 사용자가 파일을 골라 보낸 것이다. */
+	private static boolean hasFileName(MultipartFile file) {
+		String name = file.getOriginalFilename();
+		return name != null && !name.trim().isEmpty();
+	}
+
+	/**
+	 * 업로드 파일에서 <b>경로를 제외한 이름</b>을 얻는다 — 구분자({@code /}·{@code \}) 앞부분과
+	 * Windows 드라이브 접두({@code C:})를 뗀다.
+	 *
+	 * @param file 업로드 파일
+	 * @return 파일명(없으면 {@code null})
+	 */
+	public static String fileNameOf(MultipartFile file) {
+		String original = file.getOriginalFilename();
+		if (original == null) {
+			return null;
+		}
+		String trimmed = original.trim();
+		if (trimmed.isEmpty()) {
+			return trimmed;
+		}
+		// 드라이브 상대 표기("C:name")의 드라이브 접두는 구분자 없이도 경로다 — 함께 뗀다
+		if (trimmed.length() >= 2 && trimmed.charAt(1) == ':' && Character.isLetter(trimmed.charAt(0))) {
+			trimmed = trimmed.substring(2).trim();
+			if (trimmed.isEmpty()) {
+				return trimmed;
+			}
+		}
+		String baseName = EgovFiles.getBaseName(trimmed);
+		String extension = EgovFiles.getExtension(trimmed);
+		return extension.isEmpty() ? baseName : baseName + "." + extension;
+	}
+}

--- a/Presentation/org.egovframe.rte.ptl.mvc/src/main/java/org/egovframe/rte/ptl/mvc/upload/EgovValidatingMultipartResolver.java
+++ b/Presentation/org.egovframe.rte.ptl.mvc/src/main/java/org/egovframe/rte/ptl/mvc/upload/EgovValidatingMultipartResolver.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2009-2026 MOIS(Ministry of the Interior and Safety).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.egovframe.rte.ptl.mvc.upload;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.egovframe.rte.fdl.filehandling.upload.EgovUploadPolicy;
+import org.egovframe.rte.fdl.filehandling.upload.EgovUploadRejectedException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.web.multipart.MultipartException;
+import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.multipart.MultipartHttpServletRequest;
+import org.springframework.web.multipart.support.StandardServletMultipartResolver;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+/**
+ * 업로드 정책을 컨트롤러 진입 전에 일괄 적용하는 {@code MultipartResolver}.
+ *
+ * <p><b>NOTE:</b> 컨트롤러마다 검증을 반복해 넣다 보면 한 곳이 빠지고, 그 한 곳이 통로가 된다.
+ * 리졸버 단계에 두면 <b>모든 multipart 요청이 같은 정책을 거친다.</b></p>
+ *
+ * <pre>
+ * &#64;Bean
+ * public EgovUploadPolicy uploadPolicy() {
+ *     return EgovUploadPolicy.builder().allowExtensions("png", "pdf").maxFileCount(5).build();
+ * }
+ *
+ * // 메서드 이름이 곧 빈 이름이다 — DispatcherServlet 이 "multipartResolver" 로 이름 조회를 한다
+ * &#64;Bean
+ * public MultipartResolver multipartResolver(EgovUploadPolicy uploadPolicy) {
+ *     return new EgovValidatingMultipartResolver(uploadPolicy);
+ * }
+ * </pre>
+ *
+ * <p><b>빈 이름을 바꾸면 동작하지 않는다.</b> {@code DispatcherServlet} 은
+ * {@code MULTIPART_RESOLVER_BEAN_NAME}(= {@code "multipartResolver"})으로 조회하므로,
+ * 이름이 다르면 빈은 만들어지지만 요청 경로에 끼지 않는다.</p>
+ *
+ * <p><b>정책은 생성자로 받으며 필수다.</b> 기본 생성자를 두지 않은 이유는, 정책이 없는 상태를
+ * 허용하면 설정 누락이 곧 무검증으로 이어지기 때문이다(공통컴포넌트 원본은 화이트리스트
+ * 프로퍼티가 비어 있으면 <b>모든 확장자를 통과</b>시켰다).</p>
+ *
+ * <h3>이 단계에서 막지 <b>못하는</b> 것</h3>
+ *
+ * <p>서블릿 컨테이너가 요청 본문을 이미 파싱한 뒤에 검증이 이뤄지므로, <b>임시 파일은 한 번
+ * 생성된다.</b> 검증에 걸리면 즉시 정리하지만 디스크 쓰기 자체를 없애지는 못한다.
+ * 과도한 크기의 요청을 <b>받기 전에</b> 끊으려면 컨테이너 설정을 함께 건다.</p>
+ *
+ * <pre>
+ * &lt;multipart-config&gt;
+ *     &lt;max-file-size&gt;10485760&lt;/max-file-size&gt;
+ *     &lt;max-request-size&gt;52428800&lt;/max-request-size&gt;
+ * &lt;/multipart-config&gt;
+ * </pre>
+ *
+ * <p>정책 위반은 {@link MultipartException} 으로 감싸 던진다. 사유는 cause 로 실린
+ * {@link EgovUploadRejectedException#getReason()} 에서 꺼낸다 — 크기 초과는 413,
+ * 확장자 불허는 400 처럼 구분해 응답하려면 예외 핸들러에서 사유로 분기한다.</p>
+ *
+ * <pre>
+ * &lt;&lt; 개정이력(Modification Information) &gt;&gt;
+ *
+ *  수정일        수정자        수정내용
+ *  ----------  --------    ---------------------------
+ *  2026.09.01  실행환경팀     최초 생성 (공통컴포넌트 EgovMultipartResolver 의 배치와
+ *                            검증 항목을 차용하되, 화이트리스트 미설정 시 전부 허용·
+ *                            SecurityException 이 MultipartException catch 를 빠져나가
+ *                            500 이 되는 문제·검증 실패 시 임시 파일 미정리·요청마다
+ *                            프로퍼티 재조회를 재구성 — 코드 이식 아님)
+ * </pre>
+ *
+ * @author 실행환경 개발팀
+ * @since 5.1
+ */
+public class EgovValidatingMultipartResolver extends StandardServletMultipartResolver {
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(EgovValidatingMultipartResolver.class);
+
+	private final EgovUploadPolicy policy;
+
+	/**
+	 * @param policy 적용할 업로드 정책(필수)
+	 */
+	public EgovValidatingMultipartResolver(EgovUploadPolicy policy) {
+		if (policy == null) {
+			throw new IllegalArgumentException("upload policy must not be null");
+		}
+		this.policy = policy;
+	}
+
+	/**
+	 * 적용 중인 정책을 반환한다.
+	 *
+	 * @return 정책
+	 */
+	public EgovUploadPolicy getPolicy() {
+		return policy;
+	}
+
+	/**
+	 * multipart 요청을 파싱한 뒤 정책을 적용한다.
+	 *
+	 * <p>위반이면 <b>임시 파일을 정리한 뒤</b> {@link MultipartException} 을 던진다.</p>
+	 *
+	 * @param request 요청
+	 * @return 파싱된 multipart 요청
+	 * @throws MultipartException 파싱 실패 또는 정책 위반
+	 */
+	@Override
+	public MultipartHttpServletRequest resolveMultipart(HttpServletRequest request) throws MultipartException {
+		MultipartHttpServletRequest multipartRequest = super.resolveMultipart(request);
+		try {
+			applyPolicy(multipartRequest);
+		} catch (EgovUploadRejectedException ex) {
+			cleanupMultipart(multipartRequest);
+			LOGGER.warn("업로드 거부 [{}] uri={}", ex.getReason(), request.getRequestURI());
+			throw new MultipartException("Upload rejected by policy: " + ex.getReason(), ex);
+		}
+		return multipartRequest;
+	}
+
+	/**
+	 * 요청에 담긴 모든 파일에 정책을 적용한다.
+	 *
+	 * @param multipartRequest 파싱된 multipart 요청
+	 * @throws EgovUploadRejectedException 정책 위반인 경우
+	 */
+	protected void applyPolicy(MultipartHttpServletRequest multipartRequest) {
+		Map<String, List<MultipartFile>> fileMap = multipartRequest.getMultiFileMap();
+		List<MultipartFile> all = new ArrayList<>();
+		for (List<MultipartFile> files : fileMap.values()) {
+			all.addAll(files);
+		}
+		EgovMultipartFiles.validateAll(policy, all);
+	}
+}

--- a/Presentation/org.egovframe.rte.ptl.mvc/src/test/java/org/egovframe/rte/ptl/mvc/upload/EgovMultipartFilesSecurityTest.java
+++ b/Presentation/org.egovframe.rte.ptl.mvc/src/test/java/org/egovframe/rte/ptl/mvc/upload/EgovMultipartFilesSecurityTest.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright 2009-2026 MOIS(Ministry of the Interior and Safety).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.egovframe.rte.ptl.mvc.upload;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.egovframe.rte.fdl.filehandling.upload.EgovUploadPolicy;
+import org.egovframe.rte.fdl.filehandling.upload.EgovUploadRejectedException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.mock.web.MockMultipartHttpServletRequest;
+import org.springframework.mock.web.MockPart;
+import org.springframework.web.multipart.MultipartException;
+import org.springframework.web.multipart.MultipartFile;
+
+/**
+ * {@link EgovMultipartFiles} · {@link EgovValidatingMultipartResolver} 의 <b>정책 우회</b> 회귀 검증.
+ *
+ * <p>정책 자체({@link EgovUploadPolicy})의 확장자 우회 배터리는 정책 쪽 테스트가 맡는다. 이 클래스는
+ * <b>웹 계층 어댑터가 정책을 건너뛰는 틈</b>을 막는다 — 크기 0 이라는 이유로 정책에 보이지 않는 파일,
+ * content-type 에 기대는 판정, 경로가 섞인 파일명, 거부 메시지의 파일명 반사.</p>
+ *
+ * <pre>
+ * &lt;&lt; 개정이력(Modification Information) &gt;&gt;
+ *
+ *  수정일        수정자        수정내용
+ *  ----------  --------    ---------------------------
+ *  2026.09.07  실행환경팀     최초 생성
+ * </pre>
+ *
+ * @author 실행환경 개발팀
+ * @since 5.1
+ */
+class EgovMultipartFilesSecurityTest {
+
+	private static final String BS = String.valueOf((char) 92);
+	private static final String NUL = String.valueOf((char) 0);
+
+	private static EgovUploadPolicy imagePolicy() {
+		return EgovUploadPolicy.builder().allowExtensionList(".png,.jpg,.pdf").maxFileSize(1_000_000L).maxFileCount(2).build();
+	}
+
+	private static MockMultipartFile file(String name, int bytes, String contentType) {
+		return new MockMultipartFile("files", name, contentType, new byte[bytes]);
+	}
+
+	@Test
+	@DisplayName("파일명이 있는 0바이트 파일은 정책 판정을 받는다 — 크기 0 이라는 이유로 확장자 검사를 건너뛰지 않는다")
+	void 파일명_있는_0바이트_파일은_정책_판정() {
+		MockMultipartFile emptyJsp = file("shell.jsp", 0, "application/octet-stream");
+
+		EgovUploadRejectedException rejected = assertThrows(EgovUploadRejectedException.class,
+				() -> EgovMultipartFiles.validateAll(imagePolicy(), List.of(emptyJsp)));
+		assertEquals(EgovUploadPolicy.Reason.EMPTY_FILE, rejected.getReason());
+
+		Map<MultipartFile, EgovUploadPolicy.Reason> violations = EgovMultipartFiles.checkAll(imagePolicy(), List.of(emptyJsp));
+		assertEquals(EgovUploadPolicy.Reason.EMPTY_FILE, violations.get(emptyJsp));
+
+		// 빈 파일을 허용하는 정책이라도 확장자는 여전히 검사한다
+		EgovUploadPolicy emptyAllowed = EgovUploadPolicy.builder().allowExtensionList(".png,.pdf").allowEmptyFile(true).build();
+		assertEquals(Optional.of(EgovUploadPolicy.Reason.EXTENSION_NOT_ALLOWED),
+				EgovMultipartFiles.checkAll(emptyAllowed, List.of(emptyJsp)).values().stream().findFirst());
+		EgovMultipartFiles.validateAll(emptyAllowed, List.of(file("note.pdf", 0, null)));
+	}
+
+	@Test
+	@DisplayName("채우지 않은 입력칸(파일명 없음·0바이트)은 여전히 개수와 검증에서 제외된다")
+	void 파일명_없는_빈_항목은_제외() {
+		List<MultipartFile> files = Arrays.asList(file("", 0, null), file("  ", 0, null), file("photo.png", 3, null));
+
+		assertEquals(1, EgovMultipartFiles.submittedOnly(files).size());
+		EgovMultipartFiles.validateAll(imagePolicy(), files);
+		assertTrue(EgovMultipartFiles.checkAll(imagePolicy(), files).isEmpty());
+	}
+
+	@Test
+	@DisplayName("개수 상한은 파일명이 있는 0바이트 항목으로 우회되지 않는다")
+	void 개수_상한_우회_불가() {
+		List<MultipartFile> files = Arrays.asList(file("a.png", 1, null), file("b.png", 1, null),
+				file("c.png", 0, null), file("d.png", 0, null), file("e.png", 0, null));
+
+		EgovUploadRejectedException rejected = assertThrows(EgovUploadRejectedException.class,
+				() -> EgovMultipartFiles.validateAll(imagePolicy(), files));
+		assertEquals(EgovUploadPolicy.Reason.COUNT_EXCEEDED, rejected.getReason());
+	}
+
+	@Test
+	@DisplayName("리졸버는 0바이트 실행형 파일명을 컨트롤러 앞에서 거부하고, 예외 메시지에 파일명을 싣지 않는다")
+	void 리졸버_0바이트_실행형_거부() {
+		EgovValidatingMultipartResolver resolver = new EgovValidatingMultipartResolver(imagePolicy());
+		MockMultipartHttpServletRequest request = new MockMultipartHttpServletRequest();
+		request.setMethod("POST");
+		request.setContentType("multipart/form-data; boundary=boundary");
+		request.addPart(new MockPart("files", "secret-shell.jsp", new byte[0]));
+		request.addPart(new MockPart("files", "ok.png", new byte[] {1, 2, 3}));
+
+		MultipartException failure = assertThrows(MultipartException.class, () -> resolver.resolveMultipart(request));
+
+		assertTrue(failure.getCause() instanceof EgovUploadRejectedException, String.valueOf(failure.getCause()));
+		assertEquals(EgovUploadPolicy.Reason.EMPTY_FILE, ((EgovUploadRejectedException) failure.getCause()).getReason());
+		assertFalse(failure.getMessage().contains("secret-shell"), failure.getMessage());
+		assertFalse(failure.getCause().getMessage().contains("secret-shell"), failure.getCause().getMessage());
+	}
+
+	@Test
+	@DisplayName("content-type 은 판정에 쓰이지 않는다 — 위장된 형식 헤더로 허용되거나 거부되지 않는다")
+	void content_type_비의존() {
+		assertEquals(Optional.of(EgovUploadPolicy.Reason.EXTENSION_NOT_ALLOWED),
+				EgovMultipartFiles.check(imagePolicy(), file("shell.jsp", 10, "image/png")));
+		assertEquals(Optional.empty(), EgovMultipartFiles.check(imagePolicy(), file("photo.png", 10, "application/x-jsp")));
+	}
+
+	@Test
+	@DisplayName("경로가 섞인 파일명은 이름만 남는다 — 구분자 앞부분과 드라이브 접두를 떼고, 널 바이트는 정책이 거부한다")
+	void 경로_정규화() {
+		assertEquals("x.png", EgovMultipartFiles.fileNameOf(file("../../etc/x.png", 1, null)));
+		assertEquals("x.png", EgovMultipartFiles.fileNameOf(file("dir" + BS + "x.png", 1, null)));
+		assertEquals("x.png", EgovMultipartFiles.fileNameOf(file("C:" + BS + "Users" + BS + "me" + BS + "x.png", 1, null)));
+		assertEquals("x.png", EgovMultipartFiles.fileNameOf(file("C:x.png", 1, null)));
+		assertEquals("x.png", EgovMultipartFiles.fileNameOf(file("x.png.", 1, null)));
+		assertEquals("", EgovMultipartFiles.fileNameOf(file("C:", 1, null)));
+
+		assertEquals(Optional.of(EgovUploadPolicy.Reason.INVALID_FILENAME),
+				EgovMultipartFiles.check(imagePolicy(), file("shell.jsp" + NUL + ".png", 1, null)));
+		assertTrue(EgovMultipartFiles.check(imagePolicy(), file("..", 1, null)).isPresent());
+		assertTrue(EgovMultipartFiles.check(imagePolicy(), file(".htaccess", 1, null)).isPresent());
+	}
+
+}

--- a/Presentation/org.egovframe.rte.ptl.mvc/src/test/java/org/egovframe/rte/ptl/mvc/upload/EgovMultipartFilesTest.java
+++ b/Presentation/org.egovframe.rte.ptl.mvc/src/test/java/org/egovframe/rte/ptl/mvc/upload/EgovMultipartFilesTest.java
@@ -1,0 +1,239 @@
+/*
+ * Copyright 2009-2026 MOIS(Ministry of the Interior and Safety).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.egovframe.rte.ptl.mvc.upload;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import org.egovframe.rte.fdl.filehandling.upload.EgovUploadPolicy;
+import org.egovframe.rte.fdl.filehandling.upload.EgovUploadRejectedException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.mock.web.MockMultipartHttpServletRequest;
+import org.springframework.web.multipart.MultipartException;
+import org.springframework.web.multipart.MultipartFile;
+
+/**
+ * {@link EgovMultipartFiles} · {@link EgovValidatingMultipartResolver} 단위 테스트.
+ *
+ * <p>어댑터가 <b>규칙을 복제하지 않고</b> 정책에 위임하는지, 서블릿 자료형 특유의 문제
+ * (브라우저가 붙여 보내는 경로·빈 파일 항목)를 제대로 다루는지 확인한다.</p>
+ *
+ * <pre>
+ * &lt;&lt; 개정이력(Modification Information) &gt;&gt;
+ *
+ *  수정일        수정자        수정내용
+ *  ----------  --------    ---------------------------
+ *  2026.09.01  실행환경팀     최초 생성
+ * </pre>
+ *
+ * @author 실행환경 개발팀
+ * @since 5.1
+ */
+class EgovMultipartFilesTest {
+
+	private static EgovUploadPolicy policy() {
+		return EgovUploadPolicy.builder()
+				.allowExtensions("png", "pdf")
+				.maxFileSize(1024)
+				.maxFileCount(2)
+				.build();
+	}
+
+	private static MockMultipartFile file(String name, String originalFilename, int size) {
+		byte[] content = new byte[size];
+		return new MockMultipartFile(name, originalFilename, "application/octet-stream", content);
+	}
+
+	@Nested
+	@DisplayName("파일명 처리")
+	class FileName {
+
+		@Test
+		@DisplayName("브라우저가 붙여 보낸 경로를 제거하고 이름만 남긴다")
+		void 경로_제거() {
+			assertEquals("사진.png",
+					EgovMultipartFiles.fileNameOf(file("f", "C:\\Users\\me\\사진.png", 10)));
+			assertEquals("사진.png",
+					EgovMultipartFiles.fileNameOf(file("f", "/home/me/사진.png", 10)));
+		}
+
+		@Test
+		@DisplayName("경로가 붙어 와도 정상 파일은 통과한다")
+		void 경로_붙은_정상_파일_통과() {
+			assertTrue(EgovMultipartFiles.check(policy(), file("f", "C:\\tmp\\a.png", 10)).isEmpty());
+		}
+
+		@Test
+		@DisplayName("파일명이 null 이면 거부")
+		void 파일명_null() {
+			assertEquals(java.util.Optional.of(EgovUploadPolicy.Reason.NO_FILENAME),
+					EgovMultipartFiles.check(policy(), file("f", null, 10)));
+		}
+
+		@Test
+		@DisplayName("파일 자체가 null 이면 거부")
+		void 파일_null() {
+			assertEquals(java.util.Optional.of(EgovUploadPolicy.Reason.NO_FILENAME),
+					EgovMultipartFiles.check(policy(), (MultipartFile) null));
+		}
+	}
+
+	@Nested
+	@DisplayName("여러 파일 검증")
+	class MultipleFiles {
+
+		@Test
+		@DisplayName("전부 통과하면 예외 없음")
+		void 전건_통과() {
+			List<MultipartFile> files = Arrays.asList(file("a", "a.png", 10), file("b", "b.pdf", 20));
+
+			EgovMultipartFiles.validateAll(policy(), files);
+			assertTrue(EgovMultipartFiles.checkAll(policy(), files).isEmpty());
+		}
+
+		@Test
+		@DisplayName("하나라도 위반이면 예외")
+		void 일부_위반() {
+			List<MultipartFile> files = Arrays.asList(file("a", "a.png", 10), file("b", "b.exe", 20));
+
+			EgovUploadRejectedException ex = assertThrows(EgovUploadRejectedException.class,
+					() -> EgovMultipartFiles.validateAll(policy(), files));
+			assertEquals(EgovUploadPolicy.Reason.EXTENSION_NOT_ALLOWED, ex.getReason());
+		}
+
+		@Test
+		@DisplayName("check 는 위반한 것만 골라 돌려준다")
+		void 위반_목록() {
+			MultipartFile ok = file("a", "a.png", 10);
+			MultipartFile bad = file("b", "b.exe", 20);
+
+			Map<MultipartFile, EgovUploadPolicy.Reason> violations =
+					EgovMultipartFiles.checkAll(policy(), Arrays.asList(ok, bad));
+
+			assertEquals(1, violations.size());
+			assertEquals(EgovUploadPolicy.Reason.EXTENSION_NOT_ALLOWED, violations.get(bad));
+			assertFalse(violations.containsKey(ok));
+		}
+
+		@Test
+		@DisplayName("빈 파일 항목은 개수에서 제외한다 — 화면이 입력칸을 여러 개 두는 것이 보통이다")
+		void 빈_항목_제외() {
+			List<MultipartFile> files = Arrays.asList(
+					file("a", "a.png", 10),
+					file("b", "", 0),
+					file("c", "", 0));
+
+			assertEquals(1, EgovMultipartFiles.submittedOnly(files).size());
+			EgovMultipartFiles.validateAll(policy(), files);
+		}
+
+		@Test
+		@DisplayName("개수 초과는 파일별 사유가 아니라 요청 단위로 거부한다")
+		void 개수_초과() {
+			List<MultipartFile> files = Arrays.asList(
+					file("a", "a.png", 10), file("b", "b.png", 10), file("c", "c.png", 10));
+
+			EgovUploadRejectedException ex = assertThrows(EgovUploadRejectedException.class,
+					() -> EgovMultipartFiles.validateAll(policy(), files));
+			assertEquals(EgovUploadPolicy.Reason.COUNT_EXCEEDED, ex.getReason());
+
+			Map<MultipartFile, EgovUploadPolicy.Reason> violations =
+					EgovMultipartFiles.checkAll(policy(), files);
+			assertEquals(EgovUploadPolicy.Reason.COUNT_EXCEEDED, violations.get(null));
+		}
+
+		@Test
+		@DisplayName("null 목록은 빈 목록으로 다룬다")
+		void null_목록() {
+			EgovMultipartFiles.validateAll(policy(), null);
+			assertTrue(EgovMultipartFiles.checkAll(policy(), null).isEmpty());
+		}
+	}
+
+	@Nested
+	@DisplayName("MultipartResolver 어댑터")
+	class Resolver {
+
+		@Test
+		@DisplayName("정책 없이 만들 수 없다 — 설정 누락이 무검증으로 이어지지 않도록")
+		void 정책_필수() {
+			assertThrows(IllegalArgumentException.class,
+					() -> new EgovValidatingMultipartResolver(null));
+		}
+
+		@Test
+		@DisplayName("요청 전체 파일에 정책을 적용한다")
+		void 요청_전체_적용() {
+			EgovValidatingMultipartResolver resolver = new EgovValidatingMultipartResolver(policy());
+			MockMultipartHttpServletRequest request = new MockMultipartHttpServletRequest();
+			request.addFile(new MockMultipartFile("good", "a.png", null, "x".getBytes(StandardCharsets.UTF_8)));
+			request.addFile(new MockMultipartFile("bad", "b.exe", null, "x".getBytes(StandardCharsets.UTF_8)));
+
+			EgovUploadRejectedException ex = assertThrows(EgovUploadRejectedException.class,
+					() -> resolver.applyPolicy(request));
+			assertEquals(EgovUploadPolicy.Reason.EXTENSION_NOT_ALLOWED, ex.getReason());
+		}
+
+		@Test
+		@DisplayName("허용된 파일만 있으면 통과한다")
+		void 정상_요청_통과() {
+			EgovValidatingMultipartResolver resolver = new EgovValidatingMultipartResolver(policy());
+			MockMultipartHttpServletRequest request = new MockMultipartHttpServletRequest();
+			request.addFile(new MockMultipartFile("f", "a.png", null, "x".getBytes(StandardCharsets.UTF_8)));
+
+			resolver.applyPolicy(request);
+		}
+
+		@Test
+		@DisplayName("적용 중인 정책을 확인할 수 있다")
+		void 정책_조회() {
+			EgovUploadPolicy p = policy();
+
+			assertEquals(p, new EgovValidatingMultipartResolver(p).getPolicy());
+		}
+
+		@Test
+		@DisplayName("거부 사유는 MultipartException 의 cause 로 전달된다")
+		void 사유_전달_형태() {
+			MultipartException wrapped = new MultipartException("rejected",
+					new EgovUploadRejectedException(EgovUploadPolicy.Reason.SIZE_EXCEEDED, "a.png"));
+
+			assertTrue(wrapped.getCause() instanceof EgovUploadRejectedException);
+			assertEquals(EgovUploadPolicy.Reason.SIZE_EXCEEDED,
+					((EgovUploadRejectedException) wrapped.getCause()).getReason());
+		}
+
+		@Test
+		@DisplayName("파일이 없는 요청은 통과한다")
+		void 파일_없는_요청() {
+			EgovValidatingMultipartResolver resolver = new EgovValidatingMultipartResolver(policy());
+
+			resolver.applyPolicy(new MockMultipartHttpServletRequest());
+			assertTrue(EgovMultipartFiles.checkAll(policy(), Collections.emptyList()).isEmpty());
+		}
+	}
+}


### PR DESCRIPTION
> **[공통컴포넌트 공통 기능 개선 → 실행환경 이관]**
>
> 공통컴포넌트에 있던 공통 기능을 개선해 실행환경으로 올리는 항목입니다.
> 실행환경에 올라가면 공통컴포넌트를 포함한 모든 사업에서 같은 구현을 쓸 수 있습니다.
>
> 공통컴포넌트 원본
> - `egovframework.com.utl.fcc.service.EgovFileUploadUtil`
> - `egovframework.com.cmm.web.EgovMultipartResolver`

## 수정 사유 Reason for modification

- [ ] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [X] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

### 배경

`EgovUploadPolicy` 는 **이름과 크기만 받는 순수 정책 객체**입니다. MVC 에서 쓰려면

- `MultipartFile` 에서 이름·크기를 꺼내고
- **브라우저가 붙여 보낸 경로를 떼고**(IE 계열은 전체 경로를 보냅니다)
- 여러 파일을 **개수 한도까지 함께** 보는

어댑터가 필요합니다. 그 조립을 사업마다 반복하면 결국 같은 실수가 반복됩니다.

### 추가한 것

**`upload/EgovMultipartFiles`** — `MultipartFile` 대상 검증 도우미

| 메서드 | 동작 |
|---|---|
| `validate(파일 또는 목록, 정책)` | 위반 시 예외 |
| `check(목록, 정책)` | **위반한 것만 골라 반환**(판정형) |

**`upload/EgovValidatingMultipartResolver`** — 요청 전체에 정책을 적용하는 `MultipartResolver`

- **정책 없이 생성할 수 없습니다** — 설정 누락이 무검증으로 이어지지 않도록
- 거부 사유는 **`MultipartException` 의 `cause`** 로 전달해 원인이 보존됩니다

### 설계 메모

- **채우지 않은 입력칸(파일명 없음·0바이트)은 개수에서 제외**합니다. 화면이 입력칸을 여러 개 두고 일부만
  채우는 것이 보통이라, 빈 칸까지 세면 개수 한도가 의미를 잃습니다. 반면 **파일명이 있는 0바이트 파일은
  제출된 것**이라 정책이 판정합니다(기본 거부)
- **개수 초과는 파일별 사유가 아니라 요청 단위로 거부**합니다
- `null` 목록은 빈 목록으로 다루고, 파일·파일명이 `null` 이면 거부합니다

### 추가되는 의존성

| 좌표 | 비고 |
|---|---|
| `org.egovframe.rte:egovframe-rte-fdl-filehandling` | **같은 실행환경 모듈** — 외부 의존 아님 |

**보안 재검증 반영(2026-09-07)** — 컬렉션 검증(`validateAll`/`checkAll`)과 리졸버가 `isEmpty()` 항목을 전부 제외해 **파일명이 있는 0바이트 파일이 정책 판정 없이 통과**하고 개수 상한도 같은 경로로 우회되던 것을, 제외 기준을 "파일명도 내용도 없는 항목(채우지 않은 입력칸)" 으로 좁혀 닫았습니다. 내용이 없어 코드 실행은 안 되지만 `.jsp`·`web.config`·`.htaccess` 같은 임의 이름의 빈 파일이 저장 경로에 생기고 정책의 기본 거부·화이트리스트·개수 상한이 무력화되던 결함입니다. `fileNameOf` 는 Windows 드라이브 접두(`C:name`)도 뗍니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

`EgovMultipartFilesTest` **16건** + 보안 회귀 `EgovMultipartFilesSecurityTest` **6건**, 합계 **22건 신규**. `ptl.mvc` 모듈 전건 통과.

| 환경 | 기본 로케일(Locale) | 모듈 실행 건수 | 결과 |
|---|---|---:|---|
| **Windows** | ko_KR | **64** | `Tests run: 64, Failures: 0, Errors: 0, Skipped: 0` |
| **Linux** (Ubuntu 22.04 / OpenJDK 17) | C.UTF-8 | **64** | `Tests run: 64, Failures: 0, Errors: 0, Skipped: 0` |

| 구분 | 건수 | 내용 |
|---|---:|---|
| 파일명 처리 | 4 | **브라우저가 붙인 경로 제거** · 경로가 붙어도 정상 파일 통과 · 파일명 `null` 거부 · 파일 `null` 거부 |
| 여러 파일 검증 | 6 | 전부 통과 · 하나라도 위반이면 예외 · `check` 는 위반만 반환 · **빈 파일 항목은 개수에서 제외** · **개수 초과는 요청 단위 거부** · `null` 목록은 빈 목록 |
| 리졸버 어댑터 | 6 | **정책 없이 생성 불가** · 요청 전체 적용 · 허용 파일만 있으면 통과 · 적용 정책 확인 · **거부 사유는 `MultipartException` 의 `cause`** · 파일 없는 요청 통과 |

`EgovMultipartFilesSecurityTest` 6건 — **파일명이 있는 0바이트 파일은 정책이 판정**(`shell.jsp` 0 B 는 `EMPTY_FILE`, `allowEmptyFile` 이면 확장자 검사) · 채우지 않은 입력칸(파일명 없음·0 B)은 계속 제외 · 개수 상한을 빈 파일로 우회 불가 · 리졸버 거부 시 정리와 파일명 비반사 · content-type 비의존 · 경로·드라이브 접두 정규화.

**수동 확인**: 파일명에서 경로를 떼는 처리가 OS 구분자에 얽히므로 Linux 에서 교차 검증했습니다.

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

해당 없음 — 서버 측 검증 유틸·리졸버이며, 검증은 위 JUnit(`MockMultipartFile`)으로 수행했습니다.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

해당 없음 — 위 JUnit 테스트 결과로 갈음합니다.

---

<sub>base: `eGovFramework:main` @ `7ab591b` (2026-09-09 fetch 기준, #399·#400 머지 후) · 단일 커밋</sub>
