### PR TITLE
fix: EgovFileUtil 이 VFS 초기화 실패를 debug 로 삼켜 이후 호출이 원인 불명 NPE 로 끝나던 문제 수정, 결함 API deprecated

### DIFF
--- a/Foundation/org.egovframe.rte.fdl.filehandling/src/main/java/org/egovframe/rte/fdl/filehandling/EgovFileUtil.java
+++ b/Foundation/org.egovframe.rte.fdl.filehandling/src/main/java/org/egovframe/rte/fdl/filehandling/EgovFileUtil.java
@@ -35,6 +35,10 @@ import java.util.regex.Pattern;
 
 /**
  * 파일 서비스를 제공하기 위해 구현한 클래스이다.
+ *
+ * <p>로컬 파일 처리에는 기준 경로를 인자로 받고 실패를 예외로 알리는 {@link EgovFiles} 를 권장한다.
+ * 이 클래스는 Commons VFS 가 필요한 경우와 기존 코드 호환을 위해 유지한다. {@code rm}/{@code cp}/{@code mv} 는
+ * 실패를 예외로 던지지 않는 기존 계약을 지키되, 실패가 묻히지 않도록 WARN 로그를 남긴다.</p>
  * <p>
  * 수정일		수정자				수정내용
  * ----------------------------------------------
@@ -42,6 +46,7 @@ import java.util.regex.Pattern;
  * 2014.05.14	이기하				vfs -> vfs2로 패키지 변경
  * 2017.02.28	장동한				시큐어코딩(ES)-Null Pointer 역참조[CWE-476]
  * 2017.02.28	장동한				시큐어코딩(ES)-부적절한 자원 해제[CWE-404]
+ * 2026.09.10	실행환경 개발팀		VFS 초기화 실패를 WARN 과 명시 예외로 보고, rm/cp/mv 실패 WARN, cd/pwd/grep/ls deprecated
  */
 public class EgovFileUtil {
 
@@ -55,61 +60,95 @@ public class EgovFileUtil {
             manager = VFS.getManager();
             basefile = manager.resolveFile(System.getProperty("user.dir"));
         } catch (FileSystemException e) {
-            LOGGER.debug("[{}] EogvFileUtil : {}", e.getClass().getName(), e.getMessage());
+            // debug 로 삼키면 이후 모든 호출이 원인을 알 수 없는 NullPointerException 이 된다.
+            // 사용 시점에는 manager()/basefile() 가드가 원인을 담은 IllegalStateException 을 던진다.
+            LOGGER.warn("EgovFileUtil VFS initialization failed - subsequent calls will fail: {}", e.getMessage());
         }
     }
 
     /**
+     * VFS 초기화 실패 시 원인을 알 수 없는 NullPointerException 대신 명확한 예외를 던지기 위한 가드
+     */
+    private static FileSystemManager manager() {
+        if (manager == null) {
+            throw new IllegalStateException(
+                    "Commons VFS is not initialized (see startup WARN log). For local file handling use EgovFiles.");
+        }
+        return manager;
+    }
+
+    private static FileObject basefile() {
+        if (basefile == null) {
+            throw new IllegalStateException(
+                    "Commons VFS base directory is not initialized (see startup WARN log). For local file handling use EgovFiles.");
+        }
+        return basefile;
+    }
+
+    /**
      * 지정한 위치의 파일 및 디렉토리를 삭제한다.
+     *
+     * <p>삭제 범위는 자신과 직계 자식까지({@code SELECT_SELF_AND_CHILDREN})이며, 실패하면 예외 없이 -1 을 돌려주고
+     * WARN 로그를 남긴다. 깊이 제한 없는 삭제와 실패 전파가 필요하면 {@link EgovFiles#deleteRecursively(java.nio.file.Path)} 를 사용한다.</p>
      */
     public static int rm(final String cmd) {
         int result = -1;
         try {
-            final FileObject file = manager.resolveFile(basefile, cmd);
+            final FileObject file = manager().resolveFile(basefile(), cmd);
             result = file.delete(Selectors.SELECT_SELF_AND_CHILDREN);
         } catch (FileSystemException e) {
-            LOGGER.debug("[{}] EogvFileUtil : {}", e.getClass().getName(), e.getMessage());
+            LOGGER.warn("EgovFileUtil.rm failed for [{}]: {}", cmd, e.getMessage());
         }
         return result;
     }
 
     /**
      * 지정한 위치의 파일을 대상 위치로 복사한다.
+     *
+     * <p>실패하면 예외 없이 돌아오고 WARN 로그만 남긴다(기존 계약). 실패를 예외로 받으려면
+     * {@link EgovFiles#copy(java.nio.file.Path, java.nio.file.Path)} 를 사용한다.</p>
      */
     public static void cp(String source, String target) {
         try {
-            final FileObject src = manager.resolveFile(basefile, source);
-            FileObject dest = manager.resolveFile(basefile, target);
+            final FileObject src = manager().resolveFile(basefile(), source);
+            FileObject dest = manager().resolveFile(basefile(), target);
             if (dest.exists() && dest.getType() == FileType.FOLDER) {
                 dest = dest.resolveFile(src.getName().getBaseName());
             }
             dest.copyFrom(src, Selectors.SELECT_ALL);
         } catch (FileSystemException e) {
-            LOGGER.debug("[{}] EogvFileUtil : {}", e.getClass().getName(), e.getMessage());
+            LOGGER.warn("EgovFileUtil.cp failed [{}] -> [{}]: {}", source, target, e.getMessage());
         }
     }
 
     /**
      * 지정한 위치의 파일을 대상 위치로 이동한다.
+     *
+     * <p>실패하면 예외 없이 돌아오고 WARN 로그만 남긴다(기존 계약). 실패를 예외로 받으려면
+     * {@link EgovFiles#move(java.nio.file.Path, java.nio.file.Path)} 를 사용한다.</p>
      */
     public static void mv(String source, String target) {
         try {
-            final FileObject src = manager.resolveFile(basefile, source);
-            FileObject dest = manager.resolveFile(basefile, target);
+            final FileObject src = manager().resolveFile(basefile(), source);
+            FileObject dest = manager().resolveFile(basefile(), target);
             if (dest.exists() && dest.getType() == FileType.FOLDER) {
                 dest = dest.resolveFile(src.getName().getBaseName());
             }
             src.moveTo(dest);
         } catch (FileSystemException e) {
-            LOGGER.debug("[{}] EogvFileUtil : {}", e.getClass().getName(), e.getMessage());
+            LOGGER.warn("EgovFileUtil.mv failed [{}] -> [{}]: {}", source, target, e.getMessage());
         }
     }
 
     /**
      * 현재 작업위치를 리턴한다.
+     *
+     * @deprecated {@link #cd(String)} 가 바꾸는 프로세스 전역 기준 경로를 읽는 API 라 동시 요청 환경에서 안전하지 않다.
+     * 기준 경로를 인자로 받는 {@link EgovFiles} 를 사용한다.
      */
