### PR TITLE
feat: 로그·헤더에 싣기 전에 요청 식별자 형식을 검증하는 EgovRequestIds 추가

### DIFF
--- a/Foundation/org.egovframe.rte.fdl.logging/src/main/java/org/egovframe/rte/fdl/logging/util/EgovRequestIds.java
+++ b/Foundation/org.egovframe.rte.fdl.logging/src/main/java/org/egovframe/rte/fdl/logging/util/EgovRequestIds.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2009-2026 MOIS(Ministry of the Interior and Safety).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.egovframe.rte.fdl.logging.util;
+
+import java.util.UUID;
+import java.util.regex.Pattern;
+
+/**
+ * 게이트웨이·프록시가 넘긴 요청 식별자({@code X-Request-Id} 등)를 로그에 싣기 전에 형식을 검증한다.
+ *
+ * <p>승계한 값은 MDC({@code %X{requestId}})·응답 헤더·접근로그에 그대로 실린다. 제어문자·유니코드 개행·과대 길이를
+ * 거르지 않으면 로그 인젝션(CWE-117)과 응답 헤더 반사의 소재가 된다. 허용 형식은 영숫자와 {@code . _ : -} 1~128자이며,
+ * 벗어나거나 값이 없으면 승계하지 않고 새 UUID 를 만든다.</p>
+ *
+ * <pre>
+ * String requestId = EgovRequestIds.acceptOrGenerate(request.getHeader("X-Request-Id"));
+ * MDC.put("requestId", requestId);
+ * response.setHeader("X-Request-Id", requestId);
+ * </pre>
+ *
+ * @author 실행환경 개발팀
+ * @since 5.1
+ * @version 1.0
+ * <pre>
+ * 개정이력(Modification Information)
+ *
+ * 수정일		수정자				수정내용
+ * ----------------------------------------------
+ * 2026.09.10	실행환경 개발팀		최초 생성
+ * </pre>
+ */
+public final class EgovRequestIds {
+
+    /** 허용 형식 — 영숫자·점·밑줄·콜론·하이픈, 1~128자. */
+    public static final Pattern ALLOWED = Pattern.compile("[A-Za-z0-9._:\\-]{1,128}");
+
+    private EgovRequestIds() {
+    }
+
+    /**
+     * 승계할 수 있는 값이면 그대로, 아니면(없음·빈 값·형식 위반) 새 UUID 를 돌려준다.
+     *
+     * @param incoming 요청 헤더 값({@code null} 허용)
+     * @return 로그·헤더에 실어도 안전한 요청 식별자
+     */
+    public static String acceptOrGenerate(String incoming) {
+        return isAcceptable(incoming) ? incoming : UUID.randomUUID().toString();
+    }
+
+    /**
+     * 허용 형식이면 {@code true}.
+     *
+     * @param incoming 요청 헤더 값({@code null} 허용)
+     * @return 영숫자와 {@code . _ : -} 만으로 된 1~128자이면 {@code true}
+     */
+    public static boolean isAcceptable(String incoming) {
+        return incoming != null && ALLOWED.matcher(incoming).matches();
+    }
+
+}

