### PR TITLE
feat: UUID 버전 7(RFC 9562) 채번 서비스 EgovUuidV7GnrServiceImpl 추가

### DIFF
--- a/Foundation/org.egovframe.rte.fdl.idgnr/src/main/java/org/egovframe/rte/fdl/idgnr/impl/EgovUuidV7GnrServiceImpl.java
+++ b/Foundation/org.egovframe.rte.fdl.idgnr/src/main/java/org/egovframe/rte/fdl/idgnr/impl/EgovUuidV7GnrServiceImpl.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2009-2026 MOIS(Ministry of the Interior and Safety).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.egovframe.rte.fdl.idgnr.impl;
+
+import org.egovframe.rte.fdl.cmmn.exception.FdlException;
+import org.egovframe.rte.fdl.idgnr.EgovIdGnrService;
+import org.egovframe.rte.fdl.idgnr.EgovIdGnrStrategy;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.security.SecureRandom;
+import java.util.UUID;
+
+/**
+ * UUID 버전 7(RFC 9562) 채번 서비스.
+ *
+ * <p>UUIDv7 은 <b>선두 48비트 Unix 밀리초 타임스탬프 + 랜덤 74비트</b> 구조다. 시간 기반 v1 방식의
+ * {@link EgovUUIdGnrServiceImpl} 이나 무작위 v4 와 달리</p>
+ * <ul>
+ *   <li><b>시간순 정렬성</b> — 문자열·바이트 정렬이 생성 시각 순서와 일치해 DB 인덱스 지역성이 좋다. PK 채번에 적합하다</li>
+ *   <li><b>다중 인스턴스 안전</b> — 랜덤부가 {@link SecureRandom} 이라 서버 간 조정이나 address 설정 없이 쓸 수 있다</li>
+ *   <li><b>설정 불필요</b> — 네트워크 정보나 messageSource 빈에 의존하지 않는다</li>
+ * </ul>
+ *
+ * <p>같은 밀리초 안에서 만든 값 사이의 순서는 보장하지 않는다. 지원 타입은 {@link #getNextStringId()}(표준 36자 표기)와
+ * {@link #getNextBigDecimalId()}(128비트 값)이며, 축소 숫자 타입과 정책 기반 문자열은 기존 UUID 구현과 같이
+ * {@link FdlException} 으로 알린다.</p>
+ *
+ * <pre class="code">
+ * &lt;bean id="uuidV7GnrService" class="org.egovframe.rte.fdl.idgnr.impl.EgovUuidV7GnrServiceImpl"/&gt;
+ * </pre>
+ *
+ * @author 실행환경 개발팀
+ * @since 5.1
+ * @version 1.0
+ * <pre>
+ * 개정이력(Modification Information)
+ *
+ * 수정일		수정자				수정내용
+ * ----------------------------------------------
+ * 2026.09.10	실행환경 개발팀		최초 생성
+ * </pre>
+ */
+public class EgovUuidV7GnrServiceImpl implements EgovIdGnrService {
+
+    private static final SecureRandom RANDOM = new SecureRandom();
+
+    private static final String UNSUPPORTED = " type id is not supported by UUID v7 generation service";
+
+    /**
+     * RFC 9562 UUIDv7 을 만든다 — unix_ts_ms(48) | ver(4)=7 | rand_a(12) | var(2)=10 | rand_b(62).
+     *
+     * @return UUIDv7
+     */
+    public static UUID generate() {
+        long timestamp = System.currentTimeMillis();
+        byte[] random = new byte[10];
+        RANDOM.nextBytes(random);
+
+        long mostSigBits = (timestamp & 0xFFFFFFFFFFFFL) << 16;           // 48비트 Unix 밀리초
+        mostSigBits |= 0x7000L;                                            // 버전 7
+        mostSigBits |= ((random[0] & 0x0FL) << 8) | (random[1] & 0xFFL);   // rand_a 12비트
+
+        long leastSigBits = 0L;
+        for (int i = 2; i < 10; i++) {
+            leastSigBits |= (random[i] & 0xFFL) << (8 * (9 - i));          // rand_b 64비트
+        }
+        leastSigBits = (leastSigBits & 0x3FFFFFFFFFFFFFFFL) | 0x8000000000000000L; // variant 10xx
+
+        return new UUID(mostSigBits, leastSigBits);
+    }
+
+    /**
+     * UUIDv7 문자열(36자, 표준 표기). 생성 시각 순서로 정렬된다.
+     */
+    @Override
+    public String getNextStringId() throws FdlException {
+        return generate().toString();
+    }
+
+    /**
+     * UUIDv7 의 128비트 값을 BigDecimal 로 돌려준다.
+     */
+    @Override
+    public BigDecimal getNextBigDecimalId() throws FdlException {
+        UUID uuid = generate();
+        BigInteger high = BigInteger.valueOf(uuid.getMostSignificantBits()).and(UNSIGNED_LONG_MASK);
+        BigInteger low = BigInteger.valueOf(uuid.getLeastSignificantBits()).and(UNSIGNED_LONG_MASK);
+        return new BigDecimal(high.shiftLeft(64).or(low));
+    }
+
+    private static final BigInteger UNSIGNED_LONG_MASK = BigInteger.ONE.shiftLeft(64).subtract(BigInteger.ONE);
+
+    @Override
+    public byte getNextByteId() throws FdlException {
+        throw new FdlException("Byte" + UNSUPPORTED);
+    }
+
+    @Override
+    public short getNextShortId() throws FdlException {
+        throw new FdlException("Short" + UNSUPPORTED);
+    }
+
+    @Override
+    public int getNextIntegerId() throws FdlException {
+        throw new FdlException("Integer" + UNSUPPORTED);
+    }
+
+    @Override
+    public long getNextLongId() throws FdlException {
+        throw new FdlException("Long" + UNSUPPORTED);
+    }
+
+    @Override
+    public String getNextStringId(String strategyId) throws FdlException {
+        throw new FdlException("Strategy-based String" + UNSUPPORTED);
+    }
+
+    @Override
+    public String getNextStringId(EgovIdGnrStrategy strategy) throws FdlException {
+        throw new FdlException("Strategy-based String" + UNSUPPORTED);
+    }
+
+}

