### PR TITLE
feat: 구조화 오류 메시지 EgovErrorMessage 와 unchecked 업무 예외 EgovBizRuntimeException, 선언적 예외 헬퍼 추가

### DIFF
--- a/Foundation/org.egovframe.rte.fdl.cmmn/src/main/java/org/egovframe/rte/fdl/cmmn/EgovAbstractServiceImpl.java
+++ b/Foundation/org.egovframe.rte.fdl.cmmn/src/main/java/org/egovframe/rte/fdl/cmmn/EgovAbstractServiceImpl.java
@@ -17,6 +17,8 @@ package org.egovframe.rte.fdl.cmmn;
 
 import jakarta.annotation.Resource;
 import org.egovframe.rte.fdl.cmmn.exception.EgovBizException;
+import org.egovframe.rte.fdl.cmmn.exception.EgovBizRuntimeException;
+import org.egovframe.rte.fdl.cmmn.exception.EgovErrorMessage;
 import org.egovframe.rte.fdl.cmmn.trace.LeaveaTrace;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -32,6 +34,12 @@ import java.util.Locale;
  * 또한 EgovAbstractServiceImpl을 상속하는 클래스는 직접 Logger 생성없이
  * protected로 선언된 egovLogger를 사용할 수 있다.</p>
  *
