### PR TITLE
feat: 엑셀 워크북을 xls·xlsx 자동 감지로 열고 대용량을 스트리밍으로 쓰는 EgovWorkbooks 추가

### DIFF
--- a/Foundation/org.egovframe.rte.fdl.excel/src/main/java/org/egovframe/rte/fdl/excel/util/EgovWorkbooks.java
+++ b/Foundation/org.egovframe.rte.fdl.excel/src/main/java/org/egovframe/rte/fdl/excel/util/EgovWorkbooks.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright 2009-2026 MOIS(Ministry of the Interior and Safety).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.egovframe.rte.fdl.excel.util;
+
+import org.apache.poi.openxml4j.util.ZipSecureFile;
+import org.apache.poi.ss.usermodel.Workbook;
+import org.apache.poi.ss.usermodel.WorkbookFactory;
+import org.apache.poi.xssf.streaming.SXSSFWorkbook;
+import org.egovframe.rte.fdl.cmmn.exception.BaseRuntimeException;
+
+import java.io.BufferedInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+/**
+ * 엑셀 워크북을 열고 만들고 저장하는 유틸 — <b>xls·xlsx 자동 감지</b>와 <b>대용량 스트리밍 쓰기</b>.
+ *
+ * <p>기존 엑셀 로딩 API 는 xls(HSSF)가 기본이고 xlsx(XSSF)는 타입 구분용 워크북을 인자로 넘겨 가르는 구조라 호출자가
+ * 형식을 미리 알아야 한다. 이 유틸은 POI {@link WorkbookFactory} 로 <b>확장자가 아닌 내용</b>으로 형식을 감지해
+ * 하나의 API 로 연다.</p>
+ *
+ * <ul>
+ *   <li>{@link #open(InputStream)}/{@link #open(File)} — xls·xlsx 자동 감지 로딩</li>
+ *   <li>{@link #createStreaming()}/{@link #createStreaming(int)} — SXSSF 스트리밍 워크북(행 윈도만 메모리에 유지)</li>
+ *   <li>{@link #write(Workbook, File)} — 부모 디렉터리 생성, 저장, SXSSF 임시파일 정리까지 한 번에</li>
+ * </ul>
+ *
+ * <p>실패는 {@link BaseRuntimeException}(unchecked, 원인 보존)으로 알린다. 돌려받은 {@link Workbook} 을 닫는 책임은
+ * 호출자에게 있다(try-with-resources 권장).</p>
+ *
+ * @author 실행환경 개발팀
+ * @since 5.1
+ * @version 1.0
+ * <pre>
+ * 개정이력(Modification Information)
+ *
+ * 수정일		수정자				수정내용
+ * ----------------------------------------------
+ * 2026.09.10	실행환경 개발팀		최초 생성
+ * </pre>
+ */
+public final class EgovWorkbooks {
+
+    /** SXSSF 기본 메모리 행 윈도 크기 */
+    public static final int DEFAULT_ROW_ACCESS_WINDOW = 100;
+
+    /** POI 의 zip bomb 방어 기본 비율. 다른 코드가 완화했더라도 신뢰할 수 없는 입력을 열기 전에 복원한다. */
+    private static final double POI_DEFAULT_MIN_INFLATE_RATIO = 0.01d;
+
+    private EgovWorkbooks() {
+    }
+
+    /**
+     * 스트림에서 워크북을 연다 — xls·xlsx 를 내용으로 자동 감지한다.
+     * mark/reset 을 지원하지 않는 스트림은 내부에서 버퍼링한다.
+     *
+     * @param in 엑셀 입력 스트림(닫는 책임은 호출자)
+     * @return 열린 워크북(닫는 책임은 호출자)
+     * @throws IllegalArgumentException in 이 null 인 경우
+     * @throws BaseRuntimeException     엑셀이 아니거나 읽을 수 없는 경우
+     */
+    public static Workbook open(InputStream in) {
+        if (in == null) {
+            throw new IllegalArgumentException("input stream must not be null");
+        }
+        try {
+            ZipSecureFile.setMinInflateRatio(POI_DEFAULT_MIN_INFLATE_RATIO);
+            InputStream streamToUse = in.markSupported() ? in : new BufferedInputStream(in);
+            return WorkbookFactory.create(streamToUse);
+        } catch (IOException e) {
+            throw new BaseRuntimeException("Failed to open workbook from stream (xls/xlsx auto-detect)", e);
+        }
+    }
+
+    /**
+     * 파일에서 워크북을 연다 — 확장자가 아닌 내용으로 xls·xlsx 를 감지한다.
+     *
+     * @param file 엑셀 파일
+     * @return 열린 워크북(닫는 책임은 호출자)
+     * @throws IllegalArgumentException file 이 null 인 경우
+     * @throws BaseRuntimeException     파일이 없거나 엑셀이 아닌 경우
+     */
+    public static Workbook open(File file) {
+        if (file == null) {
+            throw new IllegalArgumentException("file must not be null");
+        }
+        try (InputStream in = new FileInputStream(file)) {
+            return open(in);
+        } catch (IOException e) {
+            throw new BaseRuntimeException("Failed to open workbook file: " + file, e);
+        }
+    }
+
+    /**
+     * 대용량 쓰기용 SXSSF 스트리밍 워크북을 만든다(행 윈도 {@value #DEFAULT_ROW_ACCESS_WINDOW}).
+     * {@link #write(Workbook, File)} 로 저장하면 임시파일 정리까지 함께 처리된다.
+     *
+     * @return SXSSF 워크북
+     */
+    public static SXSSFWorkbook createStreaming() {
+        return createStreaming(DEFAULT_ROW_ACCESS_WINDOW);
+    }
+
+    /**
+     * 대용량 쓰기용 SXSSF 스트리밍 워크북을 만든다.
+     *
+     * @param rowAccessWindowSize 메모리에 유지할 행 수(초과분은 임시파일로 밀어낸다). -1 은 무제한
+     * @return SXSSF 워크북
+     */
+    public static SXSSFWorkbook createStreaming(int rowAccessWindowSize) {
+        return new SXSSFWorkbook(rowAccessWindowSize);
+    }
+
+    /**
+     * 워크북을 파일로 저장한다. 부모 디렉터리가 없으면 만들고, SXSSF 워크북이면 저장 뒤 임시파일을 정리한다.
+     * 워크북을 닫는 책임은 호출자에게 있다.
+     *
+     * @param workbook 저장할 워크북
+     * @param target   대상 파일
+     * @throws IllegalArgumentException 인자가 null 인 경우
+     * @throws BaseRuntimeException     디렉터리를 만들지 못하거나 쓰기에 실패한 경우
+     */
+    public static void write(Workbook workbook, File target) {
+        if (workbook == null || target == null) {
+            throw new IllegalArgumentException("workbook and target must not be null");
+        }
+        File parent = target.getAbsoluteFile().getParentFile();
+        if (parent != null && !parent.exists() && !parent.mkdirs() && !parent.exists()) {
+            throw new BaseRuntimeException("Failed to create parent directory: " + parent);
+        }
+        try (OutputStream out = new FileOutputStream(target)) {
+            workbook.write(out);
+        } catch (IOException e) {
+            throw new BaseRuntimeException("Failed to write workbook file: " + target, e);
+        } finally {
+            if (workbook instanceof SXSSFWorkbook) {
+                ((SXSSFWorkbook) workbook).dispose();
+            }
+        }
+    }
+
+}