+    @Deprecated
     public static FileName pwd() {
-        return basefile.getName();
+        return basefile().getName();
     }
 
     /**
@@ -117,7 +156,7 @@ public class EgovFileUtil {
      */
     public static long touch(final String filepath) throws FileSystemException {
         long currentTime = 0;
-        final FileObject file = manager.resolveFile(basefile, filepath);
+        final FileObject file = manager().resolveFile(basefile(), filepath);
         if (!file.exists()) {
             file.createFile();
         }
@@ -128,7 +167,12 @@ public class EgovFileUtil {
 
     /**
      * 현재 작업공간의 위치를 지정한 위치로 이동한다.
+     *
+     * @deprecated 프로세스 전역 static 기준 경로를 바꾸므로, 한 요청의 호출이 다른 모든 스레드의
+     * {@code rm}/{@code cp}/{@code mv}/{@code touch} 상대 경로 해석 기준을 바꾼다. 기준 경로를 항상 인자로 받는
+     * {@link EgovFiles} 를 사용한다.
      */
+    @Deprecated
     public static void cd(final String changDirectory) throws FileSystemException {
         final String path;
         if (!EgovStringUtil.isNull(changDirectory)) {
@@ -137,7 +181,7 @@ public class EgovFileUtil {
             path = System.getProperty("user.home");
         }
 
-        FileObject tmp = manager.resolveFile(basefile, path);
+        FileObject tmp = manager().resolveFile(basefile(), path);
         if (tmp.exists()) {
             basefile = tmp;
         } else {
@@ -393,7 +437,11 @@ public class EgovFileUtil {
 
     /**
      * 특정 패턴이 존재하는 파일을 검색한다.
+     *
+     * @deprecated 이름과 달리 패턴에 맞는 줄이 아니라 <b>패턴을 기준으로 나눈 조각</b>을 돌려준다. 기존 호출 호환을 위해
+     * 동작은 그대로 두며, 패턴에 맞는 줄이 필요하면 {@link EgovFiles#grepLines(java.nio.file.Path, String)} 를 사용한다.
      */
+    @Deprecated
     public static List<String> grep(final Object[] search, final String pattern) {
         Pattern searchPattern = Pattern.compile(pattern);
         String[] strings = searchPattern.split(Arrays.toString(search));
@@ -402,7 +450,11 @@ public class EgovFileUtil {
 
     /**
      * 특정 패턴이 존재하는 파일을 검색한다.
+     *
+     * @deprecated 이름과 달리 패턴에 맞는 줄이 아니라 <b>패턴을 기준으로 나눈 조각</b>을 돌려준다. 기존 호출 호환을 위해
+     * 동작은 그대로 두며, 패턴에 맞는 줄이 필요하면 {@link EgovFiles#grepLines(java.nio.file.Path, String)} 를 사용한다.
      */
+    @Deprecated
     public static List<String> grep(final File file, final String pattern) throws IOException {
         Pattern searchPattern = Pattern.compile(pattern);
         List<String> lists = readTextLines(file, "UTF-8");
@@ -423,7 +475,11 @@ public class EgovFileUtil {
 
     /**
      * 지정한 위치의 파일목록을 조회한다.
+     *
+     * @deprecated 목록을 채우지 않고 <b>항상 빈 리스트</b>를 돌려주며 debug 로그만 남긴다. 기존 호출 호환을 위해 동작은
+     * 그대로 두며, 실제 목록이 필요하면 {@link EgovFiles#list(java.nio.file.Path)} 나 {@link EgovFiles#listRecursively(java.nio.file.Path)} 를 사용한다.
      */
+    @Deprecated
     public List<?> ls(final String[] cmd) throws FileSystemException {
         List<Object> list = new ArrayList<Object>();
         int pos = 1;
@@ -437,9 +493,9 @@ public class EgovFileUtil {
 
         final FileObject file;
         if (cmd.length > pos) {
-            file = manager.resolveFile(basefile, cmd[pos]);
+            file = manager().resolveFile(basefile(), cmd[pos]);
         } else {
-            file = basefile;
+            file = basefile();
         }
 
         if (file.getType() == FileType.FOLDER) {

--- a/Foundation/org.egovframe.rte.fdl.filehandling/src/test/java/org/egovframe/rte/fdl/filehandling/EgovFileUtilInitGuardTest.java
+++ b/Foundation/org.egovframe.rte.fdl.filehandling/src/test/java/org/egovframe/rte/fdl/filehandling/EgovFileUtilInitGuardTest.java
@@ -1,0 +1,173 @@
+package org.egovframe.rte.fdl.filehandling;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.appender.AbstractAppender;
+import org.apache.logging.log4j.core.config.Configuration;
+import org.apache.logging.log4j.core.config.LoggerConfig;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.lang.reflect.Field;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * VFS 초기화 실패 가드와 rm/cp/mv 의 실패 로그, deprecated API 의 기존 동작 유지를 검증한다.
+ */
+@SuppressWarnings("deprecation")
+public class EgovFileUtilInitGuardTest {
+
+    private static final String LOGGER_NAME = EgovFileUtil.class.getName();
+
+    @TempDir
+    Path tempDir;
+
+    private CapturingAppender appender;
+
+    @BeforeEach
+    void setUp() {
+        LoggerContext context = (LoggerContext) LogManager.getContext(false);
+        Configuration configuration = context.getConfiguration();
+        appender = new CapturingAppender();
+        appender.start();
+        LoggerConfig loggerConfig = new LoggerConfig(LOGGER_NAME, Level.DEBUG, false);
+        loggerConfig.addAppender(appender, Level.DEBUG, null);
+        configuration.addLogger(LOGGER_NAME, loggerConfig);
+        context.updateLoggers();
+    }
+
+    @AfterEach
+    void tearDown() {
+        LoggerContext context = (LoggerContext) LogManager.getContext(false);
+        context.getConfiguration().removeLogger(LOGGER_NAME);
+        context.updateLoggers();
+        appender.stop();
+    }
+
+    @Test
+    public void testCallsAfterFailedInitializationThrowIllegalStateInsteadOfNpe() throws Exception {
+        Object savedManager = readStatic("manager");
+        try {
+            writeStatic("manager", null);
+
+            IllegalStateException e = assertThrows(IllegalStateException.class, () -> EgovFileUtil.rm("nothing.txt"));
+            assertTrue(e.getMessage().contains("not initialized"), e.getMessage());
+            assertTrue(e.getMessage().contains("EgovFiles"), "대체 경로를 안내해야 한다: " + e.getMessage());
+            assertThrows(IllegalStateException.class, () -> EgovFileUtil.touch("nothing.txt"));
+            assertThrows(IllegalStateException.class, () -> EgovFileUtil.cp("a.txt", "b.txt"));
+            assertThrows(IllegalStateException.class, () -> EgovFileUtil.mv("a.txt", "b.txt"));
+        } finally {
+            writeStatic("manager", savedManager);
+        }
+    }
+
+    @Test
+    public void testMissingBaseDirectoryIsReportedExplicitly() throws Exception {
+        Object savedBasefile = readStatic("basefile");
+        try {
+            writeStatic("basefile", null);
+
+            IllegalStateException e = assertThrows(IllegalStateException.class, EgovFileUtil::pwd);
+            assertTrue(e.getMessage().contains("base directory"), e.getMessage());
+        } finally {
+            writeStatic("basefile", savedBasefile);
+        }
+    }
+
+    @Test
+    public void testCopyFailureIsLoggedAtWarnWithoutException() {
+        String source = tempDir.resolve("missing-source.txt").toAbsolutePath().toString();
+        String target = tempDir.resolve("copied.txt").toAbsolutePath().toString();
+
+        assertDoesNotThrow(() -> EgovFileUtil.cp(source, target), "기존 계약: 실패해도 예외를 던지지 않는다");
+
+        assertFalse(Files.exists(tempDir.resolve("copied.txt")));
+        assertTrue(appender.hasWarnContaining("EgovFileUtil.cp failed"), "실패가 WARN 으로 남아야 한다: " + appender.messages());
+    }
+
+    @Test
+    public void testMoveFailureIsLoggedAtWarnWithoutException() {
+        String source = tempDir.resolve("missing-source.txt").toAbsolutePath().toString();
+        String target = tempDir.resolve("moved.txt").toAbsolutePath().toString();
+
+        assertDoesNotThrow(() -> EgovFileUtil.mv(source, target), "기존 계약: 실패해도 예외를 던지지 않는다");
+
+        assertFalse(Files.exists(tempDir.resolve("moved.txt")));
+        assertTrue(appender.hasWarnContaining("EgovFileUtil.mv failed"), "실패가 WARN 으로 남아야 한다: " + appender.messages());
+    }
+
+    @Test
+    public void testDeprecatedApisKeepTheirBehavior() throws Exception {
+        // grep 은 패턴에 맞는 줄이 아니라 패턴으로 나눈 조각을 돌려준다(기존 동작 유지)
+        List<String> fragments = EgovFileUtil.grep(new Object[] {"a1b22c"}, "\\d{1,2}");
+        assertEquals(List.of("[a", "b", "c]"), fragments);
+
+        // ls 는 항상 빈 리스트를 돌려준다(기존 동작 유지)
+        Path dir = Files.createDirectory(tempDir.resolve("ls-dir"));
+        Files.writeString(dir.resolve("one.txt"), "1");
+        List<?> listed = new EgovFileUtil().ls(new String[] {"ls", dir.toAbsolutePath().toString()});
+        assertTrue(listed.isEmpty());
+    }
+
+    private static Object readStatic(String name) throws Exception {
+        Field field = EgovFileUtil.class.getDeclaredField(name);
+        field.setAccessible(true);
+        return field.get(null);
+    }
+
+    private static void writeStatic(String name, Object value) throws Exception {
+        Field field = EgovFileUtil.class.getDeclaredField(name);
+        field.setAccessible(true);
+        field.set(null, value);
+    }
+
+    /** 로그 이벤트를 모아 두는 테스트용 Appender. */
+    private static final class CapturingAppender extends AbstractAppender {
+
+        private final List<LogEvent> events = Collections.synchronizedList(new ArrayList<>());
+
+        private CapturingAppender() {
+            super("capturing-fileutil", null, null, true, null);
+        }
+
+        @Override
+        public void append(LogEvent event) {
+            events.add(event.toImmutable());
+        }
+
+        private boolean hasWarnContaining(String text) {
+            synchronized (events) {
+                for (LogEvent event : events) {
+                    if (event.getLevel() == Level.WARN && event.getMessage().getFormattedMessage().contains(text)) {
+                        return true;
+                    }
+                }
+            }
+            return false;
+        }
+
+        private List<String> messages() {
+            List<String> messages = new ArrayList<>();
+            synchronized (events) {
+                for (LogEvent event : events) {
+                    messages.add(event.getLevel() + " " + event.getMessage().getFormattedMessage());
+                }
+            }
+            return messages;
+        }
+    }
+}

--- a/Foundation/org.egovframe.rte.fdl.filehandling/src/test/java/org/egovframe/rte/fdl/filehandling/FilehandlingServiceTest.java
+++ b/Foundation/org.egovframe.rte.fdl.filehandling/src/test/java/org/egovframe/rte/fdl/filehandling/FilehandlingServiceTest.java
@@ -31,6 +31,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration(classes = VfsFileSystemManagerFactory.class)
+@SuppressWarnings("deprecation")
 public class FilehandlingServiceTest {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(FilehandlingServiceTest.class);


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

### 문제

`EgovFileUtil` 은 static 초기화에서 Commons VFS 매니저와 기준 디렉터리를 만드는데, **실패하면 debug 로그만 남기고
넘어갑니다.** 그 뒤의 `rm`/`cp`/`mv`/`touch`/`cd`/`pwd` 호출은 전부 `null` 필드를 참조해 `NullPointerException` 으로
끝나고, 로그 레벨이 debug 가 아니면 원인을 알 길이 없습니다.

`rm`/`cp`/`mv` 의 실패도 debug 로만 남습니다. 예외를 던지지 않는 계약이라 호출자는 반환값(`rm` 의 -1)이나 파일 상태를
직접 확인해야 하는데, 운영 로그에는 아무 흔적이 없어 "복사됐다고 믿었는데 파일이 없는" 상황을 사후에 추적할 수 없습니다.

그리고 이름과 동작이 다른 API 가 있습니다.

| API | 실제 동작 |
|---|---|
| `cd`/`pwd` | 프로세스 전역 static 기준 경로를 바꾸고 읽는다. 웹 환경에서 한 요청의 `cd` 가 다른 모든 스레드의 상대 경로 해석 기준을 바꾼다 |
| `grep` (2종) | 패턴에 맞는 줄이 아니라 **패턴을 기준으로 나눈 조각**을 돌려준다 |
| `ls` | 목록을 채우지 않고 **항상 빈 리스트**를 돌려준다(debug 로그만 남김) |

### 수정

| 항목 | 이전 | 이후 |
|---|---|---|
| VFS 초기화 실패 | debug 로그, 이후 호출은 NPE | **WARN** 로그, 이후 호출은 원인과 대체 경로를 담은 `IllegalStateException` (`manager()`/`basefile()` 가드) |
| `rm`/`cp`/`mv` 실패 | debug 로그 | **WARN** 로그(대상 경로 포함). 예외를 던지지 않는 계약과 반환값은 그대로 |
| `cd`/`pwd`/`grep`×2/`ls` | — | `@Deprecated` + javadoc 에 결함 내용과 대체 경로(`EgovFiles`) 안내. **동작은 그대로** |

기존 동작을 바꾼 것은 없습니다. 초기화가 성공한 환경(정상)에서는 로그 내용만 달라지고, 실패한 환경에서는 NPE 대신
설명이 있는 예외를 받습니다.

### 호환성

- 공개 시그니처 변경·제거 없음. deprecated 표기는 컴파일 경고만 냅니다.
- `rm` 의 -1 반환, `cp`/`mv` 의 무예외 복귀는 그대로입니다.
- 초기화 실패 환경에서 `NullPointerException` 을 잡고 있던 코드가 있다면 이제 `IllegalStateException` 을 받습니다.
  둘 다 `RuntimeException` 입니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

`EgovFileUtilInitGuardTest` **5건 신규**, `fdl.filehandling` 모듈 전건 통과.

| 환경 | 기본 로케일(Locale) | 모듈 실행 건수 | 결과 |
|---|---|---:|---|
| **Windows** | ko_KR | **127** | `Tests run: 127, Failures: 0, Errors: 0, Skipped: 2` |
| **Linux** (Ubuntu 22.04 / OpenJDK 17) | C.UTF-8 | **127** | `Tests run: 127, Failures: 0, Errors: 0, Skipped: 5` |

Skipped 는 기존 테스트의 OS 조건부 건너뛰기(플랫폼별 파일시스템 동작)이며 이 PR 과 무관합니다. 신규 5건은 두 환경 모두 실행·통과했습니다.

| 구분 | 건수 | 내용 |
|---|---:|---|
| **초기화 실패 가드** | 2 | 매니저가 없으면 `rm`/`touch`/`cp`/`mv` 가 `IllegalStateException`(메시지에 원인과 `EgovFiles` 안내) · 기준 디렉터리가 없으면 `pwd` 가 같은 예외 |
| **실패 로그** | 2 | 없는 원본을 `cp`/`mv` 하면 예외 없이 돌아오고 WARN 로그가 남는다(Log4j2 캡처) |
| 기존 동작 | 1 | deprecated `grep` 은 조각을, `ls` 는 빈 리스트를 그대로 돌려준다 |

가드 테스트는 static 필드를 리플렉션으로 비웠다가 반드시 되돌리므로 다른 테스트에 영향을 주지 않습니다.

**수동 확인**: 현재 `main`(`cc2b332`) 위에서 `fdl.filehandling` 모듈 빌드·테스트가 통과함을 Windows 와 Linux 에서 확인했습니다.

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

해당 없음 — 라이브러리 내부 수정입니다.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

해당 없음 — 위 JUnit 테스트 결과로 갈음합니다.

---

<sub>base: `eGovFramework:main` @ `cc2b332` (2026-09-10 fetch 기준, #366~#379 머지 후) · 단일 커밋</sub>