+ * <p>업무 예외를 던질 때는 {@link #throwBizException(String)} (checked) 또는
+ * {@code throw} {@link #newBizRuntimeException(String)} (unchecked) 를 쓸 수 있다. 두 헬퍼는 메시지 키 규약
+ * ({@code key}, {@code key.reason}, {@code key.solution})으로 구조화 오류 메시지({@link EgovErrorMessage})를
+ * 해석해 예외에 담는다. {@code processException} 은 예외를 반환하므로 호출부에서 {@code throw} 를 빠뜨리면
+ * 아무 일도 일어나지 않는데, {@code throwBizException} 은 그 자리에서 던진다.</p>
+ *
  * @author Daniela Kwon
  * @version 3.0
  * <pre>
@@ -41,6 +49,7 @@ import java.util.Locale;
  * ----------------------------------------------
  * 2014.06.01	Daniela Kwon		최초생성
  *   2026-09-05  이백행          [2026년 컨트리뷰션] 서비스 로거와 추적 로케일 처리 수정
+ * 2026.09.10	실행환경 개발팀		구조화 오류 메시지를 담는 throwBizException·newBizRuntimeException 헬퍼 추가
  * </pre>
  * @since 2014.06.01
  */
@@ -163,6 +172,119 @@ public abstract class EgovAbstractServiceImpl {
      */
     protected void leaveaTrace(String msgKey, String[] msgArgs, Locale locale) {
         traceObj.trace(this.getClass(), messageSource, msgKey, msgArgs, locale, egovLogger);
+    }
+
+    /**
+     * 구조화 오류 메시지를 담은 {@link EgovBizException} 을 그 자리에서 던진다.
+     *
+     * <pre class="code">
+     * if (stock &lt; quantity) {
+     *     throwBizException("fail.biz.order.stock");
+     * }
+     * </pre>
+     *
+     * @param messageKey 메세지리소스 키. {@code key}/{@code key.reason}/{@code key.solution} 규약으로 구조화 해석
+     * @throws EgovBizException 항상 발생
+     */
+    protected void throwBizException(String messageKey) throws EgovBizException {
+        throwBizException(messageKey, null, null, LocaleContextHolder.getLocale());
+    }
+
+    /**
+     * 구조화 오류 메시지를 담은 {@link EgovBizException} 을 그 자리에서 던진다.
+     *
+     * @param messageKey  메세지리소스 키
+     * @param messageArgs 메시지 치환 인자
+     * @throws EgovBizException 항상 발생
+     */
+    protected void throwBizException(String messageKey, Object[] messageArgs) throws EgovBizException {
+        throwBizException(messageKey, messageArgs, null, LocaleContextHolder.getLocale());
+    }
+
+    /**
+     * 구조화 오류 메시지를 담은 {@link EgovBizException} 을 그 자리에서 던진다.
+     *
+     * @param messageKey 메세지리소스 키
+     * @param cause      원인 예외(cause 체인에 연결된다)
+     * @throws EgovBizException 항상 발생
+     */
+    protected void throwBizException(String messageKey, Throwable cause) throws EgovBizException {
+        throwBizException(messageKey, null, cause, LocaleContextHolder.getLocale());
+    }
+
+    /**
+     * 구조화 오류 메시지를 담은 {@link EgovBizException} 을 그 자리에서 던진다.
+     *
+     * @param messageKey  메세지리소스 키
+     * @param messageArgs 메시지 치환 인자
+     * @param cause       원인 예외(cause 체인에 연결된다)
+     * @throws EgovBizException 항상 발생
+     */
+    protected void throwBizException(String messageKey, Object[] messageArgs, Throwable cause) throws EgovBizException {
+        throwBizException(messageKey, messageArgs, cause, LocaleContextHolder.getLocale());
+    }
+
+    /**
+     * 구조화 오류 메시지를 담은 {@link EgovBizException} 을 그 자리에서 던진다.
+     *
+     * @param messageKey  메세지리소스 키
+     * @param messageArgs 메시지 치환 인자
+     * @param cause       원인 예외(cause 체인에 연결된다)
+     * @param locale      명시적 국가/언어지정
+     * @throws EgovBizException 항상 발생
+     */
+    protected void throwBizException(String messageKey, Object[] messageArgs, Throwable cause, Locale locale) throws EgovBizException {
+        throw new EgovBizException(EgovErrorMessage.resolve(messageSource, messageKey, messageArgs, locale), cause);
+    }
+
+    /**
+     * 구조화 오류 메시지를 담은 unchecked {@link EgovBizRuntimeException} 을 만든다. 반드시 {@code throw} 와 함께 쓴다.
+     *
+     * <pre class="code">
+     * throw newBizRuntimeException("fail.biz.order.stock");
+     * </pre>
+     *
+     * @param messageKey 메세지리소스 키. {@code key}/{@code key.reason}/{@code key.solution} 규약으로 구조화 해석
+     * @return 만든 unchecked 예외. 호출부에서 바로 던진다
+     */
+    protected EgovBizRuntimeException newBizRuntimeException(String messageKey) {
+        return newBizRuntimeException(messageKey, null, null);
+    }
+
+    /**
+     * 구조화 오류 메시지를 담은 unchecked {@link EgovBizRuntimeException} 을 만든다.
+     *
+     * @param messageKey  메세지리소스 키
+     * @param messageArgs 메시지 치환 인자
+     * @return 만든 unchecked 예외. 호출부에서 바로 던진다
+     */
+    protected EgovBizRuntimeException newBizRuntimeException(String messageKey, Object[] messageArgs) {
+        return newBizRuntimeException(messageKey, messageArgs, null);
+    }
+
+    /**
+     * 구조화 오류 메시지를 담은 unchecked {@link EgovBizRuntimeException} 을 만든다.
+     *
+     * @param messageKey  메세지리소스 키
+     * @param messageArgs 메시지 치환 인자
+     * @param cause       원인 예외(cause 체인에 연결된다)
+     * @return 만든 unchecked 예외. 호출부에서 바로 던진다
+     */
+    protected EgovBizRuntimeException newBizRuntimeException(String messageKey, Object[] messageArgs, Throwable cause) {
+        return newBizRuntimeException(messageKey, messageArgs, cause, LocaleContextHolder.getLocale());
+    }
+
+    /**
+     * 구조화 오류 메시지를 담은 unchecked {@link EgovBizRuntimeException} 을 만든다.
+     *
+     * @param messageKey  메세지리소스 키
+     * @param messageArgs 메시지 치환 인자
+     * @param cause       원인 예외(cause 체인에 연결된다)
+     * @param locale      명시적 국가/언어지정
+     * @return 만든 unchecked 예외. 호출부에서 바로 던진다
+     */
+    protected EgovBizRuntimeException newBizRuntimeException(String messageKey, Object[] messageArgs, Throwable cause, Locale locale) {
+        return new EgovBizRuntimeException(EgovErrorMessage.resolve(messageSource, messageKey, messageArgs, locale), cause);
     }
 
     protected interface ExceptionCreator {

--- a/Foundation/org.egovframe.rte.fdl.cmmn/src/main/java/org/egovframe/rte/fdl/cmmn/exception/EgovBizException.java
+++ b/Foundation/org.egovframe.rte.fdl.cmmn/src/main/java/org/egovframe/rte/fdl/cmmn/exception/EgovBizException.java
@@ -32,12 +32,18 @@ import java.util.Locale;
  * ----------------------------------------------
  * 2009.05.30	Judd Cho			최초 생성
  * 2015.01.31	Vincent Han			코드 품질 개선
+ * 2026.09.10	실행환경 개발팀		구조화 오류 메시지(EgovErrorMessage) 생성자와 getErrorMessage() 추가
  * </pre>
  * @since 2009.06.01
  */
 public class EgovBizException extends BaseException {
 
     private static final long serialVersionUID = 1L;
+
+    /**
+     * 구조화 오류 메시지. 구조화 생성자로 만든 경우에만 설정되며 그 외에는 null 이다.
+     */
+    private EgovErrorMessage errorMessage;
 
     /**
      * EgovBizException 생성자.
@@ -169,6 +175,28 @@ public class EgovBizException extends BaseException {
         this.messageParameters = messageParameters;
         this.message = messageSource.getMessage(messageKey, messageParameters, defaultMessage, locale);
         this.wrappedException = wrappedException;
+    }
+
+    /**
+     * 구조화 오류 메시지로 생성한다. 예외 메시지는 사용자 메시지, 메시지 키는 오류 코드가 되며
+     * 원인 예외는 cause 체인에 연결된다.
+     *
+     * @param errorMessage 구조화 오류 메시지(코드·사용자 메시지·원인·조치)
+     * @param cause        원인 예외(null 가능)
+     */
+    public EgovBizException(EgovErrorMessage errorMessage, Throwable cause) {
+        super(errorMessage.getUserMessage(), (Object[]) null, cause);
+        this.messageKey = errorMessage.getCode();
+        this.errorMessage = errorMessage;
+    }
+
+    /**
+     * 구조화 오류 메시지. 구조화 생성자로 만든 경우에만 값이 있고 그 외에는 null 이다.
+     *
+     * @return 구조화 오류 메시지 또는 null
+     */
+    public EgovErrorMessage getErrorMessage() {
+        return errorMessage;
     }
 
 }

--- a/Foundation/org.egovframe.rte.fdl.cmmn/src/main/java/org/egovframe/rte/fdl/cmmn/exception/EgovBizRuntimeException.java
+++ b/Foundation/org.egovframe.rte.fdl.cmmn/src/main/java/org/egovframe/rte/fdl/cmmn/exception/EgovBizRuntimeException.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2009-2026 MOIS(Ministry of the Interior and Safety).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.egovframe.rte.fdl.cmmn.exception;
+
+import org.springframework.context.MessageSource;
+
+import java.util.Locale;
+
+/**
+ * unchecked 업무 예외.
+ *
+ * <p>checked 인 {@link EgovBizException} 과 달리 메소드 시그니처를 바꾸지 않고 전파되는 업무 예외이다.
+ * {@link EgovErrorMessage} 로 코드·사용자 메시지·원인·조치를 구조화해 보유하며, 원인 예외는 cause 체인
+ * ({@link #getCause()})에 연결된다. 서비스 구현체에서는 {@code EgovAbstractServiceImpl#newBizRuntimeException}
+ * 헬퍼로 만드는 것을 권장한다.</p>
+ *
+ * @author 실행환경 개발팀
+ * @since 5.1
+ * @version 1.0
+ * <pre>
+ * 개정이력(Modification Information)
+ *
+ * 수정일		수정자				수정내용
+ * ----------------------------------------------
+ * 2026.09.10	실행환경 개발팀		최초 생성
+ * </pre>
+ */
+public class EgovBizRuntimeException extends BaseRuntimeException {
+
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * 구조화 오류 메시지. 단순 메시지 생성자로 만든 경우 null 이다.
+     */
+    private EgovErrorMessage errorMessage;
+
+    /**
+     * 구조화 오류 메시지로 생성한다. 예외 메시지는 사용자 메시지, 메시지 키는 오류 코드가 된다.
+     *
+     * @param errorMessage 구조화 오류 메시지
+     * @param cause        원인 예외(null 가능)
+     */
+    public EgovBizRuntimeException(EgovErrorMessage errorMessage, Throwable cause) {
+        super(errorMessage.getUserMessage(), (Object[]) null, cause);
+        this.messageKey = errorMessage.getCode();
+        this.errorMessage = errorMessage;
+    }
+
+    /**
+     * 메시지 리소스 키로 생성한다. 구조화 메시지는 키 규약({@code key}, {@code key.reason}, {@code key.solution})으로
+     * 함께 해석한다.
+     *
+     * @param messageSource 메시지 리소스
+     * @param messageKey    메시지 키
+     * @param messageArgs   메시지 치환 인자(없으면 null)
+     * @param locale        로케일(Locale)
+     * @param cause         원인 예외(null 가능)
+     */
+    public EgovBizRuntimeException(MessageSource messageSource, String messageKey, Object[] messageArgs, Locale locale, Throwable cause) {
+        this(EgovErrorMessage.resolve(messageSource, messageKey, messageArgs, locale), cause);
+        this.messageParameters = messageArgs;
+    }
+
+    /**
+     * 단순 메시지로 생성한다.
+     *
+     * @param message 메시지
+     * @param cause   원인 예외(null 가능)
+     */
+    public EgovBizRuntimeException(String message, Throwable cause) {
+        super(message, (Object[]) null, cause);
+    }
+
+    /**
+     * 구조화 오류 메시지. 단순 메시지 생성자로 만든 경우 null 이다.
+     *
+     * @return 구조화 오류 메시지 또는 null
+     */
+    public EgovErrorMessage getErrorMessage() {
+        return errorMessage;
+    }
+
+}

--- a/Foundation/org.egovframe.rte.fdl.cmmn/src/main/java/org/egovframe/rte/fdl/cmmn/exception/EgovErrorMessage.java
+++ b/Foundation/org.egovframe.rte.fdl.cmmn/src/main/java/org/egovframe/rte/fdl/cmmn/exception/EgovErrorMessage.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2009-2026 MOIS(Ministry of the Interior and Safety).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.egovframe.rte.fdl.cmmn.exception;
+
+import org.springframework.context.MessageSource;
+
+import java.io.Serializable;
+import java.util.Locale;
+
+/**
+ * 구조화 오류 메시지.
+ *
+ * <p>오류를 사용자 메시지 한 줄이 아니라 <b>코드 / 사용자 메시지 / 원인(reason) / 조치(solution)</b> 으로 나누어 담는다.
+ * 화면은 사용자 메시지를, 로그와 관제는 코드와 원인을, 안내 문구는 조치를 쓰는 식으로 같은 예외에서 각자 필요한
+ * 부분을 꺼내 쓸 수 있다.</p>
+ *
+ * <p>메시지 리소스 키 규약 — 코드가 {@code fail.biz.order} 일 때:</p>
+ * <pre>
+ * fail.biz.order          = 주문 처리에 실패했습니다.      (사용자 메시지)
+ * fail.biz.order.reason   = 재고 수량이 부족합니다.        (원인, 선택)
+ * fail.biz.order.solution = 재고 확인 후 다시 시도하세요.   (조치, 선택)
+ * </pre>
+ *
+ * @author 실행환경 개발팀
+ * @since 5.1
+ * @version 1.0
+ * <pre>
+ * 개정이력(Modification Information)
+ *
+ * 수정일		수정자				수정내용
+ * ----------------------------------------------
+ * 2026.09.10	실행환경 개발팀		최초 생성
+ * </pre>
+ */
+public final class EgovErrorMessage implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    /** 원인 메시지 키 접미사 */
+    public static final String REASON_SUFFIX = ".reason";
+
+    /** 조치 메시지 키 접미사 */
+    public static final String SOLUTION_SUFFIX = ".solution";
+
+    private final String code;
+    private final String userMessage;
+    private final String reason;
+    private final String solution;
+
+    /**
+     * @param code        오류 코드(메시지 키)
+     * @param userMessage 사용자 메시지
+     * @param reason      원인(없으면 null)
+     * @param solution    조치(없으면 null)
+     */
+    public EgovErrorMessage(String code, String userMessage, String reason, String solution) {
+        this.code = code;
+        this.userMessage = userMessage;
+        this.reason = reason;
+        this.solution = solution;
+    }
+
+    /**
+     * 메시지 리소스에서 키 규약({@code code}, {@code code.reason}, {@code code.solution})으로 구조화 메시지를 해석한다.
+     * 사용자 메시지가 정의되어 있지 않으면 코드 문자열을, 원인·조치가 없으면 null 을 담는다.
+     *
+     * @param messageSource 메시지 리소스
+     * @param code          오류 코드(메시지 키)
+     * @param args          메시지 치환 인자(없으면 null)
+     * @param locale        로케일(Locale)
+     * @return 구조화 오류 메시지
+     */
+    public static EgovErrorMessage resolve(MessageSource messageSource, String code, Object[] args, Locale locale) {
+        String userMessage = messageSource.getMessage(code, args, code, locale);
+        String reason = messageSource.getMessage(code + REASON_SUFFIX, args, null, locale);
+        String solution = messageSource.getMessage(code + SOLUTION_SUFFIX, args, null, locale);
+        return new EgovErrorMessage(code, userMessage, reason, solution);
+    }
+
+    /**
+     * @return 오류 코드(메시지 키)
+     */
+    public String getCode() {
+        return code;
+    }
+
+    /**
+     * @return 사용자 메시지
+     */
+    public String getUserMessage() {
+        return userMessage;
+    }
+
+    /**
+     * @return 원인. 정의되어 있지 않으면 null
+     */
+    public String getReason() {
+        return reason;
+    }
+
+    /**
+     * @return 조치. 정의되어 있지 않으면 null
+     */
+    public String getSolution() {
+        return solution;
+    }
+
+    /**
+     * 로그·관제용 한 줄 표현. 원인과 조치가 있으면 함께 붙인다.
+     */
+    @Override
+    public String toString() {
+        StringBuilder builder = new StringBuilder();
+        builder.append('[').append(code).append("] ").append(userMessage);
+        if (reason != null) {
+            builder.append(" | reason: ").append(reason);
+        }
+        if (solution != null) {
+            builder.append(" | solution: ").append(solution);
+        }
+        return builder.toString();
+    }
+
+}

--- a/Foundation/org.egovframe.rte.fdl.cmmn/src/test/java/org/egovframe/rte/fdl/cmmn/EgovExceptionStructureTest.java
+++ b/Foundation/org.egovframe.rte.fdl.cmmn/src/test/java/org/egovframe/rte/fdl/cmmn/EgovExceptionStructureTest.java
@@ -1,0 +1,132 @@
+package org.egovframe.rte.fdl.cmmn;
+
+import org.egovframe.rte.fdl.cmmn.exception.EgovBizException;
+import org.egovframe.rte.fdl.cmmn.exception.EgovBizRuntimeException;
+import org.egovframe.rte.fdl.cmmn.exception.EgovErrorMessage;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.i18n.LocaleContextHolder;
+import org.springframework.context.support.StaticMessageSource;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Locale;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * 구조화 오류 메시지와 선언적 예외 헬퍼를 검증한다 — reason/solution 해석, cause 체인 연결, 미정의 키의 폴백.
+ */
+public class EgovExceptionStructureTest {
+
+    /** 테스트용 업무 서비스 */
+    static class OrderService extends EgovAbstractServiceImpl {
+        void orderChecked(Throwable cause) throws EgovBizException {
+            throwBizException("fail.biz.stock", new Object[] {99}, cause);
+        }
+
+        void orderUnchecked(Throwable cause) {
+            throw newBizRuntimeException("fail.biz.stock", new Object[] {99}, cause);
+        }
+
+        void orderWithoutArgs() throws EgovBizException {
+            throwBizException("fail.biz.stock");
+        }
+    }
+
+    private StaticMessageSource messageSource;
+    private OrderService service;
+
+    @BeforeEach
+    public void setUp() {
+        messageSource = new StaticMessageSource();
+        messageSource.addMessage("fail.biz.stock", Locale.KOREAN, "재고가 부족합니다.");
+        messageSource.addMessage("fail.biz.stock.reason", Locale.KOREAN, "요청 수량 {0}이 보유 재고를 초과했습니다.");
+        messageSource.addMessage("fail.biz.stock.solution", Locale.KOREAN, "수량을 줄여 다시 시도하십시오.");
+        service = new OrderService();
+        ReflectionTestUtils.setField(service, "messageSource", messageSource);
+        LocaleContextHolder.setLocale(Locale.KOREAN);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        LocaleContextHolder.resetLocaleContext();
+    }
+
+    @Test
+    public void testThrowBizExceptionCarriesStructuredMessageAndCause() {
+        IllegalStateException cause = new IllegalStateException("stock=1");
+
+        EgovBizException ex = assertThrows(EgovBizException.class, () -> service.orderChecked(cause));
+
+        assertEquals("재고가 부족합니다.", ex.getMessage());
+        assertEquals("fail.biz.stock", ex.getMessageKey());
+        EgovErrorMessage errorMessage = ex.getErrorMessage();
+        assertEquals("fail.biz.stock", errorMessage.getCode());
+        assertEquals("요청 수량 99이 보유 재고를 초과했습니다.", errorMessage.getReason());
+        assertEquals("수량을 줄여 다시 시도하십시오.", errorMessage.getSolution());
+        assertSame(cause, ex.getCause(), "원인 예외가 cause 체인에 연결되어야 한다");
+        assertSame(cause, ex.getWrappedException());
+    }
+
+    @Test
+    public void testThrowBizExceptionWithoutArgsOrCause() {
+        EgovBizException ex = assertThrows(EgovBizException.class, () -> service.orderWithoutArgs());
+
+        assertEquals("재고가 부족합니다.", ex.getMessage());
+        assertNull(ex.getCause());
+        assertNull(ex.getWrappedException());
+        assertEquals("수량을 줄여 다시 시도하십시오.", ex.getErrorMessage().getSolution());
+    }
+
+    @Test
+    public void testNewBizRuntimeExceptionIsUncheckedWithStructure() {
+        IllegalStateException cause = new IllegalStateException("stock=1");
+
+        EgovBizRuntimeException ex = assertThrows(EgovBizRuntimeException.class, () -> service.orderUnchecked(cause));
+
+        assertEquals("재고가 부족합니다.", ex.getMessage());
+        assertEquals("fail.biz.stock", ex.getMessageKey());
+        assertEquals("요청 수량 99이 보유 재고를 초과했습니다.", ex.getErrorMessage().getReason());
+        assertSame(cause, ex.getCause());
+        assertSame(cause, ex.getWrappedException());
+    }
+
+    @Test
+    public void testStructuredConstructorAndPlainMessageConstructor() {
+        EgovErrorMessage errorMessage = new EgovErrorMessage("fail.biz.custom", "사용자 메시지", "원인", "조치");
+        IllegalArgumentException cause = new IllegalArgumentException("bad");
+
+        EgovBizException checked = new EgovBizException(errorMessage, cause);
+        assertEquals("사용자 메시지", checked.getMessage());
+        assertEquals("fail.biz.custom", checked.getMessageKey());
+        assertSame(errorMessage, checked.getErrorMessage());
+        assertSame(cause, checked.getCause());
+
+        EgovBizRuntimeException plain = new EgovBizRuntimeException("단순 메시지", cause);
+        assertEquals("단순 메시지", plain.getMessage());
+        assertNull(plain.getErrorMessage());
+        assertSame(cause, plain.getCause());
+
+        assertNull(new EgovBizException("기존 생성자").getErrorMessage(), "기존 생성자로 만들면 구조화 메시지는 없다");
+    }
+
+    @Test
+    public void testErrorMessageResolveFallbacks() {
+        EgovErrorMessage resolved = EgovErrorMessage.resolve(messageSource, "no.such.code", null, Locale.KOREAN);
+
+        assertEquals("no.such.code", resolved.getUserMessage(), "사용자 메시지가 없으면 코드로 폴백한다");
+        assertNull(resolved.getReason());
+        assertNull(resolved.getSolution());
+        assertTrue(resolved.toString().contains("no.such.code"));
+
+        EgovErrorMessage full = EgovErrorMessage.resolve(messageSource, "fail.biz.stock", new Object[] {3}, Locale.KOREAN);
+        assertTrue(full.toString().contains("reason:"), full.toString());
+        assertTrue(full.toString().contains("solution:"), full.toString());
+        assertTrue(full.toString().contains("요청 수량 3이"), full.toString());
+    }
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [ ] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [X] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

### 배경

업무 예외는 사용자 메시지 한 줄만 담습니다. 화면에는 사용자 메시지, 로그와 관제에는 코드와 원인, 안내 문구에는 조치
방법이 필요한데 이를 같은 예외에서 꺼낼 구조가 없어 각 계층이 메시지를 따로 해석합니다. checked 인 `EgovBizException` 만
있어 메소드 시그니처를 바꾸지 않고 전파되는 unchecked 업무 예외도 없습니다. 그리고 `processException` 은 예외를 **반환**하는
설계라 호출부에서 `throw` 를 빠뜨리면 아무 일도 일어나지 않고 지나갑니다.

> unchecked 업무 예외의 필요는 #279 에서도 제기됐습니다. 그 PR 은 checked 인 `EgovBizException` 을 `RuntimeException` 으로
> 캐스팅하는 방식이라 호출 시 `ClassCastException` 이 나 반려됐습니다. 이 PR 은 `BaseRuntimeException` 을 잇는 **별도의
> unchecked 타입**을 두므로 그 문제가 없으며, 테스트로 타입과 전파를 확인했습니다.

### 추가한 것

| 파일 | 내용 |
|---|---|
| **`exception/EgovErrorMessage`** (신규) | 코드·사용자 메시지·원인(reason)·조치(solution)를 담는 불변 값 객체. `resolve(messageSource, code, args, locale)` 가 키 규약(`key`, `key.reason`, `key.solution`)으로 해석하며, 사용자 메시지가 없으면 코드로, 원인·조치가 없으면 `null` 로 둔다. `toString()` 은 로그용 한 줄 |
| **`exception/EgovBizRuntimeException`** (신규) | `BaseRuntimeException` 을 잇는 unchecked 업무 예외. 구조화 메시지를 보유하고 원인 예외를 cause 체인에 연결한다 |
| `exception/EgovBizException` | 구조화 메시지로 만드는 생성자 `(EgovErrorMessage, Throwable)` 와 `getErrorMessage()` 추가. 기존 생성자와 동작은 그대로 |
| `EgovAbstractServiceImpl` | `throwBizException(...)` 5종 — 그 자리에서 던지는 checked 헬퍼. `newBizRuntimeException(...)` 4종 — `throw` 와 함께 쓰는 unchecked 헬퍼. `processException` 은 그대로 두고 javadoc 에서 헬퍼를 안내 |

```java
// 메시지 리소스
// fail.biz.stock          = 재고가 부족합니다.
// fail.biz.stock.reason   = 요청 수량 {0}이 보유 재고를 초과했습니다.
// fail.biz.stock.solution = 수량을 줄여 다시 시도하십시오.

if (stock < quantity) {
    throwBizException("fail.biz.stock", new Object[] {quantity});   // checked, 즉시 던짐
}
throw newBizRuntimeException("fail.biz.stock", new Object[] {quantity}); // unchecked
```

예외를 받은 쪽은 `getMessage()` 로 사용자 메시지를, `getErrorMessage().getReason()`/`getSolution()` 으로 원인과 조치를,
`getMessageKey()` 로 코드를 얻습니다.

### 설계 메모

- **순수 추가입니다.** 기존 클래스의 공개 시그니처를 바꾸거나 없애지 않았고, `processException` 도 deprecated 로 표기하지
  않았습니다. 새 헬퍼를 쓸지 여부는 각 사업이 정합니다.
- 원인과 조치 키는 **선택**이라, 기존 메시지 리소스를 바꾸지 않아도 헬퍼를 바로 쓸 수 있습니다.
- 헬퍼는 `EgovAbstractServiceImpl` 에 주입되는 `messageSource` 와 `LocaleContextHolder` 의 로케일(Locale)을 쓰므로
  `processException` 과 같은 해석 규칙을 따릅니다.
- `throwBizException` 은 `void` 이면서 항상 던집니다. 컴파일러는 이를 모르므로 값을 돌려주는 메소드 안에서는
  `throw newBizRuntimeException(...)` 형태가 더 자연스럽습니다(javadoc 에 예시).

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

`EgovExceptionStructureTest` **5건 신규**, `fdl.cmmn` 모듈 전건 통과.

| 환경 | 기본 로케일 | 모듈 실행 건수 | 결과 |
|---|---|---:|---|
| **Windows** | ko_KR | **49** | `Tests run: 49, Failures: 0, Errors: 0, Skipped: 0` |
| **Linux** (Ubuntu 22.04 / OpenJDK 17) | C.UTF-8 | **49** | `Tests run: 49, Failures: 0, Errors: 0, Skipped: 0` |

| 구분 | 건수 | 내용 |
|---|---:|---|
| 헬퍼 | 3 | `throwBizException` 이 사용자 메시지·코드·원인·조치를 담고 cause 체인과 `getWrappedException()` 을 연결한다 · 인자·원인 없이도 동작 · `newBizRuntimeException` 의 unchecked 구조 |
| 생성자 | 1 | 구조화 생성자와 단순 메시지 생성자, 기존 생성자에서는 구조화 메시지가 `null` |
| 해석 규칙 | 1 | 미정의 키는 코드로 폴백하고 원인·조치는 `null`, 정의된 키는 치환 인자까지 반영한 한 줄 표현 |

**수동 확인**: 현재 `main`(`cc2b332`) 위에서 `fdl.cmmn` 모듈 빌드·테스트가 통과함을 Windows 와 Linux 에서 확인했습니다.

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

해당 없음 — 라이브러리 클래스 추가입니다.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

해당 없음 — 위 JUnit 테스트 결과로 갈음합니다.

---

<sub>base: `eGovFramework:main` @ `cc2b332` (2026-09-10 fetch 기준, #366~#379 머지 후) · 단일 커밋</sub>
