### PR TITLE
fix: getFullAge 가 외국인등록번호 세대코드 5~8 을 인식하지 못해 0 을 돌려주던 문제 수정

### DIFF
--- a/Foundation/org.egovframe.rte.fdl.string/src/main/java/org/egovframe/rte/fdl/string/EgovDateUtil.java
+++ b/Foundation/org.egovframe.rte.fdl.string/src/main/java/org/egovframe/rte/fdl/string/EgovDateUtil.java
@@ -33,6 +33,7 @@ import java.util.Locale;
  * 2009.06.01	윤성종            최초 생성
  * 2017.02.28	장동한            시큐어코딩(ES)-Null Pointer 역참조[CWE-476]
  * 2023.08.31   유지보수            코드 리팩토링(addCalendar(), Contribution 반영)
+ * 2026.09.10	실행환경 개발팀        getFullAge 외국인 세대코드 5~8 지원, 해석 불가 입력은 예외
  */
 public class EgovDateUtil {
 
@@ -252,37 +253,56 @@ public class EgovDateUtil {
 
     /**
      * 해당 대상자에 대해 기준일자에서의 만 나이를 구한다.
+     *
+     * <p>7번째 자리(세대코드)로 출생 세기를 정한다. 0·9 는 1800년대, 1·2 는 1900년대, 3·4 는 2000년대이며,
+     * 외국인등록번호의 5·6 은 1900년대, 7·8 은 2000년대다.</p>
+     *
+     * @param socialNo 주민등록번호 또는 외국인등록번호(구분자 없이 7자리 이상)
+     * @param keyDate  기준일자(yyyyMMdd)
+     * @return 기준일자 기준 만 나이
+     * @throws IllegalArgumentException 인자가 null 이거나 짧은 경우, 세대코드가 0~9 밖인 경우, 숫자가 아닌 경우
      */
     public static int getFullAge(String socialNo, String keyDate) {
-        String birthDate = null;
-
-        // 주민번호 7번째 자리가 0 또는 9 라면 1800년도 출생이다.
-        if (EgovStringUtil.equals(EgovStringUtil.toSubString(socialNo, 6, 7), "0") || EgovStringUtil.equals(EgovStringUtil.toSubString(socialNo, 6, 7), "9")) {
-            birthDate = "18" + socialNo.substring(0, 6);
-        }
-
-        // 주민번호 7번째 자리가 1 또는 2 라면 1900년도 출생이다.
-        else if (EgovStringUtil.equals(EgovStringUtil.toSubString(socialNo, 6, 7), "1") || EgovStringUtil.equals(EgovStringUtil.toSubString(socialNo, 6, 7), "2")) {
-            birthDate = "19" + socialNo.substring(0, 6);
-        }
-
-        // 주민번호 7번째 자리가 3 또는 4 라면 2000년도 출생이다.
-        else if (EgovStringUtil.equals(EgovStringUtil.toSubString(socialNo, 6, 7), "3") || EgovStringUtil.equals(EgovStringUtil.toSubString(socialNo, 6, 7), "4")) {
-            birthDate = "20" + socialNo.substring(0, 6);
-        }
-
         //2017.02.28 장동한 시큐어코딩(ES)-Null Pointer 역참조[CWE-476]
-        if (keyDate != null && birthDate != null) {
-            // 생일이 안지났을때 기준일자 년에서 생일년을 빼고 1년을 더뺀다.
-            if (Integer.parseInt(keyDate.substring(4, 8)) < Integer.parseInt(birthDate.substring(4, 8))) {
-                return Integer.parseInt(keyDate.substring(0, 4)) - Integer.parseInt(birthDate.substring(0, 4)) - 1;
-                // 생일이 지났을때 기준일자 년에서 생일년을 뺀다.
-            } else {
-                return Integer.parseInt(keyDate.substring(0, 4)) - Integer.parseInt(birthDate.substring(0, 4));
-            }
-        } else {
-            return 0;
+        if (socialNo == null || socialNo.length() < 7) {
+            throw new IllegalArgumentException("socialNo must have at least 7 digits");
         }
+        if (keyDate == null || keyDate.length() < 8) {
+            throw new IllegalArgumentException("keyDate must be yyyyMMdd");
+        }
+
+        // 세대코드(7번째 자리) → 출생 세기. 0·9=1800년대, 1·2=1900년대, 3·4=2000년대,
+        // 5·6=1900년대 외국인, 7·8=2000년대 외국인
+        char generationCode = socialNo.charAt(6);
+        String century;
+        switch (generationCode) {
+            case '0':
+            case '9':
+                century = "18";
+                break;
+            case '1':
+            case '2':
+            case '5':
+            case '6':
+                century = "19";
+                break;
+            case '3':
+            case '4':
+            case '7':
+            case '8':
+                century = "20";
+                break;
+            default:
+                throw new IllegalArgumentException("Unsupported generation code (7th digit) in socialNo: " + generationCode);
+        }
+        String birthDate = century + socialNo.substring(0, 6);
+
+        // 생일이 안지났을때 기준일자 년에서 생일년을 빼고 1년을 더뺀다.
+        if (Integer.parseInt(keyDate.substring(4, 8)) < Integer.parseInt(birthDate.substring(4, 8))) {
+            return Integer.parseInt(keyDate.substring(0, 4)) - Integer.parseInt(birthDate.substring(0, 4)) - 1;
+        }
+        // 생일이 지났을때 기준일자 년에서 생일년을 뺀다.
+        return Integer.parseInt(keyDate.substring(0, 4)) - Integer.parseInt(birthDate.substring(0, 4));
     }
 
     /**

--- a/Foundation/org.egovframe.rte.fdl.string/src/test/java/org/egovframe/rte/fdl/string/EgovDateUtilTest.java
+++ b/Foundation/org.egovframe.rte.fdl.string/src/test/java/org/egovframe/rte/fdl/string/EgovDateUtilTest.java
@@ -206,18 +206,38 @@ public class EgovDateUtilTest {
     }
 
     /**
-     * [Flow #-4-2] Negative/Boundary Case : getFullAge() 의 0 반환 경로(미인식 세기코드, keyDate null)를 고정한다.
+     * [Flow #-4-2] Positive Case : 외국인등록번호 세대코드 5·6(1900년대)과 7·8(2000년대)도 만 나이가 계산된다.
+     * (이전에는 세기를 정하지 못해 0 을 돌려줬다.)
      */
     @Test
-    public void testGetFullAgeReturnsZero() throws ParseException {
-        // 미인식 세기코드(5,6,7,8) → birthDate=null → 0 반환
-        assertEquals(0, EgovDateUtil.getFullAge("8001015000000", "20200101"));
-        assertEquals(0, EgovDateUtil.getFullAge("8001016000000", "20200101"));
-        assertEquals(0, EgovDateUtil.getFullAge("8001017000000", "20200101"));
-        assertEquals(0, EgovDateUtil.getFullAge("8001018000000", "20200101"));
+    public void testGetFullAgeForeignerGenerationCodes() throws ParseException {
+        // birthDate=19800101, keyDate=20200101 → 0101>=0101 → 2020-1980 = 40
+        assertEquals(40, EgovDateUtil.getFullAge("8001015000000", "20200101"));
+        assertEquals(40, EgovDateUtil.getFullAge("8001016000000", "20200101"));
 
-        // keyDate == null → birthDate 유효해도 0 반환
-        assertEquals(0, EgovDateUtil.getFullAge("7701011234567", null));
+        // birthDate=20050101, keyDate=20200101 → 2020-2005 = 15
+        assertEquals(15, EgovDateUtil.getFullAge("0501017000000", "20200101"));
+
+        // birthDate=20071231, keyDate=20200630 → 0630<1231(생일 전) → 2020-2007-1 = 12
+        assertEquals(12, EgovDateUtil.getFullAge("0712318000000", "20200630"));
+    }
+
+    /**
+     * [Flow #-4-2-1] Negative Case : 해석할 수 없는 입력은 0 대신 IllegalArgumentException 이다.
+     * (이전에는 전부 0 을 돌려줘 "0세"와 "계산 실패"를 구분할 수 없었다.)
+     */
+    @Test
+    public void testGetFullAgeRejectsUnparseableInput() {
+        // keyDate == null
+        assertThrows(IllegalArgumentException.class, () -> EgovDateUtil.getFullAge("7701011234567", null));
+        // socialNo == null / 7자리 미만
+        assertThrows(IllegalArgumentException.class, () -> EgovDateUtil.getFullAge(null, "20200101"));
+        assertThrows(IllegalArgumentException.class, () -> EgovDateUtil.getFullAge("770101", "20200101"));
+        // 세대코드 자리가 숫자가 아님(구분자가 포함된 형식은 원래 지원하지 않았다)
+        assertThrows(IllegalArgumentException.class, () -> EgovDateUtil.getFullAge("770101-1234567", "20200101"));
+        assertThrows(IllegalArgumentException.class, () -> EgovDateUtil.getFullAge("770101a234567", "20200101"));
+        // 생년월일 자리가 숫자가 아님
+        assertThrows(IllegalArgumentException.class, () -> EgovDateUtil.getFullAge("77x1011234567", "20200101"));
     }
 
     /**
@@ -241,9 +261,11 @@ public class EgovDateUtilTest {
      */
     @Test
     public void testGetCurrentFullAgeDelegation() throws ParseException {
-        // 미인식 세기코드(7번째 자리 5)는 출생년도가 정해지지 않아 현재일자 기준에서도 0 을 반환한다.
-        // (현재일자에 의존하지 않는 결정적 단정으로 위임 동작을 검증한다.)
-        assertEquals(0, EgovDateUtil.getCurrentFullAge("8001015000000"));
+        // 현재 일자를 같은 방식으로 만들어 getFullAge() 에 넘긴 값과 같아야 한다.
+        String today = EgovDateUtil.getCurrentYearAsString() + EgovDateUtil.getCurrentMonthAsString() + EgovDateUtil.getCurrentDayAsString();
+        assertEquals(EgovDateUtil.getFullAge("8001015000000", today), EgovDateUtil.getCurrentFullAge("8001015000000"));
+        // 세대코드 5(1900년대 외국인)는 이제 실제 나이가 나온다 — 1980년생은 2020년 이후 40세 이상
+        assertTrue(EgovDateUtil.getCurrentFullAge("8001015000000") >= 40);
     }
 
     /**


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

### 문제

`EgovDateUtil.getFullAge(socialNo, keyDate)` 는 7번째 자리(세대코드)로 출생 세기를 정하는데 **0·9, 1·2, 3·4 만 알고
외국인등록번호의 5·6(1900년대)·7·8(2000년대)은 모릅니다.** 그래서 외국인의 만 나이는 언제나 0 입니다.

같은 이유로 잘못된 입력(`null`, 짧은 문자열, 숫자가 아닌 세대코드)도 전부 0 을 돌려줘, 호출자는 **"0세"와 "계산 실패"를
구분할 수 없습니다.** #251 이 이 0 반환을 characterization 테스트로 고정해 두어(현재 동작의 명세화) 의도된 동작처럼
보이지만, 외국인등록번호를 처리하는 사업에서는 잘못된 나이가 조용히 저장되는 결함입니다. 이 PR 은 그 테스트를 새 계약으로 바꿉니다.

### 수정

| 입력 | 이전 | 이후 |
|---|---|---|
| 세대코드 5·6 (1900년대 외국인) | **0** | 정상 계산 |
| 세대코드 7·8 (2000년대 외국인) | **0** | 정상 계산 |
| `socialNo`/`keyDate` 가 `null` 이거나 짧음 | **0** | `IllegalArgumentException` |
| 세대코드가 0~9 밖(구분자 `-` 포함 형식 등) | **0** | `IllegalArgumentException` |
| 생년월일 자리에 숫자가 아닌 문자 | `NumberFormatException` | 그대로(`IllegalArgumentException` 의 하위) |
| 세대코드 0·9, 1·2, 3·4 의 정상 입력 | 계산 | **그대로**(생일 경과 여부에 따른 -1 포함) |

`getCurrentFullAge(socialNo)` 는 `getFullAge` 에 위임하므로 같은 규칙을 따릅니다.

### 호환성

- 정상 입력의 결과는 바뀌지 않습니다. 기존 characterization 테스트(#-4-1, #-4-3)가 그대로 통과합니다.
- **바뀌는 것은 두 가지**입니다. (1) 외국인등록번호에서 0 대신 실제 나이가 나오고, (2) 해석할 수 없는 입력은 0 대신
  예외입니다. 0 을 "계산 불가" 신호로 쓰던 호출자가 있다면 `IllegalArgumentException` 을 잡도록 바꿔야 하므로 릴리스
  노트에 계약 변경으로 적어 주시면 좋겠습니다.
- 구분자가 포함된 형식(`770101-1234567`)은 이전에도 0 을 돌려줬을 뿐 지원된 적이 없으며, 이제는 예외로 드러납니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

`EgovDateUtilTest` **갱신**(0 반환 characterization 2건 → 외국인 코드 4케이스·예외 6케이스·위임 검증), `fdl.string` 모듈 전건 통과.

| 환경 | 기본 로케일(Locale) | 모듈 실행 건수 | 결과 |
|---|---|---:|---|
| **Windows** | ko_KR | **62** | `Tests run: 62, Failures: 0, Errors: 0, Skipped: 0` |
| **Linux** (Ubuntu 22.04 / OpenJDK 17) | C.UTF-8 | **62** | `Tests run: 62, Failures: 0, Errors: 0, Skipped: 0` |

| 구분 | 내용 |
|---|---|
| **결함 회귀** | 세대코드 5·6 → 1980년생은 2020-01-01 기준 40세, 7 → 2005년생 15세, 8 → 2007-12-31생은 2020-06-30 기준 12세(생일 전 -1) |
| **예외 계약** | `keyDate` null · `socialNo` null · 6자리 · 구분자 포함 · 세대코드 자리에 영문자 · 생년월일 자리에 영문자 → 전부 `IllegalArgumentException` |
| **위임** | `getCurrentFullAge` 가 현재 일자로 `getFullAge` 에 넘긴 값과 같고, 1980년생 외국인은 40세 이상 |
| **불변 확인** | 기존 세기 접두(#-4-1)·생일 경계(#-4-3) 테스트 무변경 통과 |

**수동 확인**: 현재 `main`(`cc2b332`) 위에서 `fdl.string` 모듈 빌드·테스트가 통과함을 Windows 와 Linux 에서 확인했습니다.

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

해당 없음 — 라이브러리 내부 수정입니다.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

해당 없음 — 위 JUnit 테스트 결과로 갈음합니다.

---

<sub>base: `eGovFramework:main` @ `cc2b332` (2026-09-10 fetch 기준, #366~#379 머지 후) · 단일 커밋</sub>
