### PR TITLE
fix: encodePassword 가 지원하지 않는 알고리즘이면 평문을 해시인 것처럼 돌려주던 문제 수정

### DIFF
--- a/Foundation/org.egovframe.rte.fdl.string/src/main/java/org/egovframe/rte/fdl/string/EgovStringUtil.java
+++ b/Foundation/org.egovframe.rte.fdl.string/src/main/java/org/egovframe/rte/fdl/string/EgovStringUtil.java
@@ -45,6 +45,7 @@ import java.util.regex.Pattern;
  * 2009.06.01	윤성종			최초 생성
  * 2017.02.15	장동한			시큐어코딩(ES)-부적절한 예외 처리[CWE-253, CWE-440, CWE-754]
  * 2017.02.28	장동한			시큐어코딩(ES)-오류 메시지를 통한 정보노출[CWE-209]
+ * 2026.09.10	실행환경 개발팀		encodePassword 의 미지원 알고리즘 평문 반환을 예외로 변경, deprecated 표기
  * </pre>
  * @since 2009.06.01
  */
@@ -529,12 +530,16 @@ public final class EgovStringUtil {
 
     /**
      * Encode a string using algorithm specified in web.xml and return the resulting encrypted password.
-     * If exception, the plain credentials string is returned
      *
      * @param password  Password or other credentials to use in authenticating this username
      * @param algorithm Algorithm used to do the digest
      * @return encypted password based on the algorithm.
+     * @throws IllegalArgumentException 지원하지 않는 다이제스트 알고리즘인 경우. 예전에는 평문을 그대로 돌려줬다
+     * @deprecated 솔트 없는 1회 해시라 패스워드 저장·검증에는 부적합하다. 실행환경의
+     * {@code org.egovframe.rte.fdl.security.config.EgovIdSaltSha256PasswordEncoder}(솔트 SHA-256) 나
+     * Spring Security 의 {@code org.springframework.security.crypto.password.PasswordEncoder} 구현(bcrypt·PBKDF2)을 사용한다.
      */
+    @Deprecated
     public static String encodePassword(String password, String algorithm) {
         byte[] unencodedPassword = password.getBytes(StandardCharsets.UTF_8);
         MessageDigest md;
@@ -543,8 +548,8 @@ public final class EgovStringUtil {
             md = MessageDigest.getInstance(algorithm);
             //2017.02.15 장동한 시큐어코딩(ES)-부적절한 예외 처리[CWE-253, CWE-440, CWE-754]
         } catch (NoSuchAlgorithmException e) {
-            LOGGER.debug("[{}] EgovStringUtil encodePassword() : {}", e.getClass().getName(), e.getMessage());
-            return password;
+            // 평문을 돌려주면 호출자가 해시로 오인해 그대로 저장한다. 실패는 예외로 알린다.
+            throw new IllegalArgumentException("Unsupported digest algorithm: " + algorithm, e);
         }
 
         md.reset();

--- a/Foundation/org.egovframe.rte.fdl.string/src/test/java/org/egovframe/rte/fdl/string/EgovStringUtilEncodePasswordCharsetTest.java
+++ b/Foundation/org.egovframe.rte.fdl.string/src/test/java/org/egovframe/rte/fdl/string/EgovStringUtilEncodePasswordCharsetTest.java
@@ -35,6 +35,7 @@ class EgovStringUtilEncodePasswordCharsetTest {
 
     @Test
     @DisplayName("encodePassword hashes over UTF-8 bytes, independent of the platform default charset")
+    @SuppressWarnings("deprecation")
     void encodePassword_usesUtf8ForNonAsciiPassword() throws Exception {
         String password = "비밀번호가나다"; // "비밀번호가나다" (non-ASCII)
 

--- a/Foundation/org.egovframe.rte.fdl.string/src/test/java/org/egovframe/rte/fdl/string/EgovStringUtilTest.java
+++ b/Foundation/org.egovframe.rte.fdl.string/src/test/java/org/egovframe/rte/fdl/string/EgovStringUtilTest.java
@@ -272,14 +272,21 @@ public class EgovStringUtilTest {
     }
 
     @Test
+    @SuppressWarnings("deprecation")
     public void testEncodePassword() {
         // 1. try to encode password and compare
         String encoded1 = EgovStringUtil.encodePassword("password", "MD5");
         String encoded2 = EgovStringUtil.encodePassword("password", "MD5");
         assertEquals(encoded1, encoded2);
-        // 2. define not available algorithm 'MD6 MessageDigest'
-        String encoded3 = EgovStringUtil.encodePassword("password", "MD6");
-        assertEquals("password", encoded3);
+        // 2. 알려진 벡터 — 지원 알고리즘의 해시값은 이전과 바이트 단위로 같다
+        assertEquals("5f4dcc3b5aa765d61d8327deb882cf99", encoded1);
+        assertEquals("5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8",
+                EgovStringUtil.encodePassword("password", "SHA-256"));
+        // 3. define not available algorithm 'MD6 MessageDigest' — 평문을 돌려주는 대신 예외
+        IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
+                () -> EgovStringUtil.encodePassword("password", "MD6"));
+        assertTrue(e.getMessage().contains("MD6"), "어떤 알고리즘이 문제인지 메시지에 있어야 한다: " + e.getMessage());
+        assertNotNull(e.getCause(), "원인(NoSuchAlgorithmException)을 보존해야 한다");
     }
 
     @Test


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

### 문제

`EgovStringUtil.encodePassword(password, algorithm)` 은 `MessageDigest` 가 알고리즘을 모르면 debug 로그만 남기고
**`password` 를 그대로 돌려줍니다.** 호출자는 반환값을 해시로 알고 저장하므로 알고리즘 이름의 오타 하나
(`"SHA-256"` 을 `"SHA256"` 으로 쓰는 식)로 **평문 패스워드가 그대로 저장**되고, 로그 레벨이 debug 가 아니면 아무
흔적도 남지 않습니다. 기존 테스트 `testEncodePassword` 가 이 평문 반환을 단언하고 있어 의도된 동작처럼 보이지만,
호출자 입장에서는 실패를 알 방법이 없는 계약입니다.

### 수정

| 이전 | 이후 |
|---|---|
| 지원하지 않는 알고리즘 → **평문 반환** | 알고리즘 이름을 담은 **`IllegalArgumentException`**(원인 `NoSuchAlgorithmException` 보존) |
| 지원 알고리즘 → 16진수 해시 | **그대로**(MD5·SHA-256 알려진 벡터로 확인) |

```java
} catch (NoSuchAlgorithmException e) {
    throw new IllegalArgumentException("Unsupported digest algorithm: " + algorithm, e);
}
```

또한 이 메소드는 솔트 없는 1회 해시라 패스워드 저장·검증에 부적합하므로 `@Deprecated` 로 표기하고, javadoc 에
실행환경의 `EgovIdSaltSha256PasswordEncoder`(fdl.security, 솔트 SHA-256)와 Spring Security `PasswordEncoder`
구현(bcrypt·PBKDF2)을 안내했습니다. 메소드는 그대로 남아 있으며 컴파일 경고만 냅니다.

### 호환성

- 정상 경로의 반환값은 바이트 단위로 같습니다. UTF-8 고정은 #334 로 이미 반영되어 있어 이 PR 이 바꾸지 않습니다.
- 바뀌는 것은 **실패 경로 하나**입니다. 잘못된 알고리즘 이름으로 호출해 평문을 저장하고 있던 코드가 있다면 이제 예외로
  드러납니다. 이것이 이 PR 의 목적이므로 릴리스 노트에 계약 변경으로 적어 주시면 좋겠습니다.
- 실행환경 안의 호출부는 테스트 2파일뿐이며 본체 코드에서는 호출하지 않습니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

`EgovStringUtilTest.testEncodePassword` **갱신**(평문 단언 → 예외 단언, 알려진 벡터 2건 추가), `fdl.string` 모듈 전건 통과.

| 환경 | 기본 로케일(Locale) | 모듈 실행 건수 | 결과 |
|---|---|---:|---|
| **Windows** | ko_KR | **61** | `Tests run: 61, Failures: 0, Errors: 0, Skipped: 0` |
| **Linux** (Ubuntu 22.04 / OpenJDK 17) | C.UTF-8 | **61** | `Tests run: 61, Failures: 0, Errors: 0, Skipped: 0` |

| 구분 | 내용 |
|---|---|
| **결함 회귀** | `"MD6"` 처럼 지원하지 않는 알고리즘이면 `IllegalArgumentException` 이 나고 메시지에 알고리즘 이름, 원인에 `NoSuchAlgorithmException` 이 담긴다(이전 판에서는 `"password"` 가 그대로 돌아와 실패) |
| **불변 확인** | `MD5("password")` = `5f4dcc3b…cf99`, `SHA-256("password")` = `5e884898…42d8` — 지원 알고리즘의 결과가 바뀌지 않았다 |

**수동 확인**: 현재 `main`(`cc2b332`) 위에서 `fdl.string` 모듈 빌드·테스트가 통과함을 Windows 와 Linux 에서 확인했습니다.

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

해당 없음 — 라이브러리 내부 수정입니다.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

해당 없음 — 위 JUnit 테스트 결과로 갈음합니다.

---

<sub>base: `eGovFramework:main` @ `cc2b332` (2026-09-10 fetch 기준, #366~#379 머지 후) · 단일 커밋</sub>
