### PR TITLE
fix: 예외 후처리 매니저가 싱글톤 상태로 발생 위치를 넘겨 동시 요청 간에 섞이던 문제 수정

### DIFF
--- a/Foundation/org.egovframe.rte.fdl.cmmn/src/main/java/org/egovframe/rte/fdl/cmmn/aspect/ExceptionTransfer.java
+++ b/Foundation/org.egovframe.rte.fdl.cmmn/src/main/java/org/egovframe/rte/fdl/cmmn/aspect/ExceptionTransfer.java
@@ -50,6 +50,7 @@ import java.util.Locale;
  * 2009.05.30	Judd Cho		최초 생성
  * 2015.01.31	Vincent Han		코드 품질 개선 및 보완 (processHandling 메소드 Exception 처리)
  * 2020.08.31	유지보수			시큐어코딩(ES)-Private 배열에 Public 데이터 할당[CWE-496]
+ * 2026.09.10	실행환경 개발팀		후처리 매니저 호출을 run(Exception, String) 으로 — 싱글톤 상태 변경 제거
  * </pre>
  * @since 2009.06.01
  */
@@ -219,15 +220,16 @@ public class ExceptionTransfer {
         if (exceptionHandlerServices == null) {
             return;
         }
-
+        // 발생 위치를 파라미터로 전달한다. 싱글톤 매니저 빈의 상태(setPackageName)를 바꾸는 방식은
+        // 동시 요청 간에 발생 위치가 섞인다.
+        String packageName = clazz.getCanonicalName() + "." + methodName;
         for (ExceptionHandlerService ehm : exceptionHandlerServices) {
             // 2026.02.28 KISA 보안취약점 조치
             try {
                 if (!ehm.hasReqExpMatcher()) {
                     ehm.setReqExpMatcher(pm);
                 }
-                ehm.setPackageName(clazz.getCanonicalName() + "." + methodName);
-                ehm.run(exception);
+                ehm.run(exception, packageName);
             } catch (NullPointerException e) {
                 LOGGER.debug("[{}] ExceptionTransfer processHandling() Error >>> {}", e.getClass().getSimpleName(), e.getMessage());
             } catch (IllegalArgumentException e) {

--- a/Foundation/org.egovframe.rte.fdl.cmmn/src/main/java/org/egovframe/rte/fdl/cmmn/exception/manager/AbstractExceptionHandleManager.java
+++ b/Foundation/org.egovframe.rte.fdl.cmmn/src/main/java/org/egovframe/rte/fdl/cmmn/exception/manager/AbstractExceptionHandleManager.java
@@ -25,6 +25,8 @@ import org.springframework.util.PathMatcher;
  * 사용자 ExceptionHandleManager 구현시 상속되는 추상클래스이다.
  * ExceptionHandlerService 인터페이스의 메소드를 거의 다 구현해 놓은 추상클래스이기 때문에 사용자가 구현시
  * run(Exception exception) 만 구현을 해주면 된다.
+ * 실행환경은 {@code ExceptionHandlerService#run(Exception, String)} 으로 호출하므로, 싱글톤 빈의 상태 변경 없이
+ * 처리하려면 그 메소드를 재정의한다.
  *
  * @author Judd Cho (horanghi@gmail.com)
  * @version 1.0
@@ -35,6 +37,7 @@ import org.springframework.util.PathMatcher;
  * ----------------------------------------------
  * 2009.05.30	Judd Cho			최초 생성
  * 2015.01.31	Vincent Han			코드 품질 개선
+ * 2026.09.10	실행환경 개발팀		싱글톤 상태 변경 방식(setPackageName·run(Exception)) deprecated
  * </pre>
  * @since 2009.06.01
  */
@@ -83,7 +86,10 @@ public abstract class AbstractExceptionHandleManager {
      * 비교할 클래스 정보
      *
      * @param canonicalName 비교할 클래스명
+     * @deprecated 싱글톤 빈의 필드를 요청마다 바꾸는 방식이라 동시 요청에서 다른 호출의
+     * 발생 위치로 매칭될 수 있다. {@code ExceptionHandlerService#run(Exception, String)} 으로 발생 위치를 직접 전달한다.
      */
+    @Deprecated
     public void setPackageName(String canonicalName) {
         this.thisPackageName = canonicalName;
     }
@@ -129,7 +135,10 @@ public abstract class AbstractExceptionHandleManager {
      *
      * @param exception 발생한 Exception
      * @return boolean 실행성공여부
+     * @deprecated {@link #setPackageName(String)} 으로 미리 넣어 둔 필드에 의존하므로 동시 요청에서
+     * 오동작할 수 있다. {@code ExceptionHandlerService#run(Exception, String)} 으로 대체한다.
      */
+    @Deprecated
     public boolean run(Exception exception) throws Exception {
         if (!enableMatcher()) {
             return false;

--- a/Foundation/org.egovframe.rte.fdl.cmmn/src/main/java/org/egovframe/rte/fdl/cmmn/exception/manager/DefaultExceptionHandleManager.java
+++ b/Foundation/org.egovframe.rte.fdl.cmmn/src/main/java/org/egovframe/rte/fdl/cmmn/exception/manager/DefaultExceptionHandleManager.java
@@ -34,6 +34,7 @@ import org.slf4j.LoggerFactory;
  * ----------------------------------------------
  * 2009.05.30	Judd Cho			최초 생성
  * 2015.01.31	Vincent Han			코드 품질 개선
+ * 2026.09.10	실행환경 개발팀		발생 위치를 파라미터로 받는 run(Exception, String) 구현 — 싱글톤 필드 비의존
  * </pre>
  * @since 2009.06.01
  */
@@ -41,6 +42,7 @@ public class DefaultExceptionHandleManager extends AbstractExceptionHandleManage
 
     private static final Logger LOGGER = LoggerFactory.getLogger(DefaultExceptionHandleManager.class);
 
+    @Deprecated
     @Override
     public boolean run(Exception exception) throws Exception {
         LOGGER.debug(" DefaultExceptionHandleManager.run() ");
@@ -54,6 +56,35 @@ public class DefaultExceptionHandleManager extends AbstractExceptionHandleManage
             if (pm.match(pattern, thisPackageName)) {
                 for (ExceptionHandler eh : handlers) {
                     eh.occur(exception, getPackageName());
+                }
+                break;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * 발생 위치를 파라미터로 받아 처리한다. 싱글톤 빈의 필드를 읽거나 바꾸지 않으므로
+     * 동시 요청에서도 각 호출의 발생 위치로 매칭·전달된다.
+     *
+     * <p>이 클래스를 상속해 {@link #run(Exception)} 을 재정의한 구현이 있을 수 있으므로,
+     * 하위 클래스 인스턴스에서는 인터페이스의 기본 구현(구 방식 + 잠금)으로 위임해 재정의된 동작을 유지한다.</p>
+     */
+    @Override
+    public boolean run(Exception exception, String packageName) throws Exception {
+        if (getClass() != DefaultExceptionHandleManager.class) {
+            return ExceptionHandlerService.super.run(exception, packageName);
+        }
+        LOGGER.debug(" DefaultExceptionHandleManager.run() ");
+        // 매칭조건이 false 인 경우
+        if (!enableMatcher()) {
+            return false;
+        }
+        for (String pattern : patterns) {
+            LOGGER.debug("pattern = {}, packageName = {}", pattern, packageName);
+            if (pm.match(pattern, packageName)) {
+                for (ExceptionHandler eh : handlers) {
+                    eh.occur(exception, packageName);
                 }
                 break;
             }

--- a/Foundation/org.egovframe.rte.fdl.cmmn/src/main/java/org/egovframe/rte/fdl/cmmn/exception/manager/ExceptionHandlerService.java
+++ b/Foundation/org.egovframe.rte.fdl.cmmn/src/main/java/org/egovframe/rte/fdl/cmmn/exception/manager/ExceptionHandlerService.java
@@ -31,6 +31,7 @@ import org.springframework.util.PathMatcher;
  * ----------------------------------------------
  * 2009.05.30	Judd Cho			최초 생성
  * 2015.01.31	Vincent Han			코드 품질 개선
+ * 2026.09.10	실행환경 개발팀		발생 위치를 파라미터로 받는 run(Exception, String) 추가 — 싱글톤 상태 변경 방식 deprecated
  * </pre>
  * @since 2009.06.01
  */
@@ -54,7 +55,10 @@ public interface ExceptionHandlerService {
      * 비교할 클래스 정보.
      *
      * @param canonicalName 비교할 클래스명
+     * @deprecated 싱글톤 빈의 상태를 요청마다 바꾸는 방식이라 동시 요청에서 다른 호출의
+     * 발생 위치로 매칭될 수 있다. {@link #run(Exception, String)} 으로 발생 위치를 직접 전달한다.
      */
+    @Deprecated
     void setPackageName(String canonicalName);
 
     /**
@@ -76,8 +80,31 @@ public interface ExceptionHandlerService {
      *
      * @param exception 발생한 Exception
      * @return boolean 실행성공여부
+     * @deprecated {@link #setPackageName(String)} 으로 미리 넣어 둔 상태에 의존하므로 동시 요청에서
+     * 오동작할 수 있다. {@link #run(Exception, String)} 으로 대체한다.
      */
+    @Deprecated
     boolean run(Exception exception) throws Exception;
+
+    /**
+     * 발생 위치(패키지.클래스.메소드)를 파라미터로 받아 후처리 로직을 실행한다.
+     * 실행환경의 {@code ExceptionTransfer} 는 이 메소드로 호출한다.
+     *
+     * <p>기본 구현은 하위 호환을 위해 구 방식({@link #setPackageName(String)} 뒤 {@link #run(Exception)})으로
+     * 위임하되, 인스턴스 잠금으로 동시 호출 간의 발생 위치 혼선을 막는다. 구현체가 이 메소드를 직접
+     * 재정의하면 잠금 없이 상태 변경 없는 처리가 가능하다({@code DefaultExceptionHandleManager} 참고).</p>
+     *
+     * @param exception   발생한 Exception
+     * @param packageName 발생 위치(패키지.클래스.메소드)
+     * @return boolean 실행성공여부
+     * @throws Exception 후처리 중 발생한 예외
+     */
+    default boolean run(Exception exception, String packageName) throws Exception {
+        synchronized (this) {
+            setPackageName(packageName);
+            return run(exception);
+        }
+    }
 
     /**
      * PathMatcher 가 있는지 여부 반환.

--- a/Foundation/org.egovframe.rte.fdl.cmmn/src/test/java/org/egovframe/rte/fdl/cmmn/exception/manager/ExceptionHandlerPackageNameTest.java
+++ b/Foundation/org.egovframe.rte.fdl.cmmn/src/test/java/org/egovframe/rte/fdl/cmmn/exception/manager/ExceptionHandlerPackageNameTest.java
@@ -1,0 +1,207 @@
+package org.egovframe.rte.fdl.cmmn.exception.manager;
+
+import org.egovframe.rte.fdl.cmmn.exception.handler.ExceptionHandler;
+import org.junit.jupiter.api.Test;
+import org.springframework.util.AntPathMatcher;
+import org.springframework.util.PathMatcher;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * 예외 후처리 매니저가 발생 위치를 파라미터로 받아 처리하는 경로(run(Exception, String))와
+ * 구 방식 구현체의 하위 호환을 검증한다.
+ */
+public class ExceptionHandlerPackageNameTest {
+
+    /** 전달받은 (예외 메시지, packageName) 쌍을 기록하는 핸들러 — 메시지에 기대 발생 위치를 실어 보낸다 */
+    static class RecordingHandler implements ExceptionHandler {
+        final List<String[]> received = new CopyOnWriteArrayList<>();
+
+        @Override
+        public void occur(Exception exception, String packageName) {
+            received.add(new String[] {exception.getMessage(), packageName});
+        }
+
+        long mismatches() {
+            return received.stream().filter(pair -> !pair[0].equals(pair[1])).count();
+        }
+    }
+
+    /** 구 방식(setPackageName 뒤 run(Exception))만 아는 커스텀 구현체 */
+    @SuppressWarnings("deprecation")
+    static class LegacyManager implements ExceptionHandlerService {
+        private final ExceptionHandler handler;
+        private String packageName;
+
+        LegacyManager(ExceptionHandler handler) {
+            this.handler = handler;
+        }
+
+        @Override
+        public void setPatterns(String[] patterns) {
+        }
+
+        @Override
+        public void setHandlers(ExceptionHandler[] handlers) {
+        }
+
+        @Override
+        public void setPackageName(String canonicalName) {
+            this.packageName = canonicalName;
+        }
+
+        @Override
+        public void setException(Exception be) {
+        }
+
+        @Override
+        public void setReqExpMatcher(PathMatcher pm) {
+        }
+
+        @Override
+        public boolean run(Exception exception) {
+            handler.occur(exception, packageName);
+            return true;
+        }
+
+        @Override
+        public boolean hasReqExpMatcher() {
+            return true;
+        }
+    }
+
+    private DefaultExceptionHandleManager newManager(RecordingHandler handler) {
+        DefaultExceptionHandleManager manager = new DefaultExceptionHandleManager();
+        manager.setPatterns(new String[] {"org.sample.**"});
+        manager.setHandlers(new ExceptionHandler[] {handler});
+        manager.setReqExpMatcher(new AntPathMatcher());
+        return manager;
+    }
+
+    @Test
+    @SuppressWarnings("deprecation")
+    public void testRunWithPackageNameIgnoresSingletonField() throws Exception {
+        RecordingHandler handler = new RecordingHandler();
+        DefaultExceptionHandleManager manager = newManager(handler);
+
+        // 다른 요청이 남긴 것처럼 싱글톤 필드를 오염시켜도
+        manager.setPackageName("org.other.PollutedService.method");
+        manager.run(new Exception("org.sample.OrderService.create"), "org.sample.OrderService.create");
+
+        assertEquals(1, handler.received.size());
+        assertEquals("org.sample.OrderService.create", handler.received.get(0)[1],
+                "매칭과 전달 모두 파라미터의 발생 위치를 사용해야 한다");
+        assertEquals("org.other.PollutedService.method", manager.getPackageName(),
+                "파라미터 경로는 싱글톤 필드를 바꾸지 않는다");
+    }
+
+    @Test
+    public void testRunWithPackageNameSkipsUnmatchedPattern() throws Exception {
+        RecordingHandler handler = new RecordingHandler();
+        DefaultExceptionHandleManager manager = newManager(handler);
+
+        assertTrue(manager.run(new Exception("e"), "com.unmatched.Service.method"));
+
+        assertTrue(handler.received.isEmpty());
+    }
+
+    @Test
+    public void testRunWithPackageNameReturnsFalseWithoutMatcher() throws Exception {
+        RecordingHandler handler = new RecordingHandler();
+        DefaultExceptionHandleManager manager = new DefaultExceptionHandleManager();
+        manager.setPatterns(new String[] {"org.sample.**"});
+        manager.setHandlers(new ExceptionHandler[] {handler});
+
+        assertFalse(manager.run(new Exception("e"), "org.sample.Service.method"));
+        assertTrue(handler.received.isEmpty());
+    }
+
+    @Test
+    public void testConcurrentRunsDeliverEachCallsOwnPackageName() throws Exception {
+        RecordingHandler handler = new RecordingHandler();
+        DefaultExceptionHandleManager manager = newManager(handler);
+
+        runConcurrently(manager, handler);
+    }
+
+    @Test
+    public void testLegacyImplementationStillWorksThroughDefaultMethod() throws Exception {
+        RecordingHandler handler = new RecordingHandler();
+        ExceptionHandlerService legacy = new LegacyManager(handler);
+
+        legacy.run(new Exception("org.sample.LegacyService.method"), "org.sample.LegacyService.method");
+
+        assertEquals(1, handler.received.size());
+        assertEquals("org.sample.LegacyService.method", handler.received.get(0)[1],
+                "기본 구현이 구 방식으로 위임하여 커스텀 구현체가 수정 없이 동작해야 한다");
+    }
+
+    @Test
+    public void testLegacyImplementationIsSerializedUnderConcurrency() throws Exception {
+        RecordingHandler handler = new RecordingHandler();
+        ExceptionHandlerService legacy = new LegacyManager(handler);
+
+        runConcurrently(legacy, handler);
+    }
+
+    @Test
+    public void testSubclassOverridingLegacyRunKeepsItsBehavior() throws Exception {
+        RecordingHandler handler = new RecordingHandler();
+        List<String> overridden = new CopyOnWriteArrayList<>();
+        DefaultExceptionHandleManager subclass = new DefaultExceptionHandleManager() {
+            @Override
+            @SuppressWarnings("deprecation")
+            public boolean run(Exception exception) throws Exception {
+                overridden.add(getPackageName());
+                return super.run(exception);
+            }
+        };
+        subclass.setPatterns(new String[] {"org.sample.**"});
+        subclass.setHandlers(new ExceptionHandler[] {handler});
+        subclass.setReqExpMatcher(new AntPathMatcher());
+
+        subclass.run(new Exception("org.sample.SubService.method"), "org.sample.SubService.method");
+
+        assertEquals(List.of("org.sample.SubService.method"), overridden,
+                "하위 클래스가 재정의한 run(Exception) 이 계속 호출되어야 한다");
+        assertEquals(1, handler.received.size());
+        assertEquals("org.sample.SubService.method", handler.received.get(0)[1]);
+    }
+
+    private static void runConcurrently(ExceptionHandlerService service, RecordingHandler handler) throws Exception {
+        int threads = 4;
+        int iterations = 200;
+        ExecutorService executor = Executors.newFixedThreadPool(threads);
+        CountDownLatch ready = new CountDownLatch(threads);
+        CountDownLatch start = new CountDownLatch(1);
+        for (int t = 0; t < threads; t++) {
+            final int threadNo = t;
+            executor.submit(() -> {
+                ready.countDown();
+                start.await();
+                for (int i = 0; i < iterations; i++) {
+                    String packageName = "org.sample.Svc" + threadNo + ".m" + i;
+                    service.run(new Exception(packageName), packageName);
+                }
+                return null;
+            });
+        }
+        ready.await();
+        start.countDown();
+        executor.shutdown();
+        assertTrue(executor.awaitTermination(30, TimeUnit.SECONDS));
+
+        assertEquals(threads * iterations, handler.received.size());
+        assertEquals(0, handler.mismatches(),
+                "동시 실행에서도 각 호출의 발생 위치가 그 호출의 핸들러에 전달되어야 한다");
+    }
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

### 문제

`ExceptionTransfer.processHandling()` 은 등록된 후처리 매니저(`ExceptionHandlerService`)마다
**`setPackageName(발생 위치)` 로 싱글톤 빈의 필드를 바꾼 뒤 `run(exception)` 을 호출**합니다.
매니저는 Spring 싱글톤이므로 두 요청이 동시에 예외를 내면 한 요청이 넣은 발생 위치를
다른 요청의 `run()` 이 읽습니다. 그 결과

- 패턴 매칭이 **다른 요청의 발생 위치로 판정**되어 핸들러가 실행되지 않거나 엉뚱한 예외에 실행되고,
- 핸들러의 `occur(exception, packageName)` 이 **다른 요청의 발생 위치를 전달**받아 로그·알림에 잘못된 위치가 남습니다.

`DefaultExceptionHandleManager` 에 구 방식(`setPackageName` 뒤 `run`)으로 4 스레드 × 200 회를 동시에
넣으면 **800 건 중 776 건**에서 핸들러가 받은 발생 위치가 그 호출의 것과 달랐습니다.

### 수정

발생 위치를 **파라미터로 전달**하고 싱글톤 상태를 건드리지 않게 했습니다.

| 파일 | 변경 |
|---|---|
| `ExceptionHandlerService` | `run(Exception exception, String packageName)` 추가. **기본 구현은 구 방식으로 위임**하되 인스턴스 잠금으로 동시 호출 간 혼선을 막습니다. `setPackageName`·`run(Exception)` 은 deprecated |
| `DefaultExceptionHandleManager` | `run(Exception, String)` 을 **싱글톤 필드 없이** 구현합니다(잠금 없음). 이 클래스를 상속해 `run(Exception)` 을 재정의한 하위 클래스 인스턴스는 인터페이스 기본 구현으로 위임해 재정의된 동작을 유지합니다 |
| `AbstractExceptionHandleManager` | `setPackageName`·`run(Exception)` deprecated 표기와 안내 |
| `ExceptionTransfer` | `ehm.run(exception, packageName)` 으로 호출 |

### 하위 호환

- **기존 커스텀 구현체는 수정 없이 동작합니다.** `ExceptionHandlerService` 를 직접 구현했거나
  `AbstractExceptionHandleManager` 를 상속해 `run(Exception)` 만 구현한 경우, 새 메소드의 기본 구현이
  구 방식으로 호출합니다. 달라지는 것은 그 호출이 인스턴스 단위로 직렬화된다는 점뿐이며, 이전에는
  같은 구간이 경합 상태였습니다.
- 기본 제공 `DefaultExceptionHandleManager` 를 그대로 쓰는 설정(대부분의 경우)은 잠금 없이 파라미터 경로로 처리됩니다.
- 공개 시그니처를 제거하거나 바꾸지 않았습니다. deprecated 표기는 컴파일 경고만 냅니다.
- `AbstractExceptionHandleManager` 클래스 javadoc 이 안내하는 확장 방식(`run(Exception)` 재정의)도 계속 유효하며, 상태 변경 없이 처리하려면 `run(Exception, String)` 을 재정의하면 됩니다.

> 최근 머지된 #351 이 후처리 서비스가 없을 때의 `NullPointerException` 을 막았습니다. 이 PR 은 서비스가
> 있을 때의 동시성 결함을 다루며 #351 의 가드는 그대로 둡니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

`ExceptionHandlerPackageNameTest` **7건 신규**, `fdl.cmmn` 모듈 전건 통과.

| 환경 | 기본 로케일(Locale) | 모듈 실행 건수 | 결과 |
|---|---|---:|---|
| **Windows** | ko_KR | **49** | `Tests run: 49, Failures: 0, Errors: 0, Skipped: 0` |
| **Linux** (Ubuntu 22.04 / OpenJDK 17) | C.UTF-8 | **49** | `Tests run: 49, Failures: 0, Errors: 0, Skipped: 0` |

| 구분 | 건수 | 내용 |
|---|---:|---|
| **결함 회귀** | 2 | 싱글톤 필드를 오염시켜도 파라미터의 발생 위치로 매칭·전달하고 필드를 바꾸지 않는다 · **동시 실행(4 스레드 × 200 회)에서 각 호출의 발생 위치가 그 호출의 핸들러에 전달**된다 |
| 매칭 계약 | 2 | 패턴 불일치 시 핸들러 미호출 · `PathMatcher` 부재 시 `false` |
| **하위 호환** | 3 | 구 방식만 구현한 커스텀 구현체가 기본 구현으로 동작 · 그 구현체도 동시 실행에서 혼선 없음(직렬화) · `DefaultExceptionHandleManager` 를 상속해 `run(Exception)` 을 재정의한 하위 클래스의 재정의가 계속 호출된다 |

동시성 테스트는 핸들러가 받은 (예외 메시지, 발생 위치) 쌍을 호출마다 비교하므로, 발생 위치가 서로 바뀐 경우를 놓치지 않습니다.

**수동 확인**: 현재 `main`(`7741b59`) 위에서 `fdl.cmmn` 모듈 빌드·테스트가 통과함을 Windows 와 Linux 에서 확인했습니다.

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

해당 없음 — 라이브러리 내부 수정입니다.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

해당 없음 — 위 JUnit 테스트 결과로 갈음합니다.

---

<sub>base: `eGovFramework:main` @ `7741b59` (2026-09-10 fetch 기준, #360~#365 머지 후) · 단일 커밋</sub>
