### PR TITLE
fix: 테이블 채번의 초기 행 동시 INSERT 경합이 select 실패로 위장돼 채번이 실패하던 문제 수정

### DIFF
--- a/Foundation/org.egovframe.rte.fdl.idgnr/src/main/java/org/egovframe/rte/fdl/idgnr/impl/EgovTableIdGnrServiceImpl.java
+++ b/Foundation/org.egovframe.rte.fdl.idgnr/src/main/java/org/egovframe/rte/fdl/idgnr/impl/EgovTableIdGnrServiceImpl.java
@@ -19,6 +19,7 @@ import org.egovframe.rte.fdl.cmmn.exception.FdlException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.dao.DataAccessException;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.datasource.DataSourceTransactionManager;
@@ -63,6 +64,7 @@ import java.util.regex.Pattern;
  * 2013.09.04	한성곤				TransactionTemplate을 통해 transaction 처리 분리
  * 2014.08.18	한성곤				명명규칙 클래스 명 변경
  * 2017.02.28	장동한				시큐어코딩(ES)-오류 메시지를 통한 정보노출[CWE-209]
+ * 2026.09.10	실행환경 개발팀		초기 행 동시 INSERT 경합 시 새 트랜잭션에서 재시도, deprecated queryForObject 시그니처 교체
  * </pre>
  * @since 2009.02.01
  */
