### PR TITLE
fix: 리액티브 예외 응답을 json-simple 수기 직렬화 대신 Jackson 으로 만들고 RFC 9457 형식을 선택할 수 있게 수정

### DIFF
--- a/Presentation/org.egovframe.rte.ptl.reactive/pom.xml
+++ b/Presentation/org.egovframe.rte.ptl.reactive/pom.xml
@@ -30,7 +30,7 @@
         <jakarta.validation.version>3.1.1</jakarta.validation.version>
         <jakarta.el.version>6.0.1</jakarta.el.version>
         <glassfish.jakarta.el.version>4.0.2</glassfish.jakarta.el.version>
-        <json.simple.version>1.1.1</json.simple.version>
+        <jackson.version>2.18.2</jackson.version>
         <log4j2.version>2.25.3</log4j2.version>
         <slf4j.version>2.0.17</slf4j.version>
         <easymock.version>5.3.0</easymock.version>
@@ -131,18 +131,24 @@
             <version>${slf4j.version}</version>
         </dependency>
 
-        <!-- Commons & Utils -->
+        <!-- JSON (오류 응답 직렬화) -->
         <dependency>
-            <groupId>com.googlecode.json-simple</groupId>
-            <artifactId>json-simple</artifactId>
-            <version>${json.simple.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>junit</groupId>
-                    <artifactId>junit</artifactId>
-                </exclusion>
-            </exclusions>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>${jackson.version}</version>
         </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+
+        <!-- Commons & Utils -->
         <dependency>
             <groupId>org.easymock</groupId>
             <artifactId>easymock</artifactId>

--- a/Presentation/org.egovframe.rte.ptl.reactive/src/main/java/org/egovframe/rte/ptl/reactive/exception/EgovExceptionHandler.java
+++ b/Presentation/org.egovframe.rte.ptl.reactive/src/main/java/org/egovframe/rte/ptl/reactive/exception/EgovExceptionHandler.java
@@ -15,7 +15,8 @@
  */
 package org.egovframe.rte.ptl.reactive.exception;
 
-import org.json.simple.JSONObject;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.core.annotation.Order;
@@ -28,13 +29,17 @@ import org.springframework.web.server.WebExceptionHandler;
 import reactor.core.publisher.Mono;
 
 import java.nio.charset.StandardCharsets;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 /**
  * 발생한 오류를 처리하고 동일한 형식으로 응답을 보내기 위한 클래스
  *
  * <p>Desc.: 발생한 오류를 처리하고 동일한 형식으로 응답을 보내기 위한 클래스</p>
+ *
+ * <p>응답 본문은 기본적으로 {@code timestamp}/{@code status}/{@code code}/{@code message} 형식이다.
+ * {@link #setProblemDetailEnabled(boolean)} 로 RFC 9457(Problem Details, {@code application/problem+json})
+ * 형식을 선택할 수 있다.</p>
  *
  * @author 유지보수
  * @version 1.0
@@ -44,6 +49,7 @@ import java.util.Map;
  * 수정일		수정자				수정내용
  * ----------------------------------------------
  * 2023.08.31   유지보수            최초 생성
+ * 2026.09.10   실행환경 개발팀      json-simple 수기 직렬화를 Jackson 으로 교체, RFC 9457 problem+json 선택 옵션 추가
  * </pre>
  * @since 2023.08.31
  */
@@ -51,6 +57,34 @@ import java.util.Map;
 public class EgovExceptionHandler implements WebExceptionHandler {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(EgovExceptionHandler.class);
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    private static final MediaType PROBLEM_JSON_UTF8 = new MediaType("application", "problem+json", StandardCharsets.UTF_8);
+
+    /**
+     * RFC 9457(Problem Details) 응답 형식 사용 여부. 기본값 false 는 기존 형식을 유지한다.
+     */
+    private boolean problemDetailEnabled = false;
+
+    /**
+     * RFC 9457({@code application/problem+json}) 응답 형식을 선택한다.
+     * false(기본)면 기존 {@code timestamp}/{@code status}/{@code code}/{@code message} 형식을 유지한다.
+     *
+     * @param problemDetailEnabled true 면 Problem Details 형식으로 응답
+     */
+    public void setProblemDetailEnabled(boolean problemDetailEnabled) {
+        this.problemDetailEnabled = problemDetailEnabled;
+    }
+
+    /**
+     * RFC 9457 응답 형식 사용 여부
+     *
+     * @return true 면 Problem Details 형식
+     */
+    public boolean isProblemDetailEnabled() {
+        return problemDetailEnabled;
+    }
 
     @Override
     public Mono<Void> handle(ServerWebExchange exchange, Throwable ex) {
@@ -96,15 +130,34 @@ public class EgovExceptionHandler implements WebExceptionHandler {
     }
 
     private Mono<Void> handlerResponse(ServerHttpResponse response, String timestamp, int status, String code, String message) {
-        response.setStatusCode(HttpStatus.valueOf(status));
-        response.getHeaders().setContentType(new MediaType(MediaType.APPLICATION_JSON, StandardCharsets.UTF_8));
-        Map<String, Object> map = new HashMap<>();
-        map.put("timestamp", timestamp);
-        map.put("status", status);
-        map.put("code", code);
-        map.put("message", message);
-        JSONObject jsonObject = new JSONObject(map);
-        DataBuffer dataBuffer = response.bufferFactory().wrap(JSONObject.toJSONString(jsonObject).getBytes(StandardCharsets.UTF_8));
+        HttpStatus httpStatus = HttpStatus.valueOf(status);
+        response.setStatusCode(httpStatus);
+        Map<String, Object> body = new LinkedHashMap<>();
+        if (problemDetailEnabled) {
+            // RFC 9457 Problem Details — 표준 필드 뒤에 실행환경 확장 필드(code, timestamp)를 둔다
+            response.getHeaders().setContentType(PROBLEM_JSON_UTF8);
+            body.put("type", "about:blank");
+            body.put("title", httpStatus.getReasonPhrase());
+            body.put("status", status);
+            body.put("detail", message);
+            body.put("code", code);
+            body.put("timestamp", timestamp);
+        } else {
+            response.getHeaders().setContentType(new MediaType(MediaType.APPLICATION_JSON, StandardCharsets.UTF_8));
+            body.put("timestamp", timestamp);
+            body.put("status", status);
+            body.put("code", code);
+            body.put("message", message);
+        }
+        byte[] payload;
+        try {
+            payload = OBJECT_MAPPER.writeValueAsBytes(body);
+        } catch (JsonProcessingException e) {
+            // 문자열과 정수만 담는 맵이라 실제로는 일어나지 않지만, 응답 없이 끝나지 않도록 최소 본문으로 대체한다
+            LOGGER.error("Failed to serialize error response body", e);
+            payload = ("{\"status\":" + status + "}").getBytes(StandardCharsets.UTF_8);
+        }
+        DataBuffer dataBuffer = response.bufferFactory().wrap(payload);
         return response.writeWith(Mono.just(dataBuffer));
     }
 

--- a/Presentation/org.egovframe.rte.ptl.reactive/src/test/java/org/egovframe/rte/ptl/reactive/exception/EgovExceptionHandlerResponseTest.java
+++ b/Presentation/org.egovframe.rte.ptl.reactive/src/test/java/org/egovframe/rte/ptl/reactive/exception/EgovExceptionHandlerResponseTest.java
@@ -1,0 +1,94 @@
+package org.egovframe.rte.ptl.reactive.exception;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
+import org.springframework.mock.web.server.MockServerWebExchange;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * 오류 응답 본문의 형식을 검증한다 — 기본 형식(timestamp/status/code/message)과 RFC 9457 선택 형식.
+ */
+public class EgovExceptionHandlerResponseTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private static MockServerWebExchange handle(EgovExceptionHandler handler, Throwable ex) {
+        MockServerWebExchange exchange = MockServerWebExchange.from(MockServerHttpRequest.get("/test").build());
+        handler.handle(exchange, ex).block();
+        return exchange;
+    }
+
+    private static JsonNode body(MockServerWebExchange exchange) throws Exception {
+        String body = exchange.getResponse().getBodyAsString().block();
+        assertNotNull(body);
+        return MAPPER.readTree(body);
+    }
+
+    private static List<String> fieldNames(JsonNode node) {
+        List<String> names = new ArrayList<>();
+        for (Iterator<String> it = node.fieldNames(); it.hasNext(); ) {
+            names.add(it.next());
+        }
+        return names;
+    }
+
+    @Test
+    public void testDefaultFormatKeepsLegacyFieldsAndMediaType() throws Exception {
+        MockServerWebExchange exchange = handle(new EgovExceptionHandler(), new EgovException("업무 오류가 발생했습니다"));
+
+        assertEquals(MediaType.parseMediaType("application/json;charset=UTF-8"), exchange.getResponse().getHeaders().getContentType());
+        JsonNode body = body(exchange);
+        assertEquals(List.of("timestamp", "status", "code", "message"), fieldNames(body), "기존 형식의 필드가 그대로여야 한다");
+        assertTrue(body.get("status").isInt(), "status 는 정수여야 한다: " + body);
+        assertEquals("업무 오류가 발생했습니다", body.get("message").asText());
+        assertNull(body.get("type"), "기본값에서는 Problem Details 필드가 없어야 한다");
+    }
+
+    @Test
+    public void testUnhandledExceptionKeepsGenericMessage() throws Exception {
+        MockServerWebExchange exchange = handle(new EgovExceptionHandler(), new IllegalStateException("jdbc:oracle secret detail"));
+
+        JsonNode body = body(exchange);
+        assertEquals(500, body.get("status").asInt());
+        assertFalse(body.get("message").asText().contains("oracle"), "내부 정보가 응답에 노출되면 안 된다: " + body);
+    }
+
+    @Test
+    public void testProblemDetailOptInUsesRfc9457ShapeAndMediaType() throws Exception {
+        EgovExceptionHandler handler = new EgovExceptionHandler();
+        handler.setProblemDetailEnabled(true);
+        MockServerWebExchange exchange = handle(handler, new EgovServiceException(EgovErrorCode.INVALID_INPUT_VALUE, "검증에 실패했습니다"));
+
+        MediaType contentType = exchange.getResponse().getHeaders().getContentType();
+        assertNotNull(contentType);
+        assertEquals("application", contentType.getType());
+        assertEquals("problem+json", contentType.getSubtype());
+        JsonNode body = body(exchange);
+        assertEquals(List.of("type", "title", "status", "detail", "code", "timestamp"), fieldNames(body));
+        assertEquals("about:blank", body.get("type").asText());
+        assertEquals(400, body.get("status").asInt());
+        assertEquals("Bad Request", body.get("title").asText());
+        assertEquals("검증에 실패했습니다", body.get("detail").asText());
+    }
+
+    @Test
+    public void testKoreanMessageIsWrittenAsUtf8() throws Exception {
+        MockServerWebExchange exchange = handle(new EgovExceptionHandler(), new EgovServiceException(EgovErrorCode.INVALID_INPUT_VALUE, "서비스 예외 메시지"));
+
+        String raw = exchange.getResponse().getBodyAsString().block();
+        assertNotNull(raw);
+        assertTrue(raw.contains("\"message\":\"서비스 예외 메시지\""), raw);
+    }
+}

--- a/Presentation/org.egovframe.rte.ptl.reactive/src/test/java/org/egovframe/rte/ptl/reactive/exception/EgovExceptionHandlerTest.java
+++ b/Presentation/org.egovframe.rte.ptl.reactive/src/test/java/org/egovframe/rte/ptl/reactive/exception/EgovExceptionHandlerTest.java
@@ -10,8 +10,8 @@ import org.springframework.test.web.reactive.server.WebTestClient;
 import org.springframework.web.bind.annotation.GetMapping;
 import reactor.core.publisher.Mono;
 
-import org.json.simple.JSONObject;
-import org.json.simple.parser.JSONParser;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 import java.nio.charset.StandardCharsets;
 
@@ -49,13 +49,14 @@ public class EgovExceptionHandlerTest {
                 .expectBody()
                 .consumeWith(result -> {
                     String body = new String(result.getResponseBody(), StandardCharsets.UTF_8);
-                    JSONObject json;
+                    JsonNode json;
                     try {
-                        json = (JSONObject) new JSONParser().parse(body);
+                        json = new ObjectMapper().readTree(body);
                     } catch (Exception e) {
                         throw new AssertionError("application/json 으로 선언한 본문이 파싱되지 않는다: " + body, e);
                     }
-                    assertEquals(404L, json.get("status"));
+                    assertTrue(json.get("status").isInt(), "status 는 정수여야 한다: " + body);
+                    assertEquals(404, json.get("status").asInt());
                 });
     }
 


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [ ] 버그수정 Bug fixes
- [X] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

### 배경

`EgovExceptionHandler` 는 오류 응답 본문을 **json-simple** 로 만듭니다. json-simple 은 2012년 1.1.1 이후 갱신이 없는
라이브러리이고, 실행환경의 다른 모듈(fdl.access 등)과 사업 애플리케이션은 Jackson 을 씁니다. 이 모듈만 다른 JSON
라이브러리를 전이 의존으로 끌고 들어오는 셈입니다.

### 수정

| 항목 | 이전 | 이후 |
|---|---|---|
| 직렬화 | json-simple `JSONObject.toJSONString` | Jackson `ObjectMapper`(클래스 단위 공유) |
| 기본 응답 형식 | `timestamp`/`status`/`code`/`message`, `application/json;charset=UTF-8` | **그대로**(필드·순서·미디어 타입 동일, `status` 정수) |
| RFC 9457 형식 | 없음 | `setProblemDetailEnabled(true)` 로 선택 — `application/problem+json`, `type`/`title`/`status`/`detail` + 확장 필드 `code`/`timestamp` |
| 직렬화 실패 | (해당 없음) | `{"status":N}` 최소 본문으로 대체하고 ERROR 로그 |

```java
handler.setProblemDetailEnabled(true);   // 기본값 false — 기존 형식 유지
```

### 의존 변경 (고지)

| 구분 | 내용 |
|---|---|
| 제거 | `com.googlecode.json-simple:json-simple:1.1.1` |
| 추가 | `com.fasterxml.jackson.core:jackson-core`·`jackson-databind`·`jackson-annotations` **2.18.2** (fdl.access 와 같은 버전·선언 방식) |

- 이 모듈의 전이 의존으로 json-simple 을 쓰던 애플리케이션은 직접 선언해야 합니다. 실행환경 24모듈 중 json-simple 을
  선언한 곳은 이 모듈뿐이라, 이 PR 로 실행환경에서 json-simple 이 사라집니다.
- Jackson 을 이미 쓰는 애플리케이션(대부분)은 버전 관리(Spring Boot BOM 등)에 따라 정렬됩니다. 실행환경 안에서는
  fdl.access 가 같은 2.18.2 를 선언하고 있습니다.

### 호환성

- 기본 형식의 필드와 순서(`timestamp`, `status`, `code`, `message`), 미디어 타입, 한글 메시지의 UTF-8 출력은 그대로입니다.
  기존 테스트 3건이 무변경 통과하며, #359 가 넣은 JSON 파싱 검증은 json-simple 대신 Jackson 으로 파싱하도록 바꿔 유지했습니다.
- Problem Details 형식은 명시적으로 켜야만 적용됩니다. 필드 구성은 MVC 쪽 #397(`EgovRestExceptionHandler`)의
  problem+json 과 같은 RFC 9457 표준 필드를 따릅니다.
- #256 이 명시한 UTF-8 미디어 타입은 그대로이며 테스트로 고정했습니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

`EgovExceptionHandlerResponseTest` **4건 신규** + `EgovExceptionHandlerTest` 파싱 검증 Jackson 전환, `ptl.reactive` 모듈 전건 통과.

| 환경 | 기본 로케일(Locale) | 모듈 실행 건수 | 결과 |
|---|---|---:|---|
| **Windows** | ko_KR | **30** | `Tests run: 30, Failures: 0, Errors: 0, Skipped: 0` |
| **Linux** (Ubuntu 22.04 / OpenJDK 17) | C.UTF-8 | **30** | `Tests run: 30, Failures: 0, Errors: 0, Skipped: 0` |

| 구분 | 건수 | 내용 |
|---|---:|---|
| 기본 형식 불변 | 2 | 필드 순서 `timestamp`/`status`/`code`/`message`, 정수 `status`, `application/json;charset=UTF-8`, Problem Details 필드 없음 · 한글 메시지 UTF-8 |
| 기존 동작 회귀 | 1 | 미분류 예외는 500 과 일반화 메시지(내부 정보 미노출) |
| 선택 형식 | 1 | `application/problem+json`, `type`/`title`/`status`/`detail`/`code`/`timestamp`, 400 → `Bad Request` |

**수동 확인**: 현재 `main`(`cc2b332`) 위에서 `ptl.reactive` 모듈 빌드·테스트가 통과함을 Windows 와 Linux 에서 확인했습니다.

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

해당 없음 — 라이브러리 내부 수정입니다.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

해당 없음 — 위 JUnit 테스트 결과로 갈음합니다.

---

<sub>base: `eGovFramework:main` @ `cc2b332` (2026-09-10 fetch 기준, #366~#379 머지 후) · 단일 커밋</sub>
