### PR TITLE
fix: 프로퍼티 리소스 로딩 실패가 어느 리소스인지 알 수 없는 RuntimeException 으로 끝나던 문제 수정

### DIFF
--- a/Foundation/org.egovframe.rte.fdl.property/src/main/java/org/egovframe/rte/fdl/property/impl/EgovPropertyServiceImpl.java
+++ b/Foundation/org.egovframe.rte.fdl.property/src/main/java/org/egovframe/rte/fdl/property/impl/EgovPropertyServiceImpl.java
@@ -58,6 +58,7 @@ import static org.apache.commons.configuration2.PropertiesConfiguration.DEFAULT_
  * 2009.02.01	김태호			최초 생성
  * 2014.08.12	Vincent Han		"properties" 속성이 없는 경우 처리
  * 2020.08.31	유지보수			Property 값을 정확히 등록하기 위해 put() 메소드를 addProperty() 메소드로 변경
+ * 2026.09.10	실행환경 개발팀		리소스 로딩 실패 시 실패한 리소스를 담은 IllegalStateException 으로 보고
  * </pre>
  * @since 2009.02.01
  */
@@ -388,7 +389,8 @@ public class EgovPropertyServiceImpl implements EgovPropertyService, Application
             inputStreamReader = new InputStreamReader(inputStream, StringUtils.isEmpty(encoding) ? DEFAULT_ENCODING : encoding);
             propertiesConfiguration.read(inputStreamReader);
         } catch (ConfigurationException | IOException e) {
-            throw new RuntimeException(e);
+            // 어느 리소스가 왜 실패했는지 예외만 보고 알 수 있도록 리소스 설명을 메시지에 담는다
+            throw new IllegalStateException("Failed to load property resource: " + resource, e);
         } finally {
             if (inputStreamReader != null) {
                 try {

--- a/Foundation/org.egovframe.rte.fdl.property/src/test/java/org/egovframe/rte/fdl/property/PropertyServiceLoadFailureTest.java
+++ b/Foundation/org.egovframe.rte.fdl.property/src/test/java/org/egovframe/rte/fdl/property/PropertyServiceLoadFailureTest.java
@@ -1,0 +1,65 @@
+package org.egovframe.rte.fdl.property;
+
+import org.egovframe.rte.fdl.property.impl.EgovPropertyServiceImpl;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * 외부 프로퍼티 리소스를 읽지 못했을 때 어느 리소스가 실패했는지 예외만으로 알 수 있는지 검증한다.
+ */
+public class PropertyServiceLoadFailureTest {
+
+    private static final String MISSING_CLASSPATH = "classpath:/META-INF/properties/does-not-exist.properties";
+
+    @Test
+    public void testMissingClasspathResourceReportsResourceInMessage() {
+        EgovPropertyServiceImpl service = newService(Collections.singleton(MISSING_CLASSPATH));
+
+        IllegalStateException e = assertThrows(IllegalStateException.class, service::afterPropertiesSet);
+
+        assertTrue(e.getMessage().contains("does-not-exist.properties"),
+                "실패한 리소스가 메시지에 있어야 한다: " + e.getMessage());
+        assertInstanceOf(IOException.class, e.getCause(), "원인 예외를 그대로 보존해야 한다");
+    }
+
+    @Test
+    public void testMissingResourceGivenAsMapEntryReportsResourceInMessage() {
+        Map<String, String> entry = new HashMap<>();
+        entry.put("encoding", "UTF-8");
+        entry.put("filename", "file:./target/does-not-exist-either.properties");
+        EgovPropertyServiceImpl service = newService(Collections.singleton(entry));
+
+        IllegalStateException e = assertThrows(IllegalStateException.class, service::afterPropertiesSet);
+
+        assertTrue(e.getMessage().contains("does-not-exist-either.properties"),
+                "실패한 리소스가 메시지에 있어야 한다: " + e.getMessage());
+        assertInstanceOf(IOException.class, e.getCause());
+    }
+
+    @Test
+    public void testExistingResourceStillLoads() throws Exception {
+        EgovPropertyServiceImpl service = newService(Collections.singleton("classpath:/META-INF/properties/resource.properties"));
+
+        service.afterPropertiesSet();
+
+        assertEquals("value", service.getString("key"));
+    }
+
+    private static EgovPropertyServiceImpl newService(Set<?> extFileName) {
+        EgovPropertyServiceImpl service = new EgovPropertyServiceImpl();
+        service.setResourceLoader(new PathMatchingResourcePatternResolver());
+        service.setExtFileName(extFileName);
+        return service;
+    }
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

### 문제

`EgovPropertyServiceImpl` 은 `extFileName` 으로 지정한 외부 프로퍼티 파일을 읽다가 실패하면
`throw new RuntimeException(e)` 로 끝냅니다. 예외 메시지는 원인 예외의 문구(예: `class path resource [...] cannot be opened
because it does not exist`)를 그대로 담을 뿐이라, 스킴이 없는 이름이나 인코딩 오류처럼 원인 예외가 리소스를 말해 주지
않는 경우에는 **어느 리소스가 실패했는지 알 수 없습니다.** 여러 파일을 지정한 설정에서 기동이 실패하면 설정을 하나씩
지워 가며 찾게 됩니다.

### 수정

실패한 리소스의 설명(`Resource.toString()`)을 메시지에 담은 `IllegalStateException` 을 던집니다. 원인 예외는 그대로 보존합니다.

```java
} catch (ConfigurationException | IOException e) {
    throw new IllegalStateException("Failed to load property resource: " + resource, e);
}
```

- `IllegalStateException` 은 `RuntimeException` 의 하위 타입이므로 기존 `catch (RuntimeException)` 은 그대로 동작합니다.
- 정상 로딩 경로와 자원 정리(`finally`)는 손대지 않았습니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

`PropertyServiceLoadFailureTest` **3건 신규**, `fdl.property` 모듈 전건 통과.

| 환경 | 기본 로케일(Locale) | 모듈 실행 건수 | 결과 |
|---|---|---:|---|
| **Windows** | ko_KR | **17** | `Tests run: 17, Failures: 0, Errors: 0, Skipped: 0` |
| **Linux** (Ubuntu 22.04 / OpenJDK 17) | C.UTF-8 | **17** | `Tests run: 17, Failures: 0, Errors: 0, Skipped: 0` |

| 구분 | 건수 | 내용 |
|---|---:|---|
| **결함 회귀** | 2 | 없는 `classpath:` 리소스(문자열 지정)와 없는 `file:` 리소스(`filename`/`encoding` Map 지정) 각각 — `IllegalStateException` 메시지에 리소스 이름이 담기고 원인 `IOException` 이 보존된다 |
| 기존 동작 | 1 | 있는 리소스는 종전처럼 읽혀 값을 돌려준다 |

**수동 확인**: 현재 `main`(`cc2b332`) 위에서 `fdl.property` 모듈 빌드·테스트가 통과함을 Windows 와 Linux 에서 확인했습니다.

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

해당 없음 — 라이브러리 내부 수정입니다.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

해당 없음 — 위 JUnit 테스트 결과로 갈음합니다.

---

<sub>base: `eGovFramework:main` @ `cc2b332` (2026-09-10 fetch 기준, #366~#379 머지 후) · 단일 커밋</sub>