--- a/Foundation/org.egovframe.rte.fdl.idgnr/src/test/java/org/egovframe/rte/fdl/idgnr/EgovUuidV7GnrServiceTest.java
+++ b/Foundation/org.egovframe.rte.fdl.idgnr/src/test/java/org/egovframe/rte/fdl/idgnr/EgovUuidV7GnrServiceTest.java
@@ -1,0 +1,88 @@
+package org.egovframe.rte.fdl.idgnr;
+
+import org.egovframe.rte.fdl.cmmn.exception.FdlException;
+import org.egovframe.rte.fdl.idgnr.impl.EgovUuidV7GnrServiceImpl;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * UUID 버전 7(RFC 9562) 채번 서비스를 검증한다.
+ */
+public class EgovUuidV7GnrServiceTest {
+
+    private final EgovUuidV7GnrServiceImpl service = new EgovUuidV7GnrServiceImpl();
+
+    @Test
+    public void testVersionAndVariant() throws FdlException {
+        UUID uuid = UUID.fromString(service.getNextStringId());
+
+        assertEquals(7, uuid.version());
+        assertEquals(2, uuid.variant(), "IETF variant(10xx)여야 한다");
+    }
+
+    @Test
+    public void testLeading48BitsAreCreationTimestamp() throws FdlException {
+        long before = System.currentTimeMillis();
+        UUID uuid = UUID.fromString(service.getNextStringId());
+        long after = System.currentTimeMillis();
+
+        long embedded = uuid.getMostSignificantBits() >>> 16;
+        assertTrue(embedded >= before && embedded <= after,
+                "타임스탬프 " + embedded + " 는 [" + before + ", " + after + "] 안이어야 한다");
+    }
+
+    @Test
+    public void testLaterMillisecondSortsAfterEarlier() throws Exception {
+        String first = service.getNextStringId();
+        Thread.sleep(2);
+        String second = service.getNextStringId();
+
+        assertTrue(first.compareTo(second) < 0, first + " < " + second);
+    }
+
+    @Test
+    public void testBulkGenerationIsUnique() throws FdlException {
+        Set<String> ids = new HashSet<>();
+        for (int i = 0; i < 5_000; i++) {
+            assertTrue(ids.add(service.getNextStringId()), "중복 발생");
+        }
+    }
+
+    @Test
+    public void testBigDecimalIsUnsigned128BitValueOfTheUuid() throws FdlException {
+        BigDecimal id = service.getNextBigDecimalId();
+
+        assertTrue(id.signum() > 0);
+        assertTrue(id.toBigInteger().bitLength() <= 128, "128비트 안이어야 한다: " + id);
+        // 상위 64비트를 다시 꺼내면 버전 7 이어야 한다
+        BigInteger high = id.toBigInteger().shiftRight(64);
+        assertEquals(7, high.shiftRight(12).and(BigInteger.valueOf(0xF)).intValue());
+    }
+
+    @Test
+    public void testUnsupportedTypesThrowWithoutMessageSource() {
+        assertThrows(FdlException.class, service::getNextLongId);
+        assertThrows(FdlException.class, service::getNextIntegerId);
+        assertThrows(FdlException.class, service::getNextShortId);
+        assertThrows(FdlException.class, service::getNextByteId);
+        assertThrows(FdlException.class, () -> service.getNextStringId("policy"));
+        assertThrows(FdlException.class, () -> service.getNextStringId((EgovIdGnrStrategy) null));
+    }
+
+    @Test
+    public void testStaticGenerateNeedsNoBeanOrConfiguration() {
+        UUID uuid = EgovUuidV7GnrServiceImpl.generate();
+
+        assertEquals(7, uuid.version());
+        assertEquals(36, uuid.toString().length());
+    }
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [ ] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [X] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

### 배경

기존 UUID 채번 `EgovUUIdGnrServiceImpl` 은 시간 기반 v1 방식입니다. `address` 를 설정하면 결정론적이고, 다중 인스턴스
사이의 유일성은 설정에 기댑니다. 무작위 v4 는 유일하지만 정렬성이 없어 PK 로 쓰면 인덱스가 파편화됩니다.
RFC 9562 의 UUID 버전 7 은 이 두 문제를 함께 해결합니다.

### 추가한 것

**`impl/EgovUuidV7GnrServiceImpl`** — `EgovIdGnrService` 구현

- 선두 48비트 Unix 밀리초 타임스탬프 + `SecureRandom` 랜덤 74비트(rand_a 12 + rand_b 62), 버전 7, IETF variant.
- **시간순 정렬성**: 문자열·바이트 정렬이 생성 시각 순서와 일치해 DB 인덱스 지역성이 좋습니다. 같은 밀리초 안의 순서는
  보장하지 않습니다(RFC 허용 범위, javadoc 명시).
- **다중 인스턴스 안전**: 서버 간 조정이나 `address` 설정 없이 씁니다. messageSource 빈에도 의존하지 않아 빈 하나만 등록하면 됩니다.
- `getNextStringId()` 는 표준 36자 표기, `getNextBigDecimalId()` 는 128비트 값입니다. 축소 숫자 타입과 정책 기반 문자열은
  기존 UUID 구현과 같은 계약으로 `FdlException` 을 던집니다. 정적 `generate()` 로 빈 없이도 쓸 수 있습니다.

```xml
<bean id="uuidV7GnrService" class="org.egovframe.rte.fdl.idgnr.impl.EgovUuidV7GnrServiceImpl"/>
```

### 설계 메모

- **기존 클래스는 수정하지 않았습니다.** `EgovUUIdGnrServiceImpl` 은 그대로 두고 새 구현을 추가합니다.
- JDK 17 에는 v7 생성기가 없어 비트 배치를 직접 구성했으며, 테스트가 버전·variant·타임스탬프 비트를 확인합니다.
- 서비스 인스턴스는 상태가 없어(정적 `SecureRandom` 만) 싱글톤으로 공유해도 안전합니다.
- #399 로 머지된 `EgovStoredFileNames`(fdl.filehandling) 는 모듈 의존을 피하려고 같은 UUIDv7 을 자체 생성하며 javadoc 에서 이
  클래스를 언급합니다. 이 PR 로 채번 모듈 쪽 구현이 갖춰집니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

`EgovUuidV7GnrServiceTest` **7건 신규**, `fdl.idgnr` 모듈 전건 통과.

| 환경 | 기본 로케일(Locale) | 모듈 실행 건수 | 결과 |
|---|---|---:|---|
| **Windows** | ko_KR | **52** | `Tests run: 52, Failures: 0, Errors: 0, Skipped: 0` |
| **Linux** (Ubuntu 22.04 / OpenJDK 17) | C.UTF-8 | **52** | `Tests run: 52, Failures: 0, Errors: 0, Skipped: 0` |

| 구분 | 건수 | 내용 |
|---|---:|---|
| 형식 | 3 | 버전 7·IETF variant · 선두 48비트가 생성 시각 · 밀리초가 지나면 문자열 순서가 뒤가 된다 |
| 유일성 | 1 | 5,000건 연속 생성 중복 없음 |
| 값 | 2 | BigDecimal 이 부호 없는 128비트 값이고 상위 비트에서 버전 7 이 복원된다 · 정적 `generate()` |
| 계약 | 1 | byte·short·int·long·정책 문자열은 `FdlException` |

**수동 확인**: 현재 `main`(`cc2b332`) 위에서 `fdl.idgnr` 모듈 빌드·테스트가 통과함을 Windows 와 Linux 에서 확인했습니다.

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

해당 없음 — 라이브러리 클래스 추가입니다.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

해당 없음 — 위 JUnit 테스트 결과로 갈음합니다.

---

<sub>base: `eGovFramework:main` @ `cc2b332` (2026-09-10 fetch 기준, #366~#379 머지 후) · 단일 커밋</sub>
