### PR TITLE
fix: DefaultTraceHandler 가 전달받은 발생 클래스와 메시지를 로그에 남기지 않던 문제 수정

### DIFF
--- a/Foundation/org.egovframe.rte.fdl.cmmn/src/main/java/org/egovframe/rte/fdl/cmmn/trace/handler/DefaultTraceHandler.java
+++ b/Foundation/org.egovframe.rte.fdl.cmmn/src/main/java/org/egovframe/rte/fdl/cmmn/trace/handler/DefaultTraceHandler.java
@@ -30,6 +30,7 @@ import org.slf4j.LoggerFactory;
  * ----------------------------------------------
  * 2009.05.30	Judd Cho			최초 생성
  * 2015.01.31	Vincent Han			코드 품질 개선 및 Logger 적용
+ * 2026.09.10	실행환경 개발팀		전달받은 발생 클래스와 메시지를 실제로 로그에 남기도록 수정
  * </pre>
  * @since 2009.06.01
  */
@@ -37,8 +38,14 @@ public class DefaultTraceHandler implements TraceHandler {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(DefaultTraceHandler.class);
 
+    /**
+     * 발생 클래스와 해석된 trace 메시지를 로그에 남긴다.
+     *
+     * @param clazz   trace 를 발생시킨 클래스(null 이면 unknown 으로 표기)
+     * @param message 메시지 키로 해석된 메시지
+     */
     public void todo(Class<?> clazz, String message) {
-        LOGGER.debug("DefaultTraceHandler run...............");
+        LOGGER.debug("LeaveaTrace [{}] : {}", clazz != null ? clazz.getName() : "unknown", message);
     }
 
 }

