### PR TITLE
feat: DB 테이블의 메시지를 제공하는 EgovDbMessageSource 추가

### DIFF
--- a/Foundation/org.egovframe.rte.fdl.cmmn/src/main/java/org/egovframe/rte/fdl/cmmn/message/EgovDbMessageSource.java
+++ b/Foundation/org.egovframe.rte.fdl.cmmn/src/main/java/org/egovframe/rte/fdl/cmmn/message/EgovDbMessageSource.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2009-2026 MOIS(Ministry of the Interior and Safety).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.egovframe.rte.fdl.cmmn.message;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.context.support.AbstractMessageSource;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.util.Assert;
+
+import javax.sql.DataSource;
+import java.text.MessageFormat;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * DB 테이블의 메시지를 제공하는 MessageSource.
+ *
+ * <p>초기화 시점에 테이블을 한 번 읽어 불변 스냅숏으로 보관하고, 운영 중 문구가 바뀌면 {@link #refresh()} 로
+ * 재기동 없이 다시 읽는다. 조회는 스냅숏에서만 하므로 잠금 없이 스레드 안전하다.
+ * 부모 MessageSource({@code setParentMessageSource})와 조합하면 <b>DB 우선, 파일 폴백</b>의 메시지 체계가 된다.</p>
+ *
+ * <p>기본 조회 쿼리와 테이블 규약은 아래와 같으며 {@code query} 속성으로 바꿀 수 있다. 결과 컬럼 순서는
+ * (코드, 언어, 메시지)를 따른다. LANG 은 언어 코드("ko", "en")이며 빈 값이나 NULL 이면 모든 로케일(Locale)의
+ * 기본값으로 쓴다.</p>
+ * <pre class="code">
+ * CREATE TABLE EGOV_MESSAGE_SOURCE (
+ *     CODE    VARCHAR(100) NOT NULL,
+ *     LANG    VARCHAR(10),
+ *     MESSAGE VARCHAR(2000) NOT NULL
+ * );
+ * </pre>
+ *
+ * <pre class="code">
+ * &lt;bean id="messageSource" class="org.egovframe.rte.fdl.cmmn.message.EgovDbMessageSource"&gt;
+ *     &lt;property name="dataSource" ref="dataSource"/&gt;
+ *     &lt;property name="parentMessageSource" ref="fileMessageSource"/&gt;  &lt;!-- DB 에 없으면 파일로 폴백 --&gt;
+ * &lt;/bean&gt;
+ * </pre>
+ *
+ * @author 실행환경 개발팀
+ * @since 5.1
+ * @version 1.0
+ * <pre>
+ * 개정이력(Modification Information)
+ *
+ * 수정일		수정자				수정내용
+ * ----------------------------------------------
+ * 2026.09.10	실행환경 개발팀		최초 생성
+ * </pre>
+ */
+public class EgovDbMessageSource extends AbstractMessageSource implements InitializingBean {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(EgovDbMessageSource.class);
+
+    /** 언어 미지정(기본) 메시지의 내부 키 */
+    private static final String DEFAULT_LANG = "";
+
+    private DataSource dataSource;
+
+    private String query = "SELECT CODE, LANG, MESSAGE FROM EGOV_MESSAGE_SOURCE";
+
+    private JdbcTemplate jdbcTemplate;
+
+    /** 언어 → (코드 → 메시지). refresh 시 전체를 불변 스냅숏으로 교체한다. */
+    private volatile Map<String, Map<String, String>> messages = Collections.emptyMap();
+
+    /**
+     * 메시지 테이블을 읽을 DataSource
+     *
+     * @param dataSource DataSource
+     */
+    public void setDataSource(DataSource dataSource) {
+        this.dataSource = dataSource;
+    }
+
+    /**
+     * 메시지 조회 쿼리. 결과 컬럼 순서는 (코드, 언어, 메시지) 규약을 따른다.
+     *
+     * @param query 조회 쿼리
+     */
+    public void setQuery(String query) {
+        this.query = query;
+    }
+
+    @Override
+    public void afterPropertiesSet() {
+        Assert.notNull(dataSource, "Property 'dataSource' is required");
+        Assert.hasText(query, "Property 'query' is required");
+        this.jdbcTemplate = new JdbcTemplate(dataSource);
+        refresh();
+    }
+
+    /**
+     * DB 에서 메시지를 다시 읽는다. 운영 중 문구 변경을 재기동 없이 반영할 때 호출한다.
+     * 읽기가 끝나면 스냅숏을 통째로 교체하므로 읽는 도중에도 이전 스냅숏으로 조회가 계속된다.
+     */
+    public void refresh() {
+        Assert.state(jdbcTemplate != null, "EgovDbMessageSource is not initialized - call afterPropertiesSet() first");
+        Map<String, Map<String, String>> loaded = new HashMap<>();
+        jdbcTemplate.query(query, resultSet -> {
+            String code = resultSet.getString(1);
+            String lang = resultSet.getString(2);
+            String message = resultSet.getString(3);
+            String langKey = (lang == null || lang.trim().isEmpty()) ? DEFAULT_LANG : lang.trim().toLowerCase(Locale.ROOT);
+            loaded.computeIfAbsent(langKey, key -> new HashMap<>()).put(code, message);
+        });
+        this.messages = Collections.unmodifiableMap(loaded);
+        LOGGER.info("EgovDbMessageSource refreshed: {} language group(s), {} message(s)",
+                loaded.size(), loaded.values().stream().mapToInt(Map::size).sum());
+    }
+
+    @Override
+    protected MessageFormat resolveCode(String code, Locale locale) {
+        String message = lookup(code, locale);
+        return (message == null) ? null : createMessageFormat(message, locale);
+    }
+
+    @Override
+    protected String resolveCodeWithoutArguments(String code, Locale locale) {
+        return lookup(code, locale);
+    }
+
+    private String lookup(String code, Locale locale) {
+        Map<String, Map<String, String>> snapshot = messages;
+        Map<String, String> byLanguage = snapshot.get(locale.getLanguage().toLowerCase(Locale.ROOT));
+        if (byLanguage != null) {
+            String message = byLanguage.get(code);
+            if (message != null) {
+                return message;
+            }
+        }
+        Map<String, String> defaults = snapshot.get(DEFAULT_LANG);
+        return (defaults == null) ? null : defaults.get(code);
+    }
+
+}

--- a/Foundation/org.egovframe.rte.fdl.cmmn/src/test/java/org/egovframe/rte/fdl/cmmn/message/EgovDbMessageSourceTest.java
+++ b/Foundation/org.egovframe.rte.fdl.cmmn/src/test/java/org/egovframe/rte/fdl/cmmn/message/EgovDbMessageSourceTest.java
@@ -1,0 +1,124 @@
+package org.egovframe.rte.fdl.cmmn.message;
+
+import org.hsqldb.jdbc.JDBCDataSource;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.support.StaticMessageSource;
+
+import java.sql.Connection;
+import java.sql.Statement;
+import java.util.Locale;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * DB 기반 MessageSource 를 HSQLDB 인메모리 테이블로 검증한다.
+ */
+public class EgovDbMessageSourceTest {
+
+    private static JDBCDataSource dataSource;
+
+    @BeforeAll
+    public static void setUpDatabase() throws Exception {
+        dataSource = new JDBCDataSource();
+        dataSource.setUrl("jdbc:hsqldb:mem:egovmsg");
+        dataSource.setUser("sa");
+        dataSource.setPassword("");
+        try (Connection connection = dataSource.getConnection();
+             Statement statement = connection.createStatement()) {
+            statement.execute("DROP TABLE EGOV_MESSAGE_SOURCE IF EXISTS");
+            statement.execute("CREATE TABLE EGOV_MESSAGE_SOURCE (CODE VARCHAR(100) NOT NULL, LANG VARCHAR(10), MESSAGE VARCHAR(2000) NOT NULL)");
+            statement.execute("INSERT INTO EGOV_MESSAGE_SOURCE VALUES ('greeting', 'ko', '안녕하세요 {0}')");
+            statement.execute("INSERT INTO EGOV_MESSAGE_SOURCE VALUES ('greeting', 'en', 'Hello {0}')");
+            statement.execute("INSERT INTO EGOV_MESSAGE_SOURCE VALUES ('only.default', NULL, '기본 메시지')");
+            statement.execute("INSERT INTO EGOV_MESSAGE_SOURCE VALUES ('blank.lang', '', '빈 언어도 기본값')");
+            statement.execute("DROP TABLE CUSTOM_MSG IF EXISTS");
+            statement.execute("CREATE TABLE CUSTOM_MSG (MSG_CD VARCHAR(100), LOCALE_CD VARCHAR(10), MSG_TXT VARCHAR(2000))");
+            statement.execute("INSERT INTO CUSTOM_MSG VALUES ('custom.code', 'ko', '사용자 쿼리 메시지')");
+        }
+    }
+
+    private EgovDbMessageSource newMessageSource() {
+        EgovDbMessageSource messageSource = new EgovDbMessageSource();
+        messageSource.setDataSource(dataSource);
+        messageSource.afterPropertiesSet();
+        return messageSource;
+    }
+
+    @Test
+    public void testResolvesMessagePerLanguageWithArguments() {
+        EgovDbMessageSource messageSource = newMessageSource();
+
+        assertEquals("안녕하세요 eGov", messageSource.getMessage("greeting", new Object[] {"eGov"}, null, Locale.KOREAN));
+        assertEquals("Hello eGov", messageSource.getMessage("greeting", new Object[] {"eGov"}, null, Locale.ENGLISH));
+        assertEquals("안녕하세요 eGov", messageSource.getMessage("greeting", new Object[] {"eGov"}, null, Locale.KOREA),
+                "국가가 붙은 로케일도 언어 코드로 조회한다");
+    }
+
+    @Test
+    public void testFallsBackToDefaultLanguageRow() {
+        EgovDbMessageSource messageSource = newMessageSource();
+
+        assertEquals("기본 메시지", messageSource.getMessage("only.default", null, null, Locale.FRENCH));
+        assertEquals("빈 언어도 기본값", messageSource.getMessage("blank.lang", null, null, Locale.JAPANESE));
+    }
+
+    @Test
+    public void testAggregatesWithParentMessageSource() {
+        StaticMessageSource parent = new StaticMessageSource();
+        parent.addMessage("parent.only", Locale.KOREAN, "파일 메시지");
+        EgovDbMessageSource messageSource = newMessageSource();
+        messageSource.setParentMessageSource(parent);
+
+        assertEquals("파일 메시지", messageSource.getMessage("parent.only", null, null, Locale.KOREAN),
+                "DB 에 없는 코드는 부모 MessageSource 로 폴백한다");
+        assertEquals("안녕하세요 eGov", messageSource.getMessage("greeting", new Object[] {"eGov"}, null, Locale.KOREAN),
+                "DB 에 있는 코드는 DB 값이 우선한다");
+        assertNull(messageSource.getMessage("no.such.code", null, null, Locale.KOREAN));
+    }
+
+    @Test
+    public void testRefreshReloadsMessagesWithoutRestart() throws Exception {
+        EgovDbMessageSource messageSource = newMessageSource();
+        assertNull(messageSource.getMessage("added.later", null, null, Locale.KOREAN));
+
+        try (Connection connection = dataSource.getConnection();
+             Statement statement = connection.createStatement()) {
+            statement.execute("INSERT INTO EGOV_MESSAGE_SOURCE VALUES ('added.later', 'ko', '나중에 추가된 메시지')");
+        }
+        assertNull(messageSource.getMessage("added.later", null, null, Locale.KOREAN), "refresh 전에는 반영되지 않는다");
+
+        messageSource.refresh();
+        assertEquals("나중에 추가된 메시지", messageSource.getMessage("added.later", null, null, Locale.KOREAN));
+
+        try (Connection connection = dataSource.getConnection();
+             Statement statement = connection.createStatement()) {
+            statement.execute("DELETE FROM EGOV_MESSAGE_SOURCE WHERE CODE = 'added.later'");
+        }
+        messageSource.refresh();
+        assertNull(messageSource.getMessage("added.later", null, null, Locale.KOREAN));
+    }
+
+    @Test
+    public void testCustomQueryFollowsColumnOrderContract() {
+        EgovDbMessageSource messageSource = new EgovDbMessageSource();
+        messageSource.setDataSource(dataSource);
+        messageSource.setQuery("SELECT MSG_CD, LOCALE_CD, MSG_TXT FROM CUSTOM_MSG");
+        messageSource.afterPropertiesSet();
+
+        assertEquals("사용자 쿼리 메시지", messageSource.getMessage("custom.code", null, null, Locale.KOREAN));
+        assertNull(messageSource.getMessage("greeting", null, null, Locale.KOREAN), "다른 테이블은 읽지 않는다");
+    }
+
+    @Test
+    public void testMissingDataSourceIsReportedClearly() {
+        EgovDbMessageSource messageSource = new EgovDbMessageSource();
+
+        IllegalArgumentException e = assertThrows(IllegalArgumentException.class, messageSource::afterPropertiesSet);
+        assertTrue(e.getMessage().contains("dataSource"), e.getMessage());
+        assertThrows(IllegalStateException.class, messageSource::refresh, "초기화 전 refresh 는 명확한 예외여야 한다");
+    }
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [ ] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [X] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

### 배경

메시지 리소스는 properties 파일에만 둘 수 있어, 운영 중 안내 문구 하나를 바꾸려면 배포와 재기동이 필요합니다.
그래서 사업마다 메시지를 DB 로 관리하려고 `MessageSource` 를 직접 구현하는 일이 반복됩니다.

### 추가한 것

**`message/EgovDbMessageSource`** — `AbstractMessageSource` 를 잇는 DB 기반 MessageSource

- 초기화 시점에 테이블을 한 번 읽어 **불변 스냅숏**으로 보관합니다. 조회는 스냅숏에서만 하므로 잠금 없이 스레드 안전합니다.
- `refresh()` 로 **재기동 없이** 다시 읽습니다. 읽기가 끝나면 스냅숏을 통째로 교체하므로 읽는 도중에도 이전 값으로 조회가 계속됩니다.
- 테이블 규약은 `CODE`·`LANG`·`MESSAGE` 세 컬럼이며 `query` 속성으로 바꿀 수 있습니다(결과 컬럼 순서만 지키면 됩니다).
  `LANG` 이 비어 있거나 `NULL` 인 행은 모든 로케일(Locale)의 기본값입니다.
- 부모 MessageSource(`setParentMessageSource`)와 조합하면 **DB 우선, 파일 폴백**의 메시지 체계가 됩니다.

```xml
<bean id="messageSource" class="org.egovframe.rte.fdl.cmmn.message.EgovDbMessageSource">
    <property name="dataSource" ref="dataSource"/>
    <property name="parentMessageSource" ref="fileMessageSource"/>  <!-- DB 에 없으면 파일로 폴백 -->
</bean>
```

```sql
CREATE TABLE EGOV_MESSAGE_SOURCE (
    CODE    VARCHAR(100) NOT NULL,
    LANG    VARCHAR(10),
    MESSAGE VARCHAR(2000) NOT NULL
);
```

### 설계 메모

- **기존 클래스는 수정하지 않았습니다.** 신규 파일만 추가하며, `spring-jdbc` 는 fdl.cmmn 이 이미 컴파일 의존으로 갖고 있습니다.
- `dataSource` 나 `query` 가 없으면 초기화 시점에 `IllegalArgumentException` 으로 알립니다. 초기화 전 `refresh()` 는
  `IllegalStateException` 입니다.
- 언어는 로케일의 언어 코드(`ko`, `en`)로만 구분합니다. 국가별 분기가 필요하면 `query` 를 바꿔 다른 규약의 테이블을 쓸 수 있습니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

`EgovDbMessageSourceTest` **6건 신규**(HSQLDB 인메모리), `fdl.cmmn` 모듈 전건 통과.

| 환경 | 기본 로케일 | 모듈 실행 건수 | 결과 |
|---|---|---:|---|
| **Windows** | ko_KR | **50** | `Tests run: 50, Failures: 0, Errors: 0, Skipped: 0` |
| **Linux** (Ubuntu 22.04 / OpenJDK 17) | C.UTF-8 | **50** | `Tests run: 50, Failures: 0, Errors: 0, Skipped: 0` |

| 구분 | 건수 | 내용 |
|---|---:|---|
| 조회 | 2 | 언어별 메시지와 치환 인자, 국가가 붙은 로케일도 언어 코드로 조회 · `NULL`/빈 `LANG` 행이 다른 로케일의 기본값 |
| 집계 | 1 | 부모 MessageSource 와 조합 — DB 우선, 없으면 파일, 둘 다 없으면 `null` |
| 재적재 | 1 | 행 추가·삭제가 `refresh()` 전에는 보이지 않고 후에는 반영된다 |
| 규약 | 2 | 사용자 쿼리가 컬럼 순서 규약대로 동작 · DataSource 미설정과 초기화 전 `refresh()` 의 명확한 예외 |

**수동 확인**: 현재 `main`(`cc2b332`) 위에서 `fdl.cmmn` 모듈 빌드·테스트가 통과함을 Windows 와 Linux 에서 확인했습니다.

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

해당 없음 — 라이브러리 클래스 추가입니다.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

해당 없음 — 위 JUnit 테스트 결과로 갈음합니다.

---

<sub>base: `eGovFramework:main` @ `cc2b332` (2026-09-10 fetch 기준, #366~#379 머지 후) · 단일 커밋</sub>