@@ -71,6 +73,18 @@ public class EgovTableIdGnrServiceImpl extends AbstractDataBlockIdGnrService {
     private static final Logger LOGGER = LoggerFactory.getLogger(EgovTableIdGnrServiceImpl.class);
 
     private static final Pattern SAFE_IDENTIFIER = Pattern.compile("^[a-zA-Z0-9_]+$");
+
+    /**
+     * 초기 행 INSERT 가 중복 키로 실패한 경합 신호. 현재 트랜잭션을 되돌리고 새 트랜잭션에서 한 번 더 시도하게 한다.
+     */
+    private static final class InitialRowRaceException extends RuntimeException {
+
+        private static final long serialVersionUID = 1L;
+
+        private InitialRowRaceException(DataIntegrityViolationException cause) {
+            super(cause);
+        }
+    }
 
     /**
      * ID생성을 위한 테이블 정보 디폴트는 ids임.
@@ -147,10 +161,22 @@ public class EgovTableIdGnrServiceImpl extends AbstractDataBlockIdGnrService {
      * @throws FdlException ID생성을 위한 블럭 할당이 불가능할때
      */
     private Object allocateIdBlock(final int blockSize, final boolean useBigDecimals) throws FdlException {
+        return allocateIdBlock(blockSize, useBigDecimals, true);
+    }
+
+    /**
+     * blockSize 대로 ID 지정. 초기 행 INSERT 가 다른 인스턴스와 경합해 실패하면 새 트랜잭션에서 한 번 더 시도한다.
+     *
+     * @param blockSize      지정되는 blockSize
+     * @param useBigDecimals BigDecimal 사용 여부
+     * @param retryOnRace    초기 행 경합 시 재시도 여부(재시도 호출에서는 false)
+     * @return BigDecimal을 사용하면 BigDecimal 아니면 long 리턴
+     * @throws FdlException ID생성을 위한 블럭 할당이 불가능할때
+     */
+    private Object allocateIdBlock(final int blockSize, final boolean useBigDecimals, final boolean retryOnRace) throws FdlException {
         LOGGER.debug(messageSource.getMessage("debug.idgnr.allocate.idblock", new Object[]{Integer.valueOf(blockSize), tableName}, Locale.getDefault()));
         try {
             return transactionTemplate.execute(new TransactionCallback<Object>() {
-                @SuppressWarnings("deprecation")
                 public Object doInTransaction(TransactionStatus status) {
                     Object nextId;
                     Object newNextId;
@@ -163,24 +189,24 @@ public class EgovTableIdGnrServiceImpl extends AbstractDataBlockIdGnrService {
                         LOGGER.debug("Select Query : {}", selectQuery);
                         if (useBigDecimals) {
                             try {
-                                nextId = jdbcTemplate.queryForObject(selectQuery, new Object[]{tableName}, BigDecimal.class);
+                                nextId = jdbcTemplate.queryForObject(selectQuery, BigDecimal.class, tableName);
                             } catch (EmptyResultDataAccessException erdae) {
                                 nextId = null;
                             }
 
                             if (nextId == null) { // no row
-                                insertInitId(useBigDecimals, blockSize);
+                                insertInitIdOrSignalRace(status, useBigDecimals, blockSize);
                                 return new BigDecimal(0);
                             }
                         } else {
                             try {
-                                nextId = jdbcTemplate.queryForObject(selectQuery, new Object[]{tableName}, Long.class);
+                                nextId = jdbcTemplate.queryForObject(selectQuery, Long.class, tableName);
                             } catch (EmptyResultDataAccessException erdae) {
                                 nextId = -1L;
                             }
 
                             if ((Long) nextId == -1L) { // no row
-                                insertInitId(useBigDecimals, blockSize);
+                                insertInitIdOrSignalRace(status, useBigDecimals, blockSize);
                                 return Long.valueOf(0);
                             }
                         }
@@ -208,12 +234,33 @@ public class EgovTableIdGnrServiceImpl extends AbstractDataBlockIdGnrService {
                     }
                 }
             });
+        } catch (InitialRowRaceException race) {
+            if (!retryOnRace) {
+                throw new FdlException(messageSource, "error.idgnr.select.idblock", new String[]{tableName}, race.getCause());
+            }
+            // 같은 DB를 쓰는 다른 인스턴스가 같은 순간 초기 행을 만들었다. 실패한 트랜잭션은 되돌아갔으므로
+            // 새 트랜잭션에서 이제 존재하는 행을 잠그고(FOR UPDATE) 정상 경로로 다음 블록을 받는다.
+            LOGGER.debug("Initial row for [{}] was created concurrently - retrying in a new transaction", tableName);
+            return allocateIdBlock(blockSize, useBigDecimals, false);
         } catch (RuntimeException re) {
             if (re.getCause() instanceof FdlException) {
                 throw (FdlException) re.getCause();
             } else {
                 throw re;
             }
+        }
+    }
+
+    /**
+     * 초기 행을 INSERT 한다. 중복 키 등 무결성 제약으로 실패하면 다른 인스턴스가 먼저 만든 경합이므로
+     * 트랜잭션을 되돌리고 {@link InitialRowRaceException} 으로 재시도를 요청한다.
+     */
+    private void insertInitIdOrSignalRace(TransactionStatus status, boolean useBigDecimals, int blockSize) {
+        try {
+            insertInitId(useBigDecimals, blockSize);
+        } catch (DataIntegrityViolationException dive) {
+            status.setRollbackOnly();
+            throw new InitialRowRaceException(dive);
         }
     }
 

--- a/Foundation/org.egovframe.rte.fdl.idgnr/src/test/java/org/egovframe/rte/fdl/idgnr/EgovTableIdGnrServiceInitialRowRaceTest.java
+++ b/Foundation/org.egovframe.rte.fdl.idgnr/src/test/java/org/egovframe/rte/fdl/idgnr/EgovTableIdGnrServiceInitialRowRaceTest.java
@@ -1,0 +1,188 @@
+package org.egovframe.rte.fdl.idgnr;
+
+import jakarta.annotation.Resource;
+import org.egovframe.rte.fdl.idgnr.config.IdgnrTestConfig;
+import org.egovframe.rte.fdl.idgnr.impl.EgovTableIdGnrServiceImpl;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.context.ApplicationContext;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.jdbc.datasource.DelegatingDataSource;
+import org.springframework.jdbc.datasource.init.ScriptUtils;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import javax.sql.DataSource;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Proxy;
+import java.math.BigDecimal;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.concurrent.Callable;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * 채번 테이블에 아직 행이 없을 때 두 인스턴스가 동시에 초기 행을 INSERT 하는 경합을 재현한다.
+ *
+ * <p>같은 DB 를 쓰는 다른 인스턴스(winner)가 먼저 초기 행을 만들어 커밋한 직후에 이쪽(loser)의
+ * INSERT 가 실행되도록, loser 의 DataSource 가 내주는 Connection 의 INSERT 직전에 winner 를 실행한다.
+ * 수정 전에는 loser 의 INSERT 가 중복 키로 실패해 "select 실패" FdlException 으로 끝났다.</p>
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = {IdgnrTestConfig.class})
+public class EgovTableIdGnrServiceInitialRowRaceTest {
+
+    private static final String TABLE = "idttest";
+    private static final String RACE_NAME = "race";
+    private static final int BLOCK_SIZE = 10;
+
+    @Resource(name = "dataSource")
+    private DataSource dataSource;
+
+    @Resource
+    private ApplicationContext applicationContext;
+
+    @BeforeEach
+    public void onSetUp() throws SQLException {
+        try (Connection conn = dataSource.getConnection()) {
+            ScriptUtils.executeSqlScript(conn, new ClassPathResource("/META-INF/testdata/testdb.sql"));
+        }
+        // 잠금 모드(LOCKS)에서는 loser 의 SELECT 가 테이블 공유 잠금을 잡아 winner 의 INSERT 가 대기하므로
+        // 다중 인스턴스 배포에서 실제로 일어나는 순서(양쪽 SELECT → 한쪽 INSERT 커밋 → 다른 쪽 INSERT)를
+        // 재현하려면 MVCC 가 필요하다.
+        setTransactionControl("MVCC");
+    }
+
+    @AfterEach
+    public void onTearDown() throws SQLException {
+        setTransactionControl("LOCKS");
+        try (Connection conn = dataSource.getConnection()) {
+            ScriptUtils.executeSqlScript(conn, new ClassPathResource("/META-INF/testdata/testdb.sql"));
+        }
+    }
+
+    @Test
+    public void testLoserOfInitialRowRaceGetsNextBlockInsteadOfFailing() throws Exception {
+        EgovTableIdGnrServiceImpl winner = newService(dataSource, false);
+        long[] winnerId = new long[1];
+        EgovTableIdGnrServiceImpl loser = newService(new InsertHookDataSource(dataSource, () -> {
+            winnerId[0] = winner.getNextLongId();
+            return null;
+        }), false);
+
+        long loserId = loser.getNextLongId();
+
+        assertEquals(0L, winnerId[0], "먼저 초기 행을 만든 쪽은 첫 블록(0부터)을 받는다");
+        assertEquals(BLOCK_SIZE, loserId, "경합에서 진 쪽은 실패하지 않고 다음 블록을 받는다");
+        assertEquals(BLOCK_SIZE * 2L, readNextId(), "채번 테이블에는 두 블록이 모두 반영된다");
+
+        // 각자 받은 블록 안에서 계속 채번된다
+        assertEquals(1L, winner.getNextLongId());
+        assertEquals(BLOCK_SIZE + 1L, loser.getNextLongId());
+        assertNotEquals(winner.getNextLongId(), loser.getNextLongId());
+    }
+
+    @Test
+    public void testLoserOfInitialRowRaceGetsNextBlockWithBigDecimals() throws Exception {
+        EgovTableIdGnrServiceImpl winner = newService(dataSource, true);
+        BigDecimal[] winnerId = new BigDecimal[1];
+        EgovTableIdGnrServiceImpl loser = newService(new InsertHookDataSource(dataSource, () -> {
+            winnerId[0] = winner.getNextBigDecimalId();
+            return null;
+        }), true);
+
+        BigDecimal loserId = loser.getNextBigDecimalId();
+
+        assertEquals(0, BigDecimal.ZERO.compareTo(winnerId[0]));
+        assertEquals(0, new BigDecimal(BLOCK_SIZE).compareTo(loserId), "경합에서 진 쪽은 다음 블록을 받는다");
+        assertEquals(BLOCK_SIZE * 2L, readNextId());
+    }
+
+    @Test
+    public void testFirstCallWithoutRaceStillInsertsInitialRow() throws Exception {
+        EgovTableIdGnrServiceImpl service = newService(dataSource, false);
+
+        assertEquals(0L, service.getNextLongId(), "경합이 없으면 종전처럼 초기 행을 만들고 0부터 채번한다");
+        assertEquals((long) BLOCK_SIZE, readNextId());
+    }
+
+    private EgovTableIdGnrServiceImpl newService(DataSource ds, boolean useBigDecimals) throws Exception {
+        EgovTableIdGnrServiceImpl service = new EgovTableIdGnrServiceImpl();
+        service.setApplicationContext(applicationContext);
+        service.setDataSource(ds);
+        service.setBlockSize(BLOCK_SIZE);
+        service.setTable(TABLE);
+        service.setTableName(RACE_NAME);
+        service.setUseBigDecimals(useBigDecimals);
+        service.afterPropertiesSet();
+        return service;
+    }
+
+    private long readNextId() throws SQLException {
+        try (Connection conn = dataSource.getConnection();
+             Statement stmt = conn.createStatement();
+             ResultSet rs = stmt.executeQuery("SELECT next_id FROM " + TABLE + " WHERE table_name = '" + RACE_NAME + "'")) {
+            assertTrue(rs.next(), "채번 행이 있어야 한다");
+            long nextId = rs.getLong(1);
+            assertTrue(!rs.next(), "채번 행은 하나여야 한다");
+            return nextId;
+        }
+    }
+
+    private void setTransactionControl(String mode) throws SQLException {
+        try (Connection conn = dataSource.getConnection();
+             Statement stmt = conn.createStatement()) {
+            stmt.execute("SET DATABASE TRANSACTION CONTROL " + mode);
+            conn.commit();
+        }
+    }
+
+    /**
+     * 내주는 Connection 의 첫 INSERT 직전에 한 번 hook 을 실행하는 DataSource — 다른 인스턴스가
+     * 같은 순간 초기 행을 만들어 커밋하는 상황을 만든다.
+     */
+    private static final class InsertHookDataSource extends DelegatingDataSource {
+
+        private final Callable<Void> hook;
+        private final AtomicBoolean fired = new AtomicBoolean();
+
+        private InsertHookDataSource(DataSource target, Callable<Void> hook) {
+            super(target);
+            this.hook = hook;
+        }
+
+        @Override
+        public Connection getConnection() throws SQLException {
+            return wrap(super.getConnection());
+        }
+
+        @Override
+        public Connection getConnection(String username, String password) throws SQLException {
+            return wrap(super.getConnection(username, password));
+        }
+
+        private Connection wrap(Connection target) {
+            return (Connection) Proxy.newProxyInstance(Connection.class.getClassLoader(), new Class<?>[] {Connection.class},
+                    (proxy, method, args) -> {
+                        if ("prepareStatement".equals(method.getName()) && args != null && args.length > 0
+                                && String.valueOf(args[0]).toUpperCase().startsWith("INSERT INTO")
+                                && fired.compareAndSet(false, true)) {
+                            hook.call();
+                        }
+                        try {
+                            return method.invoke(target, args);
+                        } catch (InvocationTargetException e) {
+                            throw e.getCause();
+                        }
+                    });
+        }
+    }
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

### 문제

`EgovTableIdGnrServiceImpl` 은 채번 테이블에 해당 이름의 행이 없으면 초기 행을 INSERT 하고 첫 블록을
돌려줍니다. 같은 DB 를 쓰는 WAS 인스턴스가 여럿이면 **두 인스턴스가 동시에 "행이 없음"을 보고 둘 다
INSERT** 할 수 있습니다(존재하지 않는 행에는 `FOR UPDATE` 잠금이 걸리지 않습니다). 늦은 쪽의 INSERT 는
기본 키 중복으로 실패하는데, 이 예외가 SELECT 를 감싼 `catch (DataAccessException)` 에 잡혀
**"테이블을 선택하기 예외가 발생했습니다"(`error.idgnr.select.idblock`) 로 위장된 채 채번이 실패**합니다.

이 경합은 서비스 기동 직후 첫 채번, 새 채번 이름을 처음 쓰는 순간처럼 한 번씩만 일어나지만, 그때의
요청은 원인을 알 수 없는 오류로 끝납니다. 재시도하면 성공하기 때문에 로그만으로는 원인을 찾기 어렵습니다.

### 수정

초기 행 INSERT 가 무결성 제약(중복 키)으로 실패하면 **그 트랜잭션을 되돌리고 새 트랜잭션에서 한 번 더
블록을 할당**합니다. 두 번째 시도에서는 다른 인스턴스가 만든 행이 이미 있으므로 `FOR UPDATE` 로 잠근 뒤
정상 경로(다음 블록 할당)로 진행합니다.

- 재시도는 **한 번**입니다. 두 번째에도 같은 실패면 종전과 같은 `FdlException` 을 던지되 원인 예외를 담습니다.
- 같은 트랜잭션 안에서 다시 SELECT 하지 않고 새 트랜잭션을 쓰는 이유는, PostgreSQL 처럼 **문장 실패가
  트랜잭션 전체를 중단시키는 DB** 에서도 동작해야 하기 때문입니다.
- 잡는 예외는 `DuplicateKeyException` 의 상위인 `DataIntegrityViolationException` 입니다. Spring 의 예외
  번역기는 오류 코드표에 없는 DB 제품에서 중복 키를 `DataIntegrityViolationException` 으로만 번역합니다.
- 경합이 없는 경우의 동작(초기 행 INSERT 후 첫 블록 반환, 이후 `FOR UPDATE` 블록 할당)은 그대로입니다.
- 덤으로 deprecated 된 `queryForObject(String, Object[], Class)` 호출을 가변 인자 시그니처로 바꾸고
  `@SuppressWarnings("deprecation")` 을 제거했습니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

`EgovTableIdGnrServiceInitialRowRaceTest` **3건 신규**, `fdl.idgnr` 모듈 전건 통과.

| 환경 | 기본 로케일(Locale) | 모듈 실행 건수 | 결과 |
|---|---|---:|---|
| **Windows** | ko_KR | **48** | `Tests run: 48, Failures: 0, Errors: 0, Skipped: 0` |
| **Linux** (Ubuntu 22.04 / OpenJDK 17) | C.UTF-8 | **48** | `Tests run: 48, Failures: 0, Errors: 0, Skipped: 0` |

| 구분 | 건수 | 내용 |
|---|---:|---|
| **결함 회귀** | 2 | long·BigDecimal 각각: 다른 인스턴스가 먼저 초기 행을 만든 뒤 INSERT 가 실패해도 **다음 블록을 받아 채번이 이어지고**, 테이블에는 두 블록이 모두 반영되며 이후 두 인스턴스의 ID 가 겹치지 않는다 |
| 기존 동작 | 1 | 경합이 없으면 종전처럼 초기 행을 만들고 0 부터 채번한다 |

경합은 진 쪽 인스턴스의 DataSource 가 내주는 Connection 의 **첫 INSERT 직전에 이긴 쪽 인스턴스를 실행**하는
방식으로 재현합니다. 다중 인스턴스 배포에서 실제로 일어나는 순서(양쪽 SELECT → 한쪽 INSERT 커밋 → 다른 쪽
INSERT)를 만들기 위해 테스트 안에서만 HSQLDB 를 MVCC 로 바꾸고 끝나면 되돌립니다.

**수정 전 코드에 같은 테스트를 돌리면** 결함 회귀 2건이 `FdlException`("… 테이블을 선택하기 예외가
발생했습니다")으로 실패합니다.

**수동 확인**: 현재 `main`(`cc2b332`) 위에서 `fdl.idgnr` 모듈 빌드·테스트가 통과함을 Windows 와 Linux 에서 확인했습니다.

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

해당 없음 — 라이브러리 내부 수정입니다.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

해당 없음 — 위 JUnit 테스트 결과로 갈음합니다.

---

<sub>base: `eGovFramework:main` @ `cc2b332` (2026-09-10 fetch 기준, #366~#379 머지 후) · 단일 커밋</sub>