--- a/Foundation/org.egovframe.rte.fdl.cmmn/src/test/java/org/egovframe/rte/fdl/cmmn/trace/handler/DefaultTraceHandlerTest.java
+++ b/Foundation/org.egovframe.rte.fdl.cmmn/src/test/java/org/egovframe/rte/fdl/cmmn/trace/handler/DefaultTraceHandlerTest.java
@@ -1,0 +1,133 @@
+package org.egovframe.rte.fdl.cmmn.trace.handler;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.appender.AbstractAppender;
+import org.apache.logging.log4j.core.config.Configuration;
+import org.apache.logging.log4j.core.config.LoggerConfig;
+import org.egovframe.rte.fdl.cmmn.trace.LeaveaTrace;
+import org.egovframe.rte.fdl.cmmn.trace.manager.DefaultTraceHandleManager;
+import org.egovframe.rte.fdl.cmmn.trace.manager.TraceHandlerService;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.support.StaticMessageSource;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * 기본 TraceHandler 가 전달받은 발생 클래스와 메시지를 실제로 로그에 남기는지 검증한다.
+ */
+public class DefaultTraceHandlerTest {
+
+    private static final String LOGGER_NAME = DefaultTraceHandler.class.getName();
+
+    private CapturingAppender appender;
+
+    @BeforeEach
+    void setUp() {
+        LoggerContext context = (LoggerContext) LogManager.getContext(false);
+        Configuration configuration = context.getConfiguration();
+        appender = new CapturingAppender();
+        appender.start();
+
+        LoggerConfig loggerConfig = new LoggerConfig(LOGGER_NAME, Level.DEBUG, false);
+        loggerConfig.addAppender(appender, Level.DEBUG, null);
+        configuration.addLogger(LOGGER_NAME, loggerConfig);
+        context.updateLoggers();
+    }
+
+    @AfterEach
+    void tearDown() {
+        LoggerContext context = (LoggerContext) LogManager.getContext(false);
+        context.getConfiguration().removeLogger(LOGGER_NAME);
+        context.updateLoggers();
+        appender.stop();
+    }
+
+    @Test
+    public void testTodoLogsClassNameAndMessage() {
+        new DefaultTraceHandler().todo(DefaultTraceHandlerTest.class, "주문 처리 시작");
+
+        List<String> messages = appender.messages();
+        assertEquals(1, messages.size());
+        assertTrue(messages.get(0).contains(DefaultTraceHandlerTest.class.getName()),
+                "발생 클래스명이 로그에 있어야 한다: " + messages.get(0));
+        assertTrue(messages.get(0).contains("주문 처리 시작"),
+                "전달받은 메시지가 로그에 있어야 한다: " + messages.get(0));
+        assertEquals(Level.DEBUG, appender.events().get(0).getLevel());
+    }
+
+    @Test
+    public void testTodoWithNullClassDoesNotThrow() {
+        assertDoesNotThrow(() -> new DefaultTraceHandler().todo(null, "클래스 없음"));
+
+        List<String> messages = appender.messages();
+        assertEquals(1, messages.size());
+        assertTrue(messages.get(0).contains("unknown"));
+        assertTrue(messages.get(0).contains("클래스 없음"));
+    }
+
+    @Test
+    public void testTodoWithNullMessageDoesNotThrow() {
+        assertDoesNotThrow(() -> new DefaultTraceHandler().todo(DefaultTraceHandlerTest.class, null));
+
+        assertEquals(1, appender.messages().size());
+    }
+
+    @Test
+    public void testResolvedMessageReachesLogThroughLeaveaTrace() {
+        StaticMessageSource messageSource = new StaticMessageSource();
+        messageSource.addMessage("trace.message", Locale.KOREA, "trace {0} message");
+
+        DefaultTraceHandleManager manager = new DefaultTraceHandleManager();
+        manager.setPatterns(new String[] {"**"});
+        manager.setHandlers(new TraceHandler[] {new DefaultTraceHandler()});
+        LeaveaTrace trace = new LeaveaTrace();
+        trace.setTraceHandlerServices(new TraceHandlerService[] {manager});
+
+        trace.trace(DefaultTraceHandlerTest.class, messageSource, "trace.message", new Object[] {"resolved"}, Locale.KOREA);
+
+        List<String> messages = appender.messages();
+        assertEquals(1, messages.size());
+        assertTrue(messages.get(0).contains("trace resolved message"),
+                "메시지 키로 해석된 메시지가 기본 핸들러의 로그에 남아야 한다: " + messages.get(0));
+        assertTrue(messages.get(0).contains(DefaultTraceHandlerTest.class.getName()));
+    }
+
+    /** 로그 이벤트를 모아 두는 테스트용 Appender. */
+    private static final class CapturingAppender extends AbstractAppender {
+
+        private final List<LogEvent> events = Collections.synchronizedList(new ArrayList<>());
+
+        private CapturingAppender() {
+            super("capturing-trace", null, null, true, null);
+        }
+
+        @Override
+        public void append(LogEvent event) {
+            events.add(event.toImmutable());
+        }
+
+        private List<LogEvent> events() {
+            return new ArrayList<>(events);
+        }
+
+        private List<String> messages() {
+            List<String> messages = new ArrayList<>();
+            for (LogEvent event : events()) {
+                messages.add(event.getMessage().getFormattedMessage());
+            }
+            return messages;
+        }
+    }
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

### 문제

`LeaveaTrace` 는 메시지 키를 `MessageSource` 로 해석한 뒤, 패턴이 맞는 `TraceHandler` 의
`todo(clazz, message)` 에 발생 클래스와 해석된 메시지를 넘깁니다. 실행환경이 제공하는 기본 구현
`DefaultTraceHandler` 는 이 두 파라미터를 **전혀 사용하지 않고** 고정 문구
`"DefaultTraceHandler run..............."` 만 DEBUG 로 남깁니다.

그래서 기본 핸들러를 설정한 사업에서는 메시지 키를 해석해 놓고도 **그 메시지가 어디에도 남지
않습니다.** `LeaveaTrace.trace(...)` 에 Logger 를 직접 넘긴 경우에만 별도 줄로 찍힐 뿐, 핸들러
경로로는 발생 클래스도 메시지도 기록되지 않습니다.

### 수정

`DefaultTraceHandler.todo()` 가 발생 클래스명과 메시지를 남기도록 고쳤습니다.

```java
LOGGER.debug("LeaveaTrace [{}] : {}", clazz != null ? clazz.getName() : "unknown", message);
```

- 로그 레벨(DEBUG)과 로거 이름(`DefaultTraceHandler`)은 그대로입니다. 바뀌는 것은 로그 **내용**뿐입니다.
- `clazz` 가 `null` 이어도 예외 없이 `unknown` 으로 표기합니다.
- 인터페이스 `TraceHandler` 와 매니저(`DefaultTraceHandleManager`)는 건드리지 않았습니다.

> 열려 있는 #404 는 trace **매니저**의 진입 로그가 다른 클래스·메소드 이름을 알리는 문제를 고칩니다.
> 이 PR 은 **핸들러**가 남기는 내용을 고치는 것이라 파일이 겹치지 않으며 서로 독립입니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

`DefaultTraceHandlerTest` **4건 신규**, `fdl.cmmn` 모듈 전건 통과.

| 환경 | 기본 로케일(Locale) | 모듈 실행 건수 | 결과 |
|---|---|---:|---|
| **Windows** | ko_KR | **48** | `Tests run: 48, Failures: 0, Errors: 0, Skipped: 0` |
| **Linux** (Ubuntu 22.04 / OpenJDK 17) | C.UTF-8 | **48** | `Tests run: 48, Failures: 0, Errors: 0, Skipped: 0` |

| 구분 | 건수 | 내용 |
|---|---:|---|
| **결함 회귀** | 2 | `todo()` 로그에 발생 클래스명과 메시지가 담긴다(DEBUG) · `LeaveaTrace` → `DefaultTraceHandleManager` → `DefaultTraceHandler` 경로로 **메시지 키가 해석된 문장이 로그에 남는다**(수정 전에는 고정 문구만 남아 실패) |
| 방어적 계약 | 2 | `clazz` `null` → `unknown` 표기, 무예외 · `message` `null` 무예외 |

로그 검증은 Log4j2 `LoggerConfig` 에 캡처용 Appender 를 붙여 핸들러 로거의 DEBUG 이벤트를 읽는 방식이며, 테스트가 끝나면 설정을 되돌립니다.

**수동 확인**: 현재 `main`(`cc2b332`) 위에서 `fdl.cmmn` 모듈 빌드·테스트가 통과함을 Windows 와 Linux 에서 확인했습니다.

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

해당 없음 — 라이브러리 내부 수정입니다.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

해당 없음 — 위 JUnit 테스트 결과로 갈음합니다.

---

<sub>base: `eGovFramework:main` @ `cc2b332` (2026-09-10 fetch 기준, #366~#379 머지 후) · 단일 커밋</sub>
