### PR TITLE
fix: EgovSequenceGenerator 가 예측 가능한 Math.random() 을 쓰고 솔트마다 SecureRandom 을 새로 만들던 문제 수정

### DIFF
--- a/Foundation/org.egovframe.rte.fdl.reactive/src/main/java/org/egovframe/rte/fdl/reactive/idgnr/EgovSequenceGenerator.java
+++ b/Foundation/org.egovframe.rte.fdl.reactive/src/main/java/org/egovframe/rte/fdl/reactive/idgnr/EgovSequenceGenerator.java
@@ -40,6 +40,7 @@ import java.time.temporal.ChronoField;
  * 수정일		수정자				수정내용
  * ----------------------------------------------
  * 2023.08.31   유지보수            최초 생성
+ * 2026.09.10   실행환경 개발팀      난수 소스를 SecureRandom 하나로 통일(Math.random() 제거, 호출마다 새 SecureRandom 생성 제거)
  * </pre>
  * @since 2023.08.31
  */
@@ -48,6 +49,12 @@ public class EgovSequenceGenerator {
     private static final Logger LOGGER = LoggerFactory.getLogger(EgovSequenceGenerator.class);
 
     private static final int SALT_BYTE_LENGTH = 16;
+
+    /**
+     * 난수 소스. 랜덤 문자열과 솔트 모두 이 하나의 SecureRandom 을 쓴다.
+     * SecureRandom 은 스레드 안전하므로 공유해도 되며, 호출마다 새로 만들면 시드 수집 비용만 든다.
+     */
+    private static final SecureRandom RANDOM = new SecureRandom();
 
     public static String generateSequence(String instance) {
         byte[] salt = generateSalt();
@@ -67,7 +74,7 @@ public class EgovSequenceGenerator {
         String characters = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
         sb.append(nowDate);
         for (int i = 0; i < 5; i++) {
-            sb.append(characters.charAt((int) (Math.random() * characters.length())));
+            sb.append(characters.charAt(RANDOM.nextInt(characters.length())));
         }
         return sb.toString();
     }
@@ -101,7 +108,7 @@ public class EgovSequenceGenerator {
 
     private static byte[] generateSalt() {
         byte[] salt = new byte[SALT_BYTE_LENGTH];
-        new SecureRandom().nextBytes(salt);
+        RANDOM.nextBytes(salt);
         return salt;
     }
 

--- a/Foundation/org.egovframe.rte.fdl.reactive/src/test/java/org/egovframe/rte/fdl/reactive/idgnr/EgovSequenceGeneratorTest.java
+++ b/Foundation/org.egovframe.rte.fdl.reactive/src/test/java/org/egovframe/rte/fdl/reactive/idgnr/EgovSequenceGeneratorTest.java
@@ -5,8 +5,12 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.HashSet;
+import java.util.Set;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.times;
 
@@ -28,6 +32,33 @@ public class EgovSequenceGeneratorTest {
 
             // 호출 검증: generateSequence("SHA-1") 한 번 호출되었는지
             mockedStatic.verify(() -> EgovSequenceGenerator.generateSequence("SHA-1"), times(1));
+        }
+    }
+
+    /**
+     * 모킹 없는 실동작 — SHA-256 시퀀스는 64자 소문자 16진수이고 호출마다 다르다.
+     */
+    @Test
+    public void generateSequenceProducesUniqueHexDigests() {
+        Set<String> sequences = new HashSet<>();
+        for (int i = 0; i < 1000; i++) {
+            String sequence = EgovSequenceGenerator.generateSequence("SHA-256");
+            assertEquals(64, sequence.length());
+            assertTrue(sequence.matches("[0-9a-f]{64}"), "16진수 형식이어야 한다: " + sequence);
+            sequences.add(sequence);
+        }
+        assertEquals(1000, sequences.size(), "같은 밀리초에 만들어도 시퀀스가 겹치지 않아야 한다");
+    }
+
+    /**
+     * 랜덤 문자열은 시각(17자) 뒤에 허용 문자 집합의 5자가 붙는다.
+     */
+    @Test
+    public void generateRandomStringUsesAllowedCharactersOnly() {
+        for (int i = 0; i < 200; i++) {
+            String value = EgovSequenceGenerator.generateRandomString();
+            assertEquals(17 + 5, value.length(), value);
+            assertTrue(value.matches("\\d{17}[A-Za-z0-9]{5}"), "허용 문자 집합 밖의 문자가 있다: " + value);
         }
     }
 


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

### 문제

`EgovSequenceGenerator` 는 시각(17자)에 랜덤 5자를 붙인 문자열을 16바이트 솔트와 함께 해시해 시퀀스를 만듭니다.
그런데 두 난수가 서로 다른 소스에서 나옵니다.

- 랜덤 5자는 `Math.random()` — 시드가 관측되면 다음 값을 예측할 수 있는 일반 난수입니다.
- 솔트는 **호출마다 `new SecureRandom()`** — 안전하지만 매번 인스턴스를 만들어 시드 수집 비용을 반복합니다.

### 수정

클래스 단위로 공유하는 `SecureRandom` 하나로 랜덤 문자열과 솔트를 모두 만듭니다. `SecureRandom` 은 스레드 안전하므로
WebFlux 의 동시 호출에서도 공유할 수 있습니다.

```java
private static final SecureRandom RANDOM = new SecureRandom();
...
sb.append(characters.charAt(RANDOM.nextInt(characters.length())));   // Math.random() 대신
...
RANDOM.nextBytes(salt);                                              // new SecureRandom() 대신
```

- 생성 형식(시각 17자 + 5자, 다이제스트 16진수)과 공개 메소드 시그니처는 그대로입니다.
- 솔트가 이미 `SecureRandom` 이었으므로 결과 해시의 예측 불가성이 새로 생기는 것은 아닙니다. 이 PR 은 **난수 소스를
  하나로 통일**하고 **호출마다 SecureRandom 을 만들던 비용을 없애는** 정리입니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

`EgovSequenceGeneratorTest` **2건 추가**(기존 mockStatic 테스트 1건 유지), `fdl.reactive` 모듈 전건 통과.

| 환경 | 기본 로케일(Locale) | 모듈 실행 건수 | 결과 |
|---|---|---:|---|
| **Windows** | ko_KR | **5** | `Tests run: 5, Failures: 0, Errors: 0, Skipped: 0` |
| **Linux** (Ubuntu 22.04 / OpenJDK 17) | C.UTF-8 | **5** | `Tests run: 5, Failures: 0, Errors: 0, Skipped: 0` |

| 구분 | 건수 | 내용 |
|---|---:|---|
| 실동작 | 1 | 모킹 없이 SHA-256 시퀀스 1,000건 — 64자 소문자 16진수이고 전부 서로 다르다(같은 밀리초 포함) |
| 형식 | 1 | 랜덤 문자열은 숫자 17자 뒤에 허용 문자 집합(`A-Za-z0-9`) 5자 |

**수동 확인**: 현재 `main`(`cc2b332`) 위에서 `fdl.reactive` 모듈 빌드·테스트가 통과함을 Windows 와 Linux 에서 확인했습니다.

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

해당 없음 — 라이브러리 내부 수정입니다.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

해당 없음 — 위 JUnit 테스트 결과로 갈음합니다.

---

<sub>base: `eGovFramework:main` @ `cc2b332` (2026-09-10 fetch 기준, #366~#379 머지 후) · 단일 커밋</sub>
