### PR TITLE
fix: AbstractXMLUtility 가 인스턴스마다 연 설정 컨텍스트를 닫지 않던 문제 수정, 저장 경로 직접 주입 생성자 추가

### DIFF
--- a/Foundation/org.egovframe.rte.fdl.xml/src/main/java/org/egovframe/rte/fdl/xml/AbstractXMLUtility.java
+++ b/Foundation/org.egovframe.rte.fdl.xml/src/main/java/org/egovframe/rte/fdl/xml/AbstractXMLUtility.java
@@ -18,7 +18,6 @@ package org.egovframe.rte.fdl.xml;
 import org.egovframe.rte.fdl.xml.exception.ValidatorException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.context.ApplicationContext;
 import org.springframework.context.support.FileSystemXmlApplicationContext;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -58,6 +57,7 @@ import java.util.Set;
  * 수정일		수정자				수정내용
  * ----------------------------------------------
  * 2009.03.17	김종호				최초생성
+ * 2026.09.10	실행환경 개발팀		설정 컨텍스트를 읽은 뒤 즉시 닫도록 수정, 저장 경로 직접 주입 생성자 추가
  * </pre>
  * @since 2009.03.17
  */
@@ -66,21 +66,13 @@ public abstract class AbstractXMLUtility {
     private static final Logger LOGGER = LoggerFactory.getLogger(AbstractXMLUtility.class);
 
     /**
-     * ApplicationContext
+     * xml 설정 파일 경로(기본 생성자 전용)
      */
-    private final ApplicationContext context;
+    private static final String CONFIG_PATH = "classpath:META-INF/spring/egovxmlCfg.xml";
     /**
-     * XmlConfig class
-     **/
-    private final XmlConfig xmlConfig;
-    /**
-     * xml 설정관리 Class
+     * 기본 저장 경로. 경로를 지정하지 않은 저장 API 가 파일명을 바로 이어 붙인다.
      */
     private final String savedPath;
-    /**
-     * xml 설정 파일 경로
-     */
-    private final String configPath = "classpath:META-INF/spring/egovxmlCfg.xml";
     /**
      * 파일명
      **/
@@ -95,12 +87,24 @@ public abstract class AbstractXMLUtility {
     private String xmlValue = null;
 
     /**
-     * AbstractXMLUtility 생성자
+     * AbstractXMLUtility 생성자 — {@code egovxmlCfg.xml} 의 {@code xmlconfig} 빈에서 기본 저장 경로를 읽는다.
+     *
+     * <p>설정을 읽기 위해 여는 컨텍스트는 값을 읽은 뒤 바로 닫는다. 이전에는 인스턴스마다 만든 컨텍스트를
+     * 닫지 않고 필드로 보관해 유틸 객체를 만든 횟수만큼 컨텍스트가 남았다.</p>
      */
     public AbstractXMLUtility() {
-        context = new FileSystemXmlApplicationContext(configPath);
-        xmlConfig = (XmlConfig) context.getBean("xmlconfig");
-        savedPath = xmlConfig.getXmlpath();
+        try (FileSystemXmlApplicationContext context = new FileSystemXmlApplicationContext(CONFIG_PATH)) {
+            this.savedPath = ((XmlConfig) context.getBean("xmlconfig")).getXmlpath();
+        }
+    }
+
+    /**
+     * 기본 저장 경로를 직접 주입받는 생성자 — 설정 파일({@code egovxmlCfg.xml})과 Spring 컨텍스트 없이 동작한다.
+     *
+     * @param savedPath 경로를 지정하지 않은 저장 API 의 기본 위치. 파일명이 바로 이어 붙으므로 경로 구분자로 끝나야 한다
+     */
+    protected AbstractXMLUtility(String savedPath) {
+        this.savedPath = savedPath;
     }
 
     /**

--- a/Foundation/org.egovframe.rte.fdl.xml/src/main/java/org/egovframe/rte/fdl/xml/EgovDOMValidatorService.java
+++ b/Foundation/org.egovframe.rte.fdl.xml/src/main/java/org/egovframe/rte/fdl/xml/EgovDOMValidatorService.java
@@ -42,12 +42,22 @@ import java.util.Set;
  * 수정일		수정자				수정내용
  * ----------------------------------------------
  * 2009.03.18	김종호				최초생성
+ * 2026.09.10	실행환경 개발팀		저장 경로 직접 주입 생성자 추가
  * </pre>
  * @since 2009.03.18
  */
 public class EgovDOMValidatorService extends AbstractXMLUtility {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(EgovDOMValidatorService.class);
+
+    /**
+     * 기본 저장 경로를 직접 주입받는 생성자 — 설정 파일과 Spring 컨텍스트 없이 동작한다.
+     *
+     * @param savedPath 경로를 지정하지 않은 저장 API 의 기본 위치(경로 구분자로 끝나야 한다)
+     */
+    public EgovDOMValidatorService(String savedPath) {
+        super(savedPath);
+    }
 
     private static final String FEATURE_EXTERNAL_GENERAL_ENTITIES =
             "http://xml.org/sax/features/external-general-entities";

--- a/Foundation/org.egovframe.rte.fdl.xml/src/main/java/org/egovframe/rte/fdl/xml/EgovSAXValidatorService.java
+++ b/Foundation/org.egovframe.rte.fdl.xml/src/main/java/org/egovframe/rte/fdl/xml/EgovSAXValidatorService.java
@@ -40,12 +40,22 @@ import java.util.Set;
  * 수정일		수정자				수정내용
  * ----------------------------------------------
  * 2009.03.18	김종호				최초생성
+ * 2026.09.10	실행환경 개발팀		저장 경로 직접 주입 생성자 추가
  * </pre>
  * @since 2009.03.18
  */
 public class EgovSAXValidatorService extends AbstractXMLUtility {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(EgovSAXValidatorService.class);
+
+    /**
+     * 기본 저장 경로를 직접 주입받는 생성자 — 설정 파일과 Spring 컨텍스트 없이 동작한다.
+     *
+     * @param savedPath 경로를 지정하지 않은 저장 API 의 기본 위치(경로 구분자로 끝나야 한다)
+     */
+    public EgovSAXValidatorService(String savedPath) {
+        super(savedPath);
+    }
 
     private static final String FEATURE_EXTERNAL_GENERAL_ENTITIES =
             "http://xml.org/sax/features/external-general-entities";

--- a/Foundation/org.egovframe.rte.fdl.xml/src/test/java/org/egovframe/rte/fdl/xml/AbstractXMLUtilityLifecycleTest.java
+++ b/Foundation/org.egovframe.rte.fdl.xml/src/test/java/org/egovframe/rte/fdl/xml/AbstractXMLUtilityLifecycleTest.java
@@ -1,0 +1,76 @@
+package org.egovframe.rte.fdl.xml;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.w3c.dom.Document;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * 저장 경로를 직접 주입하는 생성자가 설정 파일·Spring 컨텍스트 없이 동작하는지 검증한다.
+ * 기본 생성자(egovxmlCfg.xml 에서 경로를 읽고 컨텍스트를 바로 닫는 경로)는 기존 테스트가 회귀 검증한다.
+ */
+public class AbstractXMLUtilityLifecycleTest {
+
+    @TempDir
+    Path tempDir;
+
+    /** parse 만 구현한 최소 서브클래스 — 경로 주입 생성자 검증용 */
+    private static final class PathInjectedUtility extends AbstractXMLUtility {
+        private PathInjectedUtility(String savedPath) {
+            super(savedPath);
+        }
+
+        @Override
+        public boolean parse(boolean isValid) {
+            return true;
+        }
+    }
+
+    @Test
+    public void testPathInjectedConstructorSavesUnderInjectedPathWithoutContext() throws Exception {
+        String savedPath = tempDir.toString() + File.separator;
+        PathInjectedUtility utility = new PathInjectedUtility(savedPath);
+
+        Document doc = DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument();
+        utility.createNewXML(doc, "root",
+                List.of(new SharedObject("name", "전자정부"), new SharedObject("layer", "fdl.xml")), null);
+
+        Path saved = tempDir.resolve("newXML.xml"); // 경로 미지정 시 savedPath + newXML.xml
+        assertTrue(Files.exists(saved), "주입한 경로 아래에 저장되어야 한다");
+        String content = Files.readString(saved, StandardCharsets.UTF_8);
+        assertTrue(content.contains("<name>전자정부</name>"), content);
+        assertTrue(content.contains("<layer>fdl.xml</layer>"), content);
+    }
+
+    @Test
+    public void testValidatorServicesOfferPathInjectedConstructor() throws Exception {
+        String savedPath = tempDir.toString() + File.separator;
+        EgovDOMValidatorService dom = new EgovDOMValidatorService(savedPath);
+        EgovSAXValidatorService sax = new EgovSAXValidatorService(savedPath);
+
+        dom.setXML("<a/>");
+        assertEquals("<a/>", dom.getXML());
+        assertTrue(dom.parse(false), "경로 주입 생성자로 만든 DOM 검증기가 파싱해야 한다");
+
+        sax.setXML("<b/>");
+        assertEquals("<b/>", sax.getXML());
+        assertTrue(sax.parse(false), "경로 주입 생성자로 만든 SAX 검증기가 파싱해야 한다");
+    }
+
+    @Test
+    public void testDefaultConstructorStillReadsConfiguredPath() throws Exception {
+        // 설정 파일 경로로 만든 인스턴스도 종전처럼 동작한다(컨텍스트는 읽은 뒤 바로 닫힌다)
+        EgovDOMValidatorService dom = new EgovDOMValidatorService();
+        dom.setXML("<c/>");
+        assertTrue(dom.parse(false));
+    }
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

### 문제

`AbstractXMLUtility` 의 기본 생성자는 `egovxmlCfg.xml` 을 읽기 위해 **인스턴스마다 `FileSystemXmlApplicationContext` 를 새로
만든 뒤 닫지 않고 필드로 보관**합니다. 설정에서 쓰는 값은 `xmlconfig` 빈의 저장 경로 하나뿐인데, 컨텍스트 전체가
인스턴스 수명 동안 유지되고 `close()` 도 호출되지 않습니다. `EgovDOMValidatorService`·`EgovSAXValidatorService` 를
요청마다 만드는 코드에서는 그 횟수만큼 컨텍스트(빈 팩토리·리소스 캐시·이벤트 멀티캐스터)가 쌓입니다.

또한 설정 파일 없이는 이 유틸을 만들 수 없어, 저장 경로 하나만 필요한 상황에서도 Spring 컨텍스트와
`egovxmlCfg.xml` 을 준비해야 했습니다.

> #268 이 같은 클래스의 저장 시 `OutputStream` 누수를 고쳤습니다. 이 PR 은 생성자 쪽에 남아 있던 컨텍스트 누수를 다룹니다.

### 수정

| 항목 | 이전 | 이후 |
|---|---|---|
| 기본 생성자 | 컨텍스트를 만들어 **필드로 보관**(미종료) | try-with-resources 로 열어 저장 경로만 읽고 **즉시 닫음** |
| `context`·`xmlConfig` 필드 | 보관(다른 곳에서 미사용) | 제거 |
| 저장 경로 주입 | 불가 | `protected AbstractXMLUtility(String savedPath)` 신설. 두 검증기에 `public` 생성자 `(String savedPath)` 추가 |
| `new EgovDOMValidatorService()` 등 기본 생성자 | 설정 파일에서 경로 읽음 | **그대로**(컨텍스트만 닫음) |

```java
public AbstractXMLUtility() {
    try (FileSystemXmlApplicationContext context = new FileSystemXmlApplicationContext(CONFIG_PATH)) {
        this.savedPath = ((XmlConfig) context.getBean("xmlconfig")).getXmlpath();
    }
}

protected AbstractXMLUtility(String savedPath) {
    this.savedPath = savedPath;
}
```

### 호환성

- 기본 생성자의 동작(설정 파일에서 저장 경로를 읽음)은 그대로이며, 컨텍스트를 닫는 것만 달라집니다. 제거한 두 필드는
  `private` 이고 클래스 안에서도 생성자 밖에서는 쓰이지 않았습니다.
- 두 검증기의 기본 생성자는 손대지 않았으므로 기존 호출은 소스·바이너리 모두 그대로 동작합니다. 새 생성자는 추가일 뿐입니다.
- `savedPath` 는 저장 API 가 파일명을 바로 이어 붙이는 기존 규칙을 따르므로 경로 구분자로 끝나야 하며, javadoc 에
  적었습니다(설정 값도 같은 규칙입니다).

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

`AbstractXMLUtilityLifecycleTest` **3건 신규**, `fdl.xml` 모듈 전건 통과.

| 환경 | 기본 로케일(Locale) | 모듈 실행 건수 | 결과 |
|---|---|---:|---|
| **Windows** | ko_KR | **6** | `Tests run: 6, Failures: 0, Errors: 0, Skipped: 0` |
| **Linux** (Ubuntu 22.04 / OpenJDK 17) | C.UTF-8 | **6** | `Tests run: 6, Failures: 0, Errors: 0, Skipped: 0` |

| 구분 | 건수 | 내용 |
|---|---:|---|
| 경로 주입 | 2 | 설정 파일·컨텍스트 없이 만든 유틸이 주입 경로 아래에 XML 을 생성·저장한다 · 두 검증기의 경로 주입 생성자로 파싱까지 동작한다 |
| 기존 동작 | 1 | 기본 생성자로 만든 검증기가 종전처럼 파싱한다(기존 `ControlXMLTest`·`XmlUtilitySaveDocumentTest` 도 무변경 통과) |

**수동 확인**: 현재 `main`(`cc2b332`) 위에서 `fdl.xml` 모듈 빌드·테스트가 통과함을 Windows 와 Linux 에서 확인했습니다.

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

해당 없음 — 라이브러리 내부 수정입니다.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

해당 없음 — 위 JUnit 테스트 결과로 갈음합니다.

---

<sub>base: `eGovFramework:main` @ `cc2b332` (2026-09-10 fetch 기준, #366~#379 머지 후) · 단일 커밋</sub>
