### PR TITLE
feat: 엑셀 업로드를 트랜잭션 밖에서 JDBC 배치로 실행하고 xls·xlsx 자동 감지 진입점 uploadExcelAuto 추가

### DIFF
--- a/Foundation/org.egovframe.rte.fdl.excel/src/main/java/org/egovframe/rte/fdl/excel/EgovExcelService.java
+++ b/Foundation/org.egovframe.rte.fdl.excel/src/main/java/org/egovframe/rte/fdl/excel/EgovExcelService.java
@@ -32,6 +32,7 @@ import java.io.InputStream;
  * 2013.05.22	이기하			XSSF, SXSSF 형식 추가
  * 2014.05.14	이기하			XSSF형식 구분자 추가 및 workbook으로 변경
  * 2024.08.17	이백행			시큐어코딩 Exception 제거
+ * 2026.09.10	실행환경 개발팀		xls·xlsx 자동 감지 업로드(uploadExcelAuto) 추가
  */
 public interface EgovExcelService {
 
@@ -123,5 +124,22 @@ public interface EgovExcelService {
      * 업로드할 엑셀의 시작 위치를 정하여 지정한 셀부터 업로드한다.
      */
     Integer uploadExcel(String queryId, InputStream fileIn, String sheetName, int start, long commitCnt, XSSFWorkbook type);
+
+    /**
+     * 엑셀 파일을 xls·xlsx <b>자동 감지</b>로 로딩해 첫 번째 시트를 DB 에 일괄 저장한다.
+     * <p>
+     * 기존 API 는 xls 가 기본 오버로드이고 xlsx 는 타입 구분용 {@code XSSFWorkbook} 인자로 가르는 구조라 호출자가 형식을 미리
+     * 알아야 했다. 이 메서드는 확장자가 아닌 내용으로 형식을 감지하는 단일 진입점이다. 기존 구현체와의 호환을 위해 default
+     * 메서드로 제공하며, 지원하지 않는 구현체는 {@link UnsupportedOperationException} 을 던진다.
+     *
+     * @param queryId   저장 SQL 매핑 쿼리 ID
+     * @param fileIn    엑셀 입력 스트림(xls·xlsx 자동 감지, 닫는 책임은 호출자)
+     * @param start     업로드 시작 행(0부터)
+     * @param commitCnt 커밋 단위 행 수(0 이면 전체를 한 번에)
+     * @return 저장된 행 수
+     */
+    default Integer uploadExcelAuto(String queryId, InputStream fileIn, int start, long commitCnt) {
+        throw new UnsupportedOperationException("uploadExcelAuto is not supported by this implementation");
+    }
 
 }

--- a/Foundation/org.egovframe.rte.fdl.excel/src/main/java/org/egovframe/rte/fdl/excel/impl/EgovExcelServiceImpl.java
+++ b/Foundation/org.egovframe.rte.fdl.excel/src/main/java/org/egovframe/rte/fdl/excel/impl/EgovExcelServiceImpl.java
@@ -24,6 +24,7 @@ import org.apache.poi.poifs.filesystem.POIFSFileSystem;
 import org.apache.poi.ss.usermodel.Row;
 import org.apache.poi.ss.usermodel.Sheet;
 import org.apache.poi.ss.usermodel.Workbook;
+import org.apache.poi.ss.usermodel.WorkbookFactory;
 import org.apache.poi.xssf.usermodel.XSSFWorkbook;
 import org.egovframe.rte.fdl.cmmn.exception.BaseRuntimeException;
 import org.egovframe.rte.fdl.excel.EgovExcelMapping;
@@ -57,6 +58,7 @@ import java.util.Locale;
  * 2017.02.15  장동한				ES-부적절한 예외 처리[CWE-253, CWE-440, CWE-754]
  * 2020.08.31  유지보수				ES-부적절한 예외 처리[CWE-253, CWE-440, CWE-754]
  * 2024.08.17  이백행				시큐어코딩 Exception 제거
+ * 2026.09.10  실행환경 개발팀		xls·xlsx 자동 감지 업로드(uploadExcelAuto) 추가
  */
 public class EgovExcelServiceImpl implements EgovExcelService, ApplicationContextAware {
 
@@ -321,6 +323,24 @@ public class EgovExcelServiceImpl implements EgovExcelService, ApplicationContex
         LOGGER.debug("uploadExcel result count is {}", rowsAffected);
 
         return rowsAffected;
+    }
+
+    /**
+     * 엑셀 파일을 xls·xlsx 자동 감지로 로딩해 첫 번째 시트를 DB 에 일괄 저장한다.
+     * 형식은 확장자가 아닌 내용으로 감지하며, 워크북은 저장이 끝나면 닫는다.
+     */
+    @Override
+    public Integer uploadExcelAuto(String queryId, InputStream fileIn, int start, long commitCnt) {
+        if (fileIn == null) {
+            throw new IllegalArgumentException("fileIn must not be null");
+        }
+        // xlsx 는 zip 형식이라 zip bomb 방어 비율을 열기 직전에 POI 기본값으로 복원한다(loadWorkbook(InputStream, XSSFWorkbook) 과 동일).
+        ZipSecureFile.setMinInflateRatio(0.01d);
+        try (Workbook wb = WorkbookFactory.create(fileIn)) {
+            return uploadExcel(queryId, wb.getSheetAt(0), start, commitCnt);
+        } catch (IOException e) {
+            throw new BaseRuntimeException("Failed to open workbook for upload (xls/xlsx auto-detect)", e);
+        }
     }
 
     /**

--- a/Foundation/org.egovframe.rte.fdl.excel/src/main/java/org/egovframe/rte/fdl/excel/impl/EgovExcelServiceMapper.java
+++ b/Foundation/org.egovframe.rte.fdl.excel/src/main/java/org/egovframe/rte/fdl/excel/impl/EgovExcelServiceMapper.java
@@ -15,25 +15,44 @@
  */
 package org.egovframe.rte.fdl.excel.impl;
 
+import org.apache.ibatis.exceptions.PersistenceException;
+import org.apache.ibatis.executor.BatchResult;
+import org.apache.ibatis.session.ExecutorType;
+import org.apache.ibatis.session.SqlSession;
 import org.egovframe.rte.psl.dataaccess.EgovAbstractMapper;
 import org.mybatis.spring.SqlSessionTemplate;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.dao.DataAccessException;
+import org.springframework.dao.support.PersistenceExceptionTranslator;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
-import java.util.Iterator;
 import java.util.List;
 
 /**
  * 엑셀서비스을 처리하는 Mapper 클래스.
+ *
+ * <p>업로드 실행 방식은 호출 문맥에 따라 다르다.</p>
+ * <ul>
+ *   <li><b>Spring 트랜잭션 밖</b>: MyBatis {@link ExecutorType#BATCH} 세션을 열어 JDBC 배치로 실행하고
+ *       {@code batchInsert} 호출(=커밋 단위 청크)마다 flush·commit 한다. 반환값은 JDBC 배치 결과의 영향 행 수다.
+ *       MyBatis 예외는 {@link SqlSessionTemplate} 과 같은 방식으로 Spring {@link DataAccessException} 으로 변환한다.</li>
+ *   <li><b>Spring 트랜잭션 안</b>: 기존과 같이 주입된 {@link SqlSessionTemplate} 으로 행별 실행해 둘러싼 트랜잭션에
+ *       참여한다. 같은 트랜잭션에서 SIMPLE/BATCH executor 를 혼용할 수 없다는 MyBatis 제약 때문이다.</li>
+ * </ul>
  * <p>
  * 개정이력(Modification Information)
  * <p>
  * 수정일		수정자				수정내용
  * ----------------------------------------------
  * 2014.05.07	이기하				최초 생성
+ * 2026.09.10	실행환경 개발팀		트랜잭션 밖 업로드를 BATCH executor 세션의 JDBC 배치 실행으로 변경, 트랜잭션 안은 행별 실행 유지
  */
 public class EgovExcelServiceMapper extends EgovAbstractMapper {
 
-    @SuppressWarnings("unused")
-    private SqlSessionTemplate sqlSessionTemplate = null;
+    private static final Logger LOGGER = LoggerFactory.getLogger(EgovExcelServiceMapper.class);
+
+    private final SqlSessionTemplate sqlSessionTemplate;
 
     public EgovExcelServiceMapper(SqlSessionTemplate sqlSessionTemplate) {
         this.sqlSessionTemplate = sqlSessionTemplate;
@@ -44,25 +63,74 @@ public class EgovExcelServiceMapper extends EgovAbstractMapper {
      * 엑셀서비스의 배치업로드를 실행한다.
      */
     public Integer batchInsert(String queryId, List<Object> list) {
-        Iterator<Object> itr = list.iterator();
-        int count = 0;
-        while (itr.hasNext()) {
-            count += insert(queryId, itr.next());
-        }
-        return count;
+        return batchInsert(queryId, list, 0);
     }
 
     /**
      * 엑셀서비스의 배치업로드를 실행한다.
      * 업로드할 엑셀의 시작 위치를 정하여 지정한 셀부터 업로드한다.
+     * Spring 트랜잭션 밖에서는 JDBC 배치로 실행한 뒤 커밋하고, 트랜잭션 안에서는 행별로 실행해 둘러싼 트랜잭션에 참여한다.
      */
     public Integer batchInsert(final String queryId, final List<Object> list, final int start) {
+        if (list == null || start >= list.size()) {
+            return 0;
+        }
+        if (TransactionSynchronizationManager.isActualTransactionActive()) {
+            return rowByRowInsert(queryId, list, start);
+        }
+        return batchExecutorInsert(queryId, list, start);
+    }
+
+    /**
+     * 트랜잭션 밖 경로 — BATCH executor 세션으로 JDBC 배치 실행 후 커밋한다.
+     */
+    private Integer batchExecutorInsert(String queryId, List<Object> list, int start) {
+        try (SqlSession batchSession = sqlSessionTemplate.getSqlSessionFactory().openSession(ExecutorType.BATCH)) {
+            for (int i = start; i < list.size(); i++) {
+                batchSession.insert(queryId, list.get(i));
+            }
+            List<BatchResult> results = batchSession.flushStatements();
+            batchSession.commit();
+            int affected = countAffected(results);
+            LOGGER.debug("Excel batch insert executed with BATCH executor: {} rows requested, {} affected", list.size() - start, affected);
+            return affected;
+        } catch (PersistenceException e) {
+            throw translate(e);
+        }
+    }
+
+    /**
+     * 트랜잭션 안 경로 — 기존과 같은 행별 실행.
+     */
+    private Integer rowByRowInsert(String queryId, List<Object> list, int start) {
         int count = 0;
         int size = list.size();
         for (int i = start; i < size; i++) {
             count += insert(queryId, list.get(i));
         }
         return count;
+    }
+
+    /**
+     * JDBC 배치 결과에서 영향 행 수를 집계한다. 드라이버가 건수를 보고하지 않으면(SUCCESS_NO_INFO) 문장당 1행으로 센다.
+     */
+    private static int countAffected(List<BatchResult> results) {
+        int affected = 0;
+        for (BatchResult result : results) {
+            for (int updateCount : result.getUpdateCounts()) {
+                affected += (updateCount >= 0) ? updateCount : 1;
+            }
+        }
+        return affected;
+    }
+
+    /**
+     * SqlSessionTemplate 과 같은 방식으로 MyBatis 예외를 Spring DataAccessException 으로 변환한다. 변환할 수 없으면 그대로 돌려준다.
+     */
+    private RuntimeException translate(PersistenceException e) {
+        PersistenceExceptionTranslator translator = sqlSessionTemplate.getPersistenceExceptionTranslator();
+        DataAccessException translated = (translator != null) ? translator.translateExceptionIfPossible(e) : null;
+        return (translated != null) ? translated : e;
     }
 
 }

--- a/Foundation/org.egovframe.rte.fdl.excel/src/test/java/org/egovframe/rte/fdl/excel/EgovExcelBatchUploadTest.java
+++ b/Foundation/org.egovframe.rte.fdl.excel/src/test/java/org/egovframe/rte/fdl/excel/EgovExcelBatchUploadTest.java
@@ -1,0 +1,186 @@
+package org.egovframe.rte.fdl.excel;
+
+import jakarta.annotation.Resource;
+import org.apache.poi.ss.usermodel.Row;
+import org.apache.poi.ss.usermodel.Sheet;
+import org.apache.poi.ss.usermodel.Workbook;
+import org.apache.poi.ss.usermodel.WorkbookFactory;
+import org.apache.poi.xssf.usermodel.XSSFSheet;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import org.egovframe.rte.fdl.excel.config.ExcelTestConfig;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mockito;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.dao.DataAccessException;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.datasource.init.ScriptUtils;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import javax.sql.DataSource;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.sql.Connection;
+import java.sql.SQLException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * 엑셀 업로드의 xls·xlsx 자동 감지(uploadExcelAuto)와 트랜잭션 밖 JDBC 배치 실행을 검증한다.
+ *
+ * <p>의도적으로 @Transactional 없이 실행한다. 트랜잭션 밖에서는 BATCH executor 세션이 쓰이고 반환 건수가 실제 저장 행 수와
+ * 일치해야 하며, 트랜잭션 안에서는 기존 행별 실행이 둘러싼 트랜잭션에 참여해야 한다.</p>
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = ExcelTestConfig.class)
+public class EgovExcelBatchUploadTest {
+
+    private static final String XLSX = "testdata/testBatch.xlsx";
+    private static final String XLS = "testdata/testBatch.xls";
+    private static final String QUERY_ID = "insertEmpUsingBatch";
+
+    @Resource(name = "dataSource")
+    private DataSource dataSource;
+
+    @Resource(name = "excelService")
+    private EgovExcelService excelService;
+
+    @Resource(name = "txManager")
+    private PlatformTransactionManager txManager;
+
+    private JdbcTemplate jdbcTemplate;
+
+    @BeforeEach
+    public void onSetUp() throws SQLException {
+        jdbcTemplate = new JdbcTemplate(dataSource);
+        try (Connection conn = dataSource.getConnection()) {
+            ScriptUtils.executeSqlScript(conn, new ClassPathResource("/META-INF/testdata/testdb.sql"));
+        }
+    }
+
+    private int empCount() {
+        Integer count = jdbcTemplate.queryForObject("select count(*) from emp", Integer.class);
+        return count == null ? 0 : count;
+    }
+
+    private static int rowsIn(String path) throws IOException {
+        try (Workbook wb = WorkbookFactory.create(new File(path))) {
+            return wb.getSheetAt(0).getPhysicalNumberOfRows();
+        }
+    }
+
+    private Integer uploadAuto(String path, int start, long commitCnt) throws IOException {
+        try (InputStream in = new FileInputStream(path)) {
+            return excelService.uploadExcelAuto(QUERY_ID, in, start, commitCnt);
+        }
+    }
+
+    @Test
+    public void testAutoDetectUploadOfXlsxReturnsTheStoredRowCount() throws IOException {
+        int expected = rowsIn(XLSX);
+
+        Integer affected = uploadAuto(XLSX, 0, 0);
+
+        assertEquals(expected, affected);
+        assertEquals(expected, empCount());
+    }
+
+    @Test
+    public void testAutoDetectUploadOfXlsUsesTheSameApi() throws IOException {
+        int expected = rowsIn(XLS);
+
+        Integer affected = uploadAuto(XLS, 0, 0);
+
+        assertEquals(expected, affected);
+        assertEquals(expected, empCount());
+    }
+
+    @Test
+    public void testCommitChunksStoreEveryRowAndReturnTheTotal() throws IOException {
+        int expected = rowsIn(XLSX);
+
+        Integer affected = uploadAuto(XLSX, 0, 1000);
+
+        assertEquals(expected, affected);
+        assertEquals(expected, empCount());
+    }
+
+    @Test
+    public void testStartOffsetSkipsLeadingRows() throws IOException {
+        int total = rowsIn(XLSX);
+
+        Integer affected = uploadAuto(XLSX, total - 2, 0);
+
+        assertEquals(2, affected);
+        assertEquals(2, empCount());
+    }
+
+    @Test
+    public void testSheetUploadOutsideTransactionUsesTheBatchPath() throws IOException {
+        try (XSSFWorkbook wb = new XSSFWorkbook()) {
+            XSSFSheet sheet = wb.createSheet("emp");
+            createEmpRow(sheet, 0, 9001, "kim", "dev");
+            createEmpRow(sheet, 1, 9002, "lee", "ops");
+            createEmpRow(sheet, 2, 9003, "park", "qa");
+
+            Integer affected = excelService.uploadExcel(QUERY_ID, (Sheet) sheet, 1, 0);
+
+            assertEquals(2, affected);
+            assertEquals(2, empCount());
+        }
+    }
+
+    @Test
+    public void testUploadInsideTransactionJoinsTheEnclosingTransaction() throws IOException {
+        int expected = rowsIn(XLSX);
+        TransactionTemplate tx = new TransactionTemplate(txManager);
+
+        tx.executeWithoutResult(status -> {
+            try {
+                uploadAuto(XLSX, 0, 0);
+            } catch (IOException e) {
+                throw new IllegalStateException(e);
+            }
+            status.setRollbackOnly();
+        });
+        assertEquals(0, empCount());
+
+        tx.executeWithoutResult(status -> {
+            try {
+                uploadAuto(XLSX, 0, 0);
+            } catch (IOException e) {
+                throw new IllegalStateException(e);
+            }
+        });
+        assertEquals(expected, empCount());
+    }
+
+    @Test
+    public void testDuplicateKeysAreReportedAsDataAccessException() throws IOException {
+        uploadAuto(XLSX, 0, 0);
+
+        assertThrows(DataAccessException.class, () -> uploadAuto(XLSX, 0, 0));
+    }
+
+    @Test
+    public void testDefaultUploadExcelAutoIsUnsupportedForOtherImplementations() {
+        EgovExcelService other = Mockito.mock(EgovExcelService.class, Mockito.CALLS_REAL_METHODS);
+
+        assertThrows(UnsupportedOperationException.class, () -> other.uploadExcelAuto(QUERY_ID, InputStream.nullInputStream(), 0, 0));
+    }
+
+    private static void createEmpRow(XSSFSheet sheet, int rowIdx, int empNo, String name, String job) {
+        Row row = sheet.createRow(rowIdx);
+        row.createCell(0).setCellValue(empNo);
+        row.createCell(1).setCellValue(name);
+        row.createCell(2).setCellValue(job);
+    }
+
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [ ] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [X] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

### 배경

엑셀 업로드의 "배치" 저장(`EgovExcelServiceMapper.batchInsert`)은 이름과 달리 행마다 `insert` 를 반복해 **행 수만큼 SQL
왕복**이 일어납니다. 트랜잭션 밖에서 `ExecutorType.BATCH` 타입의 `SqlSessionTemplate` 과 조합하면 `insert` 반환값이 실제
건수가 아니어서 **반환 건수도 실제 저장 행 수와 달랐습니다**. 업로드 API 는 xls 가 기본 오버로드이고 xlsx 는 타입 구분용
`XSSFWorkbook` 인자로 가르는 구조라 호출자가 파일 형식을 미리 알아야 합니다.

### 변경한 것

**1. `EgovExcelServiceMapper` — 트랜잭션 밖에서는 JDBC 배치, 트랜잭션 안에서는 기존 행별 실행**

| 호출 문맥 | 동작 |
|---|---|
| **Spring 트랜잭션 밖** | MyBatis `ExecutorType.BATCH` 세션을 열어 JDBC 배치로 실행하고 `batchInsert` 호출(=`commitCnt` 청크)마다 flush·commit. 반환값은 JDBC 배치 결과(`BatchResult`)의 영향 행 수 합계. MyBatis 예외는 `SqlSessionTemplate` 과 같은 변환기로 Spring `DataAccessException` 으로 변환 |
| **Spring 트랜잭션 안** | **기존과 동일** — 주입된 `SqlSessionTemplate` 으로 행별 실행해 둘러싼 트랜잭션에 참여. 같은 트랜잭션에서 SIMPLE/BATCH executor 를 혼용할 수 없다는 MyBatis 제약 때문 |

```java
public Integer batchInsert(String queryId, List<Object> list, int start) {
    if (list == null || start >= list.size()) return 0;
    if (TransactionSynchronizationManager.isActualTransactionActive()) {
        return rowByRowInsert(queryId, list, start);      // 기존 경로
    }
    return batchExecutorInsert(queryId, list, start);     // BATCH executor 세션 → flushStatements → commit
}
```

**2. `EgovExcelService.uploadExcelAuto(queryId, fileIn, start, commitCnt)` — xls·xlsx 자동 감지 단일 진입점**

POI `WorkbookFactory` 로 **확장자가 아닌 내용**으로 형식을 감지해 첫 시트를 저장합니다. 기존 구현체와의 호환을 위해
인터페이스에는 **default 메서드**로 두었고(지원하지 않는 구현체는 `UnsupportedOperationException`), `EgovExcelServiceImpl`
이 구현합니다. 워크북은 저장이 끝나면 닫고, xlsx 의 zip bomb 방어 비율은 기존 `loadWorkbook(InputStream, XSSFWorkbook)`
과 같이 열기 직전에 POI 기본값으로 복원합니다.

```java
try (InputStream in = file.getInputStream()) {
    int saved = excelService.uploadExcelAuto("insertEmpUsingBatch", in, 1, 1000);   // xls 든 xlsx 든 같은 코드
}
```

### 호환성과 동작 차이

- **기존 메서드 시그니처·반환 타입 변경 없음.** 트랜잭션 안에서의 동작은 그대로입니다(대부분의 서비스 계층 호출).
- **트랜잭션 밖 호출의 커밋 단위가 바뀝니다.** 기존에는 행마다 자동 커밋이라 실패한 행 앞의 행이 남았지만, 이제는
  `commitCnt` 청크 단위로 실행·커밋됩니다. 파라미터 `commitCnt` 의 본래 의미와 일치합니다.
- 트랜잭션 밖 호출의 반환값은 이제 JDBC 배치 결과의 실제 영향 행 수입니다. 드라이버가 건수를 보고하지 않으면
  (`SUCCESS_NO_INFO`) 문장당 1행으로 셉니다.
- 빈 행이 섞인 시트의 순회 상한·null 행 문제는 **#386** 이 다루고 있어 이 PR 은 그 영역을 건드리지 않습니다(같은 파일이지만
  hunk 가 겹치지 않음).

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

`EgovExcelBatchUploadTest` **8건 신규**(의도적으로 `@Transactional` 없이 실행), `fdl.excel` 모듈 전건 통과.

| 환경 | 기본 로케일(Locale) | 모듈 실행 건수 | 결과 |
|---|---|---:|---|
| **Windows** | ko_KR | **41** | `Tests run: 41, Failures: 0, Errors: 0, Skipped: 0` |
| **Linux** (Ubuntu 22.04 / OpenJDK 17) | C.UTF-8 | **41** | `Tests run: 41, Failures: 0, Errors: 0, Skipped: 0` |

| 구분 | 건수 | 내용 |
|---|---:|---|
| 자동 감지 | 2 | `testBatch.xlsx`·`testBatch.xls`(4,502행)를 같은 API 로 업로드, 반환 건수 = 시트 행 수 = DB 건수 |
| 배치 경로 | 3 | 1,000행 단위 커밋(4×1,000 + 502)도 전체 저장 · 시작 행 지정 · 시트 직접 업로드 |
| 트랜잭션 안 | 1 | `TransactionTemplate` 안에서 rollback-only 면 0건, 커밋하면 전체 — 둘러싼 트랜잭션에 참여 |
| 예외 | 2 | 중복 키는 `DataAccessException` · 다른 구현체의 default `uploadExcelAuto` 는 `UnsupportedOperationException` |

**수동 확인**: 현재 `main`(`cc2b332`) 위에서 `fdl.excel` 모듈 빌드·테스트가 통과함을 Windows 와 Linux 에서 확인했습니다.
디버그 로그로 트랜잭션 밖 경로가 BATCH executor 로 실행됨을 확인했습니다(`4502 rows requested, 4502 affected`).

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

해당 없음 — 라이브러리 변경입니다.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

해당 없음 — 위 JUnit 테스트 결과로 갈음합니다.

---

<sub>base: `eGovFramework:main` @ `cc2b332` (2026-09-10 fetch 기준, #366~#379 머지 후) · 단일 커밋</sub>