--- a/Foundation/org.egovframe.rte.fdl.logging/src/test/java/org/egovframe/rte/fdl/logging/util/EgovRequestIdsTest.java
+++ b/Foundation/org.egovframe.rte.fdl.logging/src/test/java/org/egovframe/rte/fdl/logging/util/EgovRequestIdsTest.java
@@ -1,0 +1,57 @@
+package org.egovframe.rte.fdl.logging.util;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.regex.Pattern;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * EgovRequestIds 의 요청 식별자 승계 규칙(허용 문자·길이)을 경계값으로 검증한다.
+ */
+public class EgovRequestIdsTest {
+
+    private static final Pattern UUID = Pattern.compile("[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}");
+
+    @Test
+    public void testWellFormedIdsAreAcceptedAsIs() {
+        String[] accepted = {"0af7651916cd43dd8448eb211c80319c", "req-2026.09.10:1234", "a1b2-c3d4_e5", "x", "a".repeat(128)};
+        for (String id : accepted) {
+            assertTrue(EgovRequestIds.isAcceptable(id), id);
+            assertEquals(id, EgovRequestIds.acceptOrGenerate(id));
+        }
+    }
+
+    @Test
+    public void testIdLongerThanLimitIsReplaced() {
+        String id = "a".repeat(129);
+
+        assertFalse(EgovRequestIds.isAcceptable(id));
+        String generated = EgovRequestIds.acceptOrGenerate(id);
+        assertNotEquals(id, generated);
+        assertTrue(UUID.matcher(generated).matches(), generated);
+    }
+
+    @Test
+    public void testHostileIdsAreReplaced() {
+        String[] hostile = {"abc\r\nX-Injected: 1", "abc\u00a0evil", "abc\u200bevil", "abc\u2028evil", "abc\u0085evil",
+                "abc\u0000", " abc", "abc ", "abc def", "abc\tdef", "\ud55c\uae00", "abc<script>", "a/b", "a=b", "a,b", "a;b", "a|b",
+                "a%0d%0a"};
+        for (String id : hostile) {
+            assertFalse(EgovRequestIds.isAcceptable(id), id);
+            String generated = EgovRequestIds.acceptOrGenerate(id);
+            assertTrue(UUID.matcher(generated).matches(), generated);
+        }
+    }
+
+    @Test
+    public void testNullOrEmptyGeneratesFreshUuid() {
+        assertTrue(UUID.matcher(EgovRequestIds.acceptOrGenerate(null)).matches());
+        assertTrue(UUID.matcher(EgovRequestIds.acceptOrGenerate("")).matches());
+        assertNotEquals(EgovRequestIds.acceptOrGenerate(null), EgovRequestIds.acceptOrGenerate(null));
+    }
+
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [ ] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [X] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

### 배경

게이트웨이·프록시가 넘긴 `X-Request-Id` 같은 요청 식별자는 보통 그대로 MDC(`%X{requestId}`)·응답 헤더·접근로그에
실립니다. 값에 든 제어문자·유니코드 개행·과대 길이를 거르지 않으면 **로그 인젝션(CWE-117)** 과 **응답 헤더 반사**의
소재가 됩니다. 실행환경에는 이 검증을 한곳에서 하는 API 가 없어 애플리케이션마다 따로 구현하거나 빠뜨립니다.

### 추가한 것

**`util/EgovRequestIds`** — 요청 식별자 승계 규칙

| API | 내용 |
|---|---|
| `acceptOrGenerate(String incoming)` | 영숫자와 `. _ : -` 로 된 **1~128자**면 그대로 승계, 없거나 빈 값이거나 형식을 벗어나면 **새 UUID** 반환 |
| `isAcceptable(String incoming)` | 허용 형식 판정(`null` 허용) |
| `ALLOWED` | 허용 패턴 상수(`[A-Za-z0-9._:\-]{1,128}`) |

```java
String requestId = EgovRequestIds.acceptOrGenerate(request.getHeader("X-Request-Id"));
MDC.put("requestId", requestId);
response.setHeader("X-Request-Id", requestId);
```

### 설계 메모

- **기존 클래스는 수정하지 않았고 의존도 추가하지 않았습니다**(`java.util` 만 사용).
- 허용 문자를 화이트리스트로 좁혀 두어 개행(`\r\n`)·NUL·탭·공백은 물론 NBSP(U+00A0)·zero-width space(U+200B)·
  LINE SEPARATOR(U+2028)·NEL(U+0085) 같은 유니코드 줄바꿈 계열도 승계하지 않습니다. 형식을 벗어난 값은 버리고 새로 만들
  뿐 예외를 던지지 않으므로 요청 처리 흐름에는 영향이 없습니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

`EgovRequestIdsTest` **4건 신규**, `fdl.logging` 모듈 전건 통과.

| 환경 | 기본 로케일(Locale) | 모듈 실행 건수 | 결과 |
|---|---|---:|---|
| **Windows** | ko_KR | **40** | `Tests run: 40, Failures: 0, Errors: 0, Skipped: 0` |
| **Linux** (Ubuntu 22.04 / OpenJDK 17) | C.UTF-8 | **40** | `Tests run: 40, Failures: 0, Errors: 0, Skipped: 0` |

| 구분 | 건수 | 내용 |
|---|---:|---|
| 승계 | 1 | 32자 hex·점/콜론/하이픈/밑줄 조합·1자·128자 경계는 그대로 승계 |
| 길이 | 1 | 129자는 승계하지 않고 UUID 형식의 새 값 |
| 적대적 값 | 1 | CRLF 헤더 삽입·NBSP·zero-width space·U+2028·NEL·NUL·앞뒤 공백·탭·한글·`<script>`·`/ = , ; \|`·`%0d%0a` 18종 모두 새 UUID |
| 없음 | 1 | `null`·빈 값은 새 UUID, 호출마다 다른 값 |

**수동 확인**: 현재 `main`(`cc2b332`) 위에서 `fdl.logging` 모듈 빌드·테스트가 통과함을 Windows 와 Linux 에서 확인했습니다.

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

해당 없음 — 라이브러리 클래스 추가입니다.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

해당 없음 — 위 JUnit 테스트 결과로 갈음합니다.

---

<sub>base: `eGovFramework:main` @ `cc2b332` (2026-09-10 fetch 기준, #366~#379 머지 후) · 단일 커밋</sub>
