### PR TITLE
feat: EgovPropertyService 를 Spring Environment 에 편입하는 EgovServicePropertySource 추가

### DIFF
--- a/Foundation/org.egovframe.rte.fdl.property/src/main/java/org/egovframe/rte/fdl/property/EgovServicePropertySource.java
+++ b/Foundation/org.egovframe.rte.fdl.property/src/main/java/org/egovframe/rte/fdl/property/EgovServicePropertySource.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2009-2026 MOIS(Ministry of the Interior and Safety).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.egovframe.rte.fdl.property;
+
+import org.springframework.core.env.EnumerablePropertySource;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+/**
+ * {@link EgovPropertyService} 의 프로퍼티를 Spring {@code Environment} 에 편입하는 PropertySource.
+ *
+ * <p>{@code EgovPropertyService} 로 읽는 값은 Spring {@code Environment} 와 연결되어 있지 않아 {@code @Value} 나
+ * 플레이스홀더에서 보이지 않는다. 이 클래스를 {@code Environment} 의 PropertySources 에 등록하면 같은 값을
+ * {@code @Value("${...}")} 와 {@code resolvePlaceholders} 에서 쓸 수 있다.</p>
+ *
+ * <pre>{@code
+ * // ApplicationContextInitializer 나 초기화 코드에서
+ * ConfigurableEnvironment env = context.getEnvironment();
+ * env.getPropertySources().addLast(new EgovServicePropertySource("egovPropertyService", egovPropertyService));
+ * // 이후 @Value("${Globals.DbType}") 로 EgovPropertyService 값을 쓸 수 있다
+ * }</pre>
+ *
+ * <p>조회는 같은 서비스 인스턴스에 위임하므로 {@code EgovPropertyServiceImpl.refreshPropertyFiles()} 로 다시 읽은 값이
+ * 그대로 보인다. 단, {@code @Value} 로 주입된 필드는 주입 시점의 값이 고정되며 갱신 반영은 {@code Environment} 를
+ * 직접 조회할 때 기준이다.</p>
+ *
+ * @author 실행환경 개발팀
+ * @since 5.1
+ * @version 1.0
+ * <pre>
+ * 개정이력(Modification Information)
+ *
+ * 수정일		수정자				수정내용
+ * ----------------------------------------------
+ * 2026.09.10	실행환경 개발팀		최초 생성
+ * </pre>
+ */
+public class EgovServicePropertySource extends EnumerablePropertySource<EgovPropertyService> {
+
+    /**
+     * @param name   PropertySource 이름
+     * @param source 값을 제공할 EgovPropertyService
+     */
+    public EgovServicePropertySource(String name, EgovPropertyService source) {
+        super(name, source);
+    }
+
+    /**
+     * 없는 키는 예외 대신 null 을 돌려줘 다음 PropertySource 로 넘어가게 한다(PropertySource 계약).
+     */
+    @Override
+    public Object getProperty(String name) {
+        return getSource().getString(name, null);
+    }
+
+    @Override
+    public String[] getPropertyNames() {
+        List<String> names = new ArrayList<>();
+        Iterator<?> keys = getSource().getKeys();
+        if (keys != null) {
+            while (keys.hasNext()) {
+                Object key = keys.next();
+                if (key != null) {
+                    names.add(String.valueOf(key));
+                }
+            }
+        }
+        return names.toArray(new String[0]);
+    }
+
+}

--- a/Foundation/org.egovframe.rte.fdl.property/src/test/java/org/egovframe/rte/fdl/property/EgovServicePropertySourceTest.java
+++ b/Foundation/org.egovframe.rte.fdl.property/src/test/java/org/egovframe/rte/fdl/property/EgovServicePropertySourceTest.java
@@ -1,0 +1,75 @@
+package org.egovframe.rte.fdl.property;
+
+import org.egovframe.rte.fdl.property.impl.EgovPropertyServiceImpl;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.env.StandardEnvironment;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * EgovPropertyService 값이 Spring Environment 에서 보이는지 검증한다.
+ */
+public class EgovServicePropertySourceTest {
+
+    private EgovPropertyServiceImpl propertyService;
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        propertyService = new EgovPropertyServiceImpl();
+        Map<String, String> props = new LinkedHashMap<>();
+        props.put("Globals.DbType", "hsql");
+        props.put("Globals.MainPage", "/index.do");
+        props.put("Globals.PageSize", "20");
+        propertyService.setProperties(props);
+        propertyService.afterPropertiesSet();
+    }
+
+    @Test
+    public void testReadsServiceValuesAndReturnsNullForMissingKey() {
+        EgovServicePropertySource source = new EgovServicePropertySource("egovProps", propertyService);
+
+        assertEquals("hsql", source.getProperty("Globals.DbType"));
+        assertNull(source.getProperty("no.such.key"), "없는 키는 예외 대신 null 이어야 다음 PropertySource 로 넘어간다");
+        List<String> names = List.of(source.getPropertyNames());
+        assertTrue(names.contains("Globals.DbType") && names.contains("Globals.MainPage") && names.contains("Globals.PageSize"), names.toString());
+    }
+
+    @Test
+    public void testEnvironmentResolvesPlaceholdersFromService() {
+        StandardEnvironment environment = new StandardEnvironment();
+        environment.getPropertySources().addLast(new EgovServicePropertySource("egovProps", propertyService));
+
+        assertEquals("hsql", environment.getProperty("Globals.DbType"));
+        assertEquals("main=/index.do", environment.resolvePlaceholders("main=${Globals.MainPage}"));
+        assertEquals("fallback", environment.resolvePlaceholders("${no.such.key:fallback}"), "없는 키는 기본값 구문으로 넘어간다");
+    }
+
+    @Test
+    public void testEnvironmentConvertsTypes() {
+        StandardEnvironment environment = new StandardEnvironment();
+        environment.getPropertySources().addLast(new EgovServicePropertySource("egovProps", propertyService));
+
+        assertEquals(Integer.valueOf(20), environment.getProperty("Globals.PageSize", Integer.class));
+    }
+
+    @Test
+    public void testRefreshedValuesAreVisibleThroughSameSource() throws Exception {
+        StandardEnvironment environment = new StandardEnvironment();
+        environment.getPropertySources().addLast(new EgovServicePropertySource("egovProps", propertyService));
+
+        Map<String, String> updated = new LinkedHashMap<>();
+        updated.put("Globals.DbType", "oracle");
+        propertyService.setProperties(updated);
+        propertyService.refreshPropertyFiles();
+
+        assertEquals("oracle", environment.getProperty("Globals.DbType"), "다시 읽은 값이 재기동 없이 보여야 한다");
+        assertNull(environment.getProperty("Globals.MainPage"), "다시 읽으면서 사라진 키는 보이지 않는다");
+    }
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [ ] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [X] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