--- a/Foundation/org.egovframe.rte.fdl.excel/src/test/java/org/egovframe/rte/fdl/excel/EgovWorkbooksTest.java
+++ b/Foundation/org.egovframe.rte.fdl.excel/src/test/java/org/egovframe/rte/fdl/excel/EgovWorkbooksTest.java
@@ -1,0 +1,137 @@
+package org.egovframe.rte.fdl.excel;
+
+import org.apache.poi.hssf.usermodel.HSSFWorkbook;
+import org.apache.poi.ss.usermodel.Row;
+import org.apache.poi.ss.usermodel.Sheet;
+import org.apache.poi.ss.usermodel.Workbook;
+import org.apache.poi.xssf.streaming.SXSSFWorkbook;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import org.egovframe.rte.fdl.cmmn.exception.BaseRuntimeException;
+import org.egovframe.rte.fdl.excel.util.EgovWorkbooks;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * EgovWorkbooks 의 형식 자동 감지 로딩과 SXSSF 스트리밍 쓰기를 검증한다.
+ */
+public class EgovWorkbooksTest {
+
+    @TempDir
+    Path tempDir;
+
+    private File save(Workbook wb, String name) throws IOException {
+        File target = tempDir.resolve(name).toFile();
+        EgovWorkbooks.write(wb, target);
+        wb.close();
+        return target;
+    }
+
+    @Test
+    public void testXlsIsDetectedByContentNotExtension() throws IOException {
+        HSSFWorkbook src = new HSSFWorkbook();
+        src.createSheet("legacy").createRow(0).createCell(0).setCellValue("xls");
+        File saved = save(src, "misleading.dat");
+
+        try (Workbook opened = EgovWorkbooks.open(saved)) {
+            assertInstanceOf(HSSFWorkbook.class, opened);
+            assertEquals("xls", opened.getSheetAt(0).getRow(0).getCell(0).getStringCellValue());
+        }
+    }
+
+    @Test
+    public void testXlsxIsDetectedWithTheSameApi() throws IOException {
+        XSSFWorkbook src = new XSSFWorkbook();
+        src.createSheet("modern").createRow(0).createCell(0).setCellValue("xlsx");
+        File saved = save(src, "modern.bin");
+
+        try (Workbook opened = EgovWorkbooks.open(saved)) {
+            assertInstanceOf(XSSFWorkbook.class, opened);
+            assertEquals("xlsx", opened.getSheetAt(0).getRow(0).getCell(0).getStringCellValue());
+        }
+    }
+
+    @Test
+    public void testStreamInputWithoutMarkSupportIsBuffered() throws IOException {
+        XSSFWorkbook src = new XSSFWorkbook();
+        src.createSheet("s").createRow(0).createCell(0).setCellValue("stream");
+        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        src.write(bytes);
+        src.close();
+        InputStream noMark = new InputStream() {
+            private final InputStream delegate = new ByteArrayInputStream(bytes.toByteArray());
+
+            @Override
+            public int read() throws IOException {
+                return delegate.read();
+            }
+
+            @Override
+            public boolean markSupported() {
+                return false;
+            }
+        };
+
+        try (Workbook opened = EgovWorkbooks.open(noMark)) {
+            assertEquals("stream", opened.getSheetAt(0).getRow(0).getCell(0).getStringCellValue());
+        }
+    }
+
+    @Test
+    public void testStreamingWorkbookWritesFiveThousandRowsAndReadsBack() throws IOException {
+        SXSSFWorkbook streaming = EgovWorkbooks.createStreaming();
+        Sheet sheet = streaming.createSheet("big");
+        for (int i = 0; i < 5_000; i++) {
+            Row row = sheet.createRow(i);
+            row.createCell(0).setCellValue(i);
+            row.createCell(1).setCellValue("행-" + i);
+        }
+        File saved = save(streaming, "big.xlsx");
+
+        try (Workbook opened = EgovWorkbooks.open(saved)) {
+            Sheet readBack = opened.getSheetAt(0);
+            assertEquals(4_999, readBack.getLastRowNum());
+            assertEquals("행-4999", readBack.getRow(4_999).getCell(1).getStringCellValue());
+        }
+    }
+
+    @Test
+    public void testWriteCreatesMissingParentDirectories() throws IOException {
+        XSSFWorkbook wb = new XSSFWorkbook();
+        wb.createSheet("s");
+        File nested = tempDir.resolve("out/deep/wb.xlsx").toFile();
+
+        EgovWorkbooks.write(wb, nested);
+        wb.close();
+
+        assertTrue(nested.exists());
+        try (Workbook opened = EgovWorkbooks.open(nested)) {
+            assertEquals(1, opened.getNumberOfSheets());
+        }
+    }
+
+    @Test
+    public void testNonExcelAndNullInputsAreRejected() throws IOException {
+        Path bogus = tempDir.resolve("not-excel.txt");
+        Files.writeString(bogus, "plain text", StandardCharsets.UTF_8);
+
+        assertThrows(BaseRuntimeException.class, () -> EgovWorkbooks.open(bogus.toFile()));
+        assertThrows(BaseRuntimeException.class, () -> EgovWorkbooks.open(tempDir.resolve("missing.xlsx").toFile()));
+        assertThrows(IllegalArgumentException.class, () -> EgovWorkbooks.open((File) null));
+        assertThrows(IllegalArgumentException.class, () -> EgovWorkbooks.open((InputStream) null));
+        assertThrows(IllegalArgumentException.class, () -> EgovWorkbooks.write(null, tempDir.resolve("x.xlsx").toFile()));
+    }
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [ ] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [X] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

### 배경

엑셀 로딩 API 는 xls(HSSF)가 기본이고 xlsx(XSSF)는 타입 구분용 워크북을 인자로 넘겨 가르는 구조입니다. 호출자가 파일
형식을 미리 알아야 하고, 확장자만 보고 잘못 고르면 열리지 않습니다. 대용량 출력은 XSSF 가 시트 전체를 메모리에 두어
행 수가 많으면 힘듭니다.

### 추가한 것

**`util/EgovWorkbooks`** — 워크북을 열고 만들고 저장하는 유틸

| API | 내용 |
|---|---|
| `open(InputStream)` / `open(File)` | POI `WorkbookFactory` 로 **확장자가 아닌 내용**으로 xls·xlsx 를 감지해 연다. mark 를 지원하지 않는 스트림은 버퍼링한다. 신뢰할 수 없는 업로드 파일에 대비해 zip bomb 방어 비율을 POI 기본값으로 복원한 뒤 연다 |
| `createStreaming()` / `createStreaming(int)` | SXSSF 스트리밍 워크북(기본 행 윈도 100). 대용량 쓰기에서 행 윈도만 메모리에 유지한다 |
| `write(Workbook, File)` | 부모 디렉터리 생성, 저장, SXSSF 임시파일 정리를 한 번에 |

```java
try (Workbook wb = EgovWorkbooks.open(uploadedFile)) {   // xls 든 xlsx 든 같은 코드
    ...
}

SXSSFWorkbook big = EgovWorkbooks.createStreaming();
... // 수십만 행
EgovWorkbooks.write(big, new File("/data/out/report.xlsx"));  // 저장 + 임시파일 정리
big.close();
```

### 설계 메모

- **기존 클래스는 수정하지 않았습니다.** `EgovExcelService` 계열은 그대로이며 새 유틸을 추가합니다.
- 실패는 `BaseRuntimeException`(unchecked, 원인 보존)으로 알립니다. 돌려받은 워크북을 닫는 책임은 호출자에게 있으며 javadoc 에 명시했습니다.
- zip bomb 방어 비율(`ZipSecureFile.setMinInflateRatio`)은 POI 전역 설정입니다. 같은 JVM 의 다른 코드가 완화했더라도 이
  유틸로 여는 순간에는 기본값(0.01)이 적용되도록 복원합니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

`EgovWorkbooksTest` **6건 신규**, `fdl.excel` 모듈 전건 통과.

| 환경 | 기본 로케일(Locale) | 모듈 실행 건수 | 결과 |
|---|---|---:|---|
| **Windows** | ko_KR | **39** | `Tests run: 39, Failures: 0, Errors: 0, Skipped: 0` |
| **Linux** (Ubuntu 22.04 / OpenJDK 17) | C.UTF-8 | **39** | `Tests run: 39, Failures: 0, Errors: 0, Skipped: 0` |

| 구분 | 건수 | 내용 |
|---|---:|---|
| 자동 감지 | 3 | `.dat` 확장자의 xls 와 `.bin` 확장자의 xlsx 가 내용으로 열린다 · mark 미지원 스트림도 버퍼링해 연다 |
| 스트리밍 | 1 | SXSSF 로 5,000행을 쓰고 다시 읽는다(임시파일 정리 포함) |
| 저장 | 1 | 없는 부모 디렉터리를 만들고 저장한다 |
| 계약 | 1 | 엑셀이 아닌 파일·없는 파일은 `BaseRuntimeException`, null 인자는 `IllegalArgumentException` |

**수동 확인**: 현재 `main`(`cc2b332`) 위에서 `fdl.excel` 모듈 빌드·테스트가 통과함을 Windows 와 Linux 에서 확인했습니다.

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

해당 없음 — 라이브러리 클래스 추가입니다.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

해당 없음 — 위 JUnit 테스트 결과로 갈음합니다.

---

<sub>base: `eGovFramework:main` @ `cc2b332` (2026-09-10 fetch 기준, #366~#379 머지 후) · 단일 커밋</sub>