### 배경

`EgovPropertyService` 로 읽는 프로퍼티는 Spring `Environment` 와 연결되어 있지 않습니다. 그래서 같은 값을 `@Value` 나
플레이스홀더에서 쓰려면 properties 를 두 곳에 두거나, 서비스를 주입받아 `getString()` 을 직접 호출해야 합니다.
DB 프로퍼티(`DbPropertySourceDelegate`)는 `Environment` 에 편입되는데 파일 기반 서비스 값만 빠져 있는 셈입니다.

### 추가한 것

**`EgovServicePropertySource`** — `EnumerablePropertySource<EgovPropertyService>` 구현

- 조회는 `EgovPropertyService.getString(name, null)` 로 위임합니다. 없는 키는 예외 대신 `null` 을 돌려줘 다음
  PropertySource 로 넘어가게 합니다(PropertySource 계약).
- 키 목록은 `getKeys()` 로 만들어 열거형 PropertySource 로 동작합니다.
- `Environment` 의 PropertySources 에 등록하면 `@Value("${Globals.DbType}")` 와 `resolvePlaceholders` 에서 서비스 값을
  쓸 수 있고, `Environment` 의 타입 변환(`getProperty(name, Integer.class)`)도 그대로 적용됩니다.

```java
ConfigurableEnvironment env = context.getEnvironment();
env.getPropertySources().addLast(new EgovServicePropertySource("egovPropertyService", egovPropertyService));
```

### 설계 메모

- **기존 클래스는 수정하지 않았습니다.** 신규 파일만 추가하며 외부 의존도 없습니다.
- 같은 서비스 인스턴스를 위임 조회하므로 `refreshPropertyFiles()` 로 다시 읽은 값이 재기동 없이 보입니다. 단 `@Value` 로
  주입된 필드는 주입 시점 값이 고정되며, 갱신 반영은 `Environment` 를 직접 조회할 때 기준입니다(javadoc 에 명시).
- 등록 위치(`addLast`/`addFirst`)는 사업이 정합니다. 시스템 프로퍼티나 다른 소스와 키가 겹칠 때의 우선순위를 그 순서로 조정할 수 있습니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

`EgovServicePropertySourceTest` **4건 신규**, `fdl.property` 모듈 전건 통과.

| 환경 | 기본 로케일(Locale) | 모듈 실행 건수 | 결과 |
|---|---|---:|---|
| **Windows** | ko_KR | **18** | `Tests run: 18, Failures: 0, Errors: 0, Skipped: 0` |
| **Linux** (Ubuntu 22.04 / OpenJDK 17) | C.UTF-8 | **18** | `Tests run: 18, Failures: 0, Errors: 0, Skipped: 0` |

| 구분 | 건수 | 내용 |
|---|---:|---|
| PropertySource 계약 | 1 | 서비스 값 조회, 없는 키는 `null`, 키 목록 열거 |
| Environment 편입 | 2 | `getProperty`·`resolvePlaceholders` 해석과 기본값 구문 · `Integer` 타입 변환 |
| 갱신 반영 | 1 | `refreshPropertyFiles()` 뒤 바뀐 값이 보이고 사라진 키는 보이지 않는다 |

**수동 확인**: 현재 `main`(`cc2b332`) 위에서 `fdl.property` 모듈 빌드·테스트가 통과함을 Windows 와 Linux 에서 확인했습니다.

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

해당 없음 — 라이브러리 클래스 추가입니다.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

해당 없음 — 위 JUnit 테스트 결과로 갈음합니다.

---

<sub>base: `eGovFramework:main` @ `cc2b332` (2026-09-10 fetch 기준, #366~#379 머지 후) · 단일 커밋</sub>
