### PR TITLE
feat: WebFlux 요청 단위 접근로그를 남기는 EgovReactiveWebAccessLogFilter 추가

### DIFF
--- a/Foundation/org.egovframe.rte.fdl.reactive/src/main/java/org/egovframe/rte/fdl/reactive/logging/EgovReactiveWebAccessLogFilter.java
+++ b/Foundation/org.egovframe.rte.fdl.reactive/src/main/java/org/egovframe/rte/fdl/reactive/logging/EgovReactiveWebAccessLogFilter.java
@@ -1,0 +1,215 @@
+/*
+ * Copyright 2009-2026 MOIS(Ministry of the Interior and Safety).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.egovframe.rte.fdl.reactive.logging;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.core.Ordered;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.util.AntPathMatcher;
+import org.springframework.util.PathMatcher;
+import org.springframework.web.server.ServerWebExchange;
+import org.springframework.web.server.WebFilter;
+import org.springframework.web.server.WebFilterChain;
+import reactor.core.publisher.Mono;
+
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * WebFlux 요청 단위 접근로그 필터 — 요청 1건마다 전용 로거 {@value #LOGGER_NAME} 에 1줄을 남긴다.
+ *
+ * <pre>method=GET uri=/api/list status=200 elapsedMs=12 requestId=… clientIp=… userId=- [error=SimpleName]</pre>
+ *
+ * <ul>
+ *   <li>{@code doFinally} 에서 기록하므로 오류·취소로 끝난 요청도 남는다. 오류는 status 500 과 {@code error=} 로 표시하고
+ *       정상 INFO, 오류·5xx 는 WARN 으로 남긴다</li>
+ *   <li>requestId·clientIp·userId 는 exchange 속성({@link #ATTR_REQUEST_ID}·{@link #ATTR_CLIENT_IP}·{@link #ATTR_USER_ID})이
+ *       있으면 그 값을 쓰고, 없으면 각각 {@code ServerHttpRequest.getId()}·원격 주소·{@code -} 를 쓴다. 게이트웨이 식별자나
+ *       프록시 헤더를 해석하는 필터가 있으면 이 필터보다 안쪽(더 큰 order)에 두고 속성을 채우면 된다</li>
+ *   <li>쿼리스트링은 기본으로 기록하지 않고(민감 파라미터 유출 방지), 제외 패턴은 Ant 형식(애플리케이션 내 경로 기준)</li>
+ *   <li>기록 실패는 요청 처리에 전파되지 않는다</li>
+ * </ul>
+ *
+ * <p>빈으로 등록해야 동작한다. 전용 로거를 별도 파일로 나누려면 로깅 설정에 {@value #LOGGER_NAME} 이름의 Logger 를 추가한다.</p>
+ *
+ * <pre>
+ * &#64;Bean
+ * public EgovReactiveWebAccessLogFilter webAccessLogFilter() {
+ *     EgovReactiveWebAccessLogFilter filter = new EgovReactiveWebAccessLogFilter();
+ *     filter.setExcludePathPatterns(List.of("/css/**", "/actuator/**"));
+ *     return filter;
+ * }
+ * </pre>
+ *
+ * @author 실행환경 개발팀
+ * @since 5.1
+ * @version 1.0
+ * <pre>
+ * 개정이력(Modification Information)
+ *
+ * 수정일		수정자				수정내용
+ * ----------------------------------------------
+ * 2026.09.10	실행환경 개발팀		최초 생성
+ * </pre>
+ */
+public class EgovReactiveWebAccessLogFilter implements WebFilter, Ordered {
+
+    /** 전용 로거(채널) 이름. */
+    public static final String LOGGER_NAME = "EGOV_WEB_ACCESS";
+
+    /** exchange 속성 — 요청 식별자(없으면 {@code ServerHttpRequest.getId()}). */
+    public static final String ATTR_REQUEST_ID = EgovReactiveWebAccessLogFilter.class.getName() + ".requestId";
+
+    /** exchange 속성 — 클라이언트 IP(없으면 원격 주소). */
+    public static final String ATTR_CLIENT_IP = EgovReactiveWebAccessLogFilter.class.getName() + ".clientIp";
+
+    /** exchange 속성 — 사용자 식별자(없으면 {@code -}). */
+    public static final String ATTR_USER_ID = EgovReactiveWebAccessLogFilter.class.getName() + ".userId";
+
+    /** 기본 순서 — 가장 바깥쪽에 가깝게 두어 안쪽 필터에서 끝난 요청도 기록한다. */
+    public static final int DEFAULT_ORDER = Ordered.HIGHEST_PRECEDENCE + 10;
+
+    /** 기본 제외 패턴 — 정적 자원·모니터링 경로. */
+    public static final List<String> DEFAULT_EXCLUDE_PATTERNS = List.of(
+            "/css/**", "/js/**", "/images/**", "/webjars/**", "/actuator/**", "/favicon.ico");
+
+    private static final Logger ACCESS = LoggerFactory.getLogger(LOGGER_NAME);
+    private static final Logger LOGGER = LoggerFactory.getLogger(EgovReactiveWebAccessLogFilter.class);
+    private static final String NONE = "-";
+
+    private final PathMatcher pathMatcher = new AntPathMatcher();
+    private List<String> excludePathPatterns = DEFAULT_EXCLUDE_PATTERNS;
+    private boolean includeQueryString;
+    private int order = DEFAULT_ORDER;
+
+    /**
+     * 제외 경로 패턴(Ant 형식, 애플리케이션 내 경로 기준). null 이면 제외 없음.
+     *
+     * @param patterns 제외 패턴 목록
+     */
+    public void setExcludePathPatterns(List<String> patterns) {
+        this.excludePathPatterns = (patterns == null) ? Collections.emptyList() : List.copyOf(patterns);
+    }
+
+    /**
+     * 쿼리스트링을 경로에 덧붙여 기록할지 여부(기본 false).
+     *
+     * @param includeQueryString true 면 {@code uri=/path?query} 로 기록
+     */
+    public void setIncludeQueryString(boolean includeQueryString) {
+        this.includeQueryString = includeQueryString;
+    }
+
+    public void setOrder(int order) {
+        this.order = order;
+    }
+
+    @Override
+    public int getOrder() {
+        return order;
+    }
+
+    @Override
+    public Mono<Void> filter(ServerWebExchange exchange, WebFilterChain chain) {
+        if (isExcluded(exchange)) {
+            return chain.filter(exchange);
+        }
+        long started = System.nanoTime();
+        AtomicReference<Throwable> error = new AtomicReference<>();
+        return chain.filter(exchange)
+                .doOnError(error::set)
+                .doFinally(signal -> record(exchange, started, error.get()));
+    }
+
+    private boolean isExcluded(ServerWebExchange exchange) {
+        if (excludePathPatterns.isEmpty()) {
+            return false;
+        }
+        String path = exchange.getRequest().getPath().pathWithinApplication().value();
+        for (String pattern : excludePathPatterns) {
+            if (pathMatcher.match(pattern, path)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private void record(ServerWebExchange exchange, long started, Throwable error) {
+        try {
+            long elapsedMs = (System.nanoTime() - started) / 1_000_000L;
+            HttpStatusCode code = exchange.getResponse().getStatusCode();
+            String status = (code != null) ? String.valueOf(code.value()) : (error != null ? "500" : NONE);
+            String uri = exchange.getRequest().getPath().value();
+            String query = exchange.getRequest().getURI().getRawQuery();
+            if (includeQueryString && query != null && !query.isEmpty()) {
+                uri = uri + "?" + query;
+            }
+            StringBuilder line = new StringBuilder(160)
+                    .append("method=").append(exchange.getRequest().getMethod())
+                    .append(" uri=").append(uri)
+                    .append(" status=").append(status)
+                    .append(" elapsedMs=").append(elapsedMs)
+                    .append(" requestId=").append(attribute(exchange, ATTR_REQUEST_ID, exchange.getRequest().getId()))
+                    .append(" clientIp=").append(attribute(exchange, ATTR_CLIENT_IP, remoteHost(exchange)))
+                    .append(" userId=").append(attribute(exchange, ATTR_USER_ID, NONE));
+            if (error != null) {
+                line.append(" error=").append(error.getClass().getSimpleName());
+            }
+            boolean failed = error != null || (code != null && code.is5xxServerError());
+            emit(failed, line.toString());
+        } catch (RuntimeException e) {
+            // 접근 기록 실패가 요청 처리에 새지 않도록 격리한다
+            LOGGER.debug("Failed to write web access log", e);
+        }
+    }
+
+    /**
+     * 발신 지점 — 기본은 전용 로거(정상 INFO, 오류·5xx WARN). 다른 파이프라인으로 보내려면 오버라이드한다.
+     *
+     * @param failed 오류 또는 5xx 로 끝났으면 true
+     * @param line   접근로그 1줄
+     */
+    protected void emit(boolean failed, String line) {
+        if (failed) {
+            ACCESS.warn(line);
+        } else {
+            ACCESS.info(line);
+        }
+    }
+
+    private static String attribute(ServerWebExchange exchange, String name, String fallback) {
+        Object value = exchange.getAttributes().get(name);
+        if (value == null) {
+            return (fallback == null || fallback.isEmpty()) ? NONE : fallback;
+        }
+        return Objects.toString(value);
+    }
+
+    private static String remoteHost(ServerWebExchange exchange) {
+        InetSocketAddress remote = exchange.getRequest().getRemoteAddress();
+        if (remote == null) {
+            return NONE;
+        }
+        InetAddress address = remote.getAddress();
+        return (address != null) ? address.getHostAddress() : remote.getHostString();
+    }
+
+}

--- a/Foundation/org.egovframe.rte.fdl.reactive/src/test/java/org/egovframe/rte/fdl/reactive/logging/EgovReactiveWebAccessLogFilterTest.java
+++ b/Foundation/org.egovframe.rte.fdl.reactive/src/test/java/org/egovframe/rte/fdl/reactive/logging/EgovReactiveWebAccessLogFilterTest.java
@@ -1,0 +1,136 @@
+package org.egovframe.rte.fdl.reactive.logging;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
+import org.springframework.mock.web.server.MockServerWebExchange;
+import org.springframework.web.server.WebFilterChain;
+import reactor.core.publisher.Mono;
+
+import java.net.InetSocketAddress;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * EgovReactiveWebAccessLogFilter 의 접근로그 1줄 형식, 오류·5xx 처리, 제외 패턴, 속성 폴백, 기록 실패 격리를 검증한다.
+ */
+public class EgovReactiveWebAccessLogFilterTest {
+
+    static class CapturingFilter extends EgovReactiveWebAccessLogFilter {
+        final List<String> lines = new ArrayList<>();
+        final List<Boolean> failed = new ArrayList<>();
+
+        @Override
+        protected void emit(boolean isFailed, String line) {
+            failed.add(isFailed);
+            lines.add(line);
+        }
+    }
+
+    private static final WebFilterChain OK = exchange -> {
+        exchange.getResponse().setStatusCode(HttpStatus.OK);
+        return Mono.empty();
+    };
+
+    @Test
+    public void testNormalRequestIsRecordedAsOneLineWithAttributes() {
+        CapturingFilter filter = new CapturingFilter();
+        MockServerWebExchange exchange = MockServerWebExchange.from(MockServerHttpRequest.get("/api/list"));
+        exchange.getAttributes().put(EgovReactiveWebAccessLogFilter.ATTR_REQUEST_ID, "req-1");
+        exchange.getAttributes().put(EgovReactiveWebAccessLogFilter.ATTR_CLIENT_IP, "10.0.0.9");
+        exchange.getAttributes().put(EgovReactiveWebAccessLogFilter.ATTR_USER_ID, "hong");
+
+        filter.filter(exchange, OK).block();
+
+        assertEquals(1, filter.lines.size());
+        String line = filter.lines.get(0);
+        assertTrue(line.startsWith("method=GET uri=/api/list status=200 elapsedMs="), line);
+        assertTrue(line.endsWith(" requestId=req-1 clientIp=10.0.0.9 userId=hong"), line);
+        assertEquals(false, filter.failed.get(0));
+    }
+
+    @Test
+    public void testFailedRequestIsRecordedWithStatus500AndErrorThenPropagated() {
+        CapturingFilter filter = new CapturingFilter();
+        MockServerWebExchange exchange = MockServerWebExchange.from(MockServerHttpRequest.get("/api/fail"));
+
+        assertThrows(IllegalStateException.class,
+                () -> filter.filter(exchange, ex -> Mono.error(new IllegalStateException("boom"))).block());
+
+        assertEquals(1, filter.lines.size());
+        String line = filter.lines.get(0);
+        assertTrue(line.contains("uri=/api/fail status=500"), line);
+        assertTrue(line.endsWith(" error=IllegalStateException"), line);
+        assertEquals(true, filter.failed.get(0));
+    }
+
+    @Test
+    public void testServerErrorStatusIsMarkedFailed() {
+        CapturingFilter filter = new CapturingFilter();
+        MockServerWebExchange exchange = MockServerWebExchange.from(MockServerHttpRequest.post("/api/busy"));
+
+        filter.filter(exchange, ex -> {
+            ex.getResponse().setStatusCode(HttpStatus.SERVICE_UNAVAILABLE);
+            return Mono.empty();
+        }).block();
+
+        assertTrue(filter.lines.get(0).startsWith("method=POST uri=/api/busy status=503 "), filter.lines.get(0));
+        assertFalse(filter.lines.get(0).contains(" error="), filter.lines.get(0));
+        assertEquals(true, filter.failed.get(0));
+    }
+
+    @Test
+    public void testQueryStringIsOmittedByDefaultAndExcludedPathsAreNotRecorded() {
+        CapturingFilter filter = new CapturingFilter();
+        filter.filter(MockServerWebExchange.from(MockServerHttpRequest.get("/api/search?rrn=900101-1234567")), OK).block();
+        assertFalse(filter.lines.get(0).contains("rrn="), filter.lines.get(0));
+
+        CapturingFilter verbose = new CapturingFilter();
+        verbose.setIncludeQueryString(true);
+        verbose.filter(MockServerWebExchange.from(MockServerHttpRequest.get("/api/search?rrn=1")), OK).block();
+        assertTrue(verbose.lines.get(0).contains(" uri=/api/search?rrn=1 "), verbose.lines.get(0));
+
+        CapturingFilter excluded = new CapturingFilter();
+        excluded.filter(MockServerWebExchange.from(MockServerHttpRequest.get("/css/site.css")), OK).block();
+        excluded.filter(MockServerWebExchange.from(MockServerHttpRequest.get("/actuator/health")), OK).block();
+        assertTrue(excluded.lines.isEmpty(), "excluded: " + excluded.lines);
+
+        CapturingFilter none = new CapturingFilter();
+        none.setExcludePathPatterns(null);
+        none.filter(MockServerWebExchange.from(MockServerHttpRequest.get("/css/site.css")), OK).block();
+        assertEquals(1, none.lines.size());
+    }
+
+    @Test
+    public void testFallsBackToRequestIdAndRemoteAddressWhenAttributesAreAbsent() {
+        CapturingFilter filter = new CapturingFilter();
+        MockServerWebExchange exchange = MockServerWebExchange.from(MockServerHttpRequest.get("/api/secure")
+                .remoteAddress(new InetSocketAddress("192.168.1.7", 45678)));
+
+        filter.filter(exchange, OK).block();
+
+        String line = filter.lines.get(0);
+        assertTrue(line.endsWith(" requestId=" + exchange.getRequest().getId() + " clientIp=192.168.1.7 userId=-"), line);
+    }
+
+    @Test
+    public void testRecordingFailureDoesNotAffectTheRequest() {
+        EgovReactiveWebAccessLogFilter broken = new EgovReactiveWebAccessLogFilter() {
+            @Override
+            protected void emit(boolean failed, String line) {
+                throw new IllegalStateException("appender down");
+            }
+        };
+        MockServerWebExchange exchange = MockServerWebExchange.from(MockServerHttpRequest.get("/api/ok"));
+
+        broken.filter(exchange, OK).block();
+
+        assertEquals(HttpStatus.OK, exchange.getResponse().getStatusCode());
+    }
+
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [ ] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [X] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

### 배경

리액티브(WebFlux) 스택에는 요청 1건마다 메서드·경로·상태·소요시간을 한 줄로 남기는 접근로그 필터가 없습니다.
애플리케이션마다 따로 만들거나 빠뜨리고, 만들더라도 오류·취소로 끝난 요청이 빠지거나 쿼리스트링의 민감 파라미터가
그대로 로그에 실리는 경우가 흔합니다.

### 추가한 것

**`logging/EgovReactiveWebAccessLogFilter`** — `WebFilter` + `Ordered`

```
method=GET uri=/api/list status=200 elapsedMs=12 requestId=… clientIp=… userId=- [error=SimpleName]
```

| 항목 | 내용 |
|---|---|
| 기록 시점 | `doFinally` — 오류·취소로 끝난 요청도 남는다. 오류는 status 500 과 `error=` 로 표시, 정상 INFO · 오류/5xx WARN |
| 채널 | 전용 로거 `EGOV_WEB_ACCESS`. 별도 파일로 나누려면 로깅 설정에 이 이름의 Logger 를 추가 |
| requestId·clientIp·userId | exchange 속성(`ATTR_REQUEST_ID`·`ATTR_CLIENT_IP`·`ATTR_USER_ID`)이 있으면 그 값, 없으면 `ServerHttpRequest.getId()`·원격 주소·`-`. 게이트웨이 식별자·프록시 헤더를 해석하는 필터가 있으면 이 필터보다 안쪽에 두고 속성을 채우면 된다 |
| 쿼리스트링 | 기본 비기록(`setIncludeQueryString(true)` 로 켬) |
| 제외 패턴 | Ant 형식, 기본 `/css/**`·`/js/**`·`/images/**`·`/webjars/**`·`/actuator/**`·`/favicon.ico` |
| 실패 격리 | 기록 실패는 요청 처리에 전파되지 않는다. 발신 지점 `emit(boolean failed, String line)` 은 protected 라 다른 파이프라인으로 보낼 수 있다 |

```java
@Bean
public EgovReactiveWebAccessLogFilter webAccessLogFilter() {
    EgovReactiveWebAccessLogFilter filter = new EgovReactiveWebAccessLogFilter();
    filter.setExcludePathPatterns(List.of("/css/**", "/actuator/**"));
    return filter;
}
```

### 설계 메모

- **기존 클래스는 수정하지 않았고 의존도 추가하지 않았습니다.** 빈으로 등록해야 동작하므로 등록하지 않은 애플리케이션에는
  아무 영향이 없습니다.
- 기본 순서는 `HIGHEST_PRECEDENCE + 10` 으로 가장 바깥쪽에 가깝게 두어 안쪽 필터에서 끝난 요청(인증 거부 등)도 기록됩니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

`EgovReactiveWebAccessLogFilterTest` **6건 신규**(`MockServerWebExchange` 사용, 추가 테스트 의존 없음), `fdl.reactive` 모듈 전건 통과.

| 환경 | 기본 로케일(Locale) | 모듈 실행 건수 | 결과 |
|---|---|---:|---|
| **Windows** | ko_KR | **9** | `Tests run: 9, Failures: 0, Errors: 0, Skipped: 0` |
| **Linux** (Ubuntu 22.04 / OpenJDK 17) | C.UTF-8 | **9** | `Tests run: 9, Failures: 0, Errors: 0, Skipped: 0` |

| 구분 | 건수 | 내용 |
|---|---:|---|
| 형식 | 1 | 정상 요청 1줄 — 항목 순서와 속성 값(requestId·clientIp·userId) |
| 오류·5xx | 2 | 오류로 끝난 요청은 status 500 + `error=` 로 남고 오류는 그대로 전파 · 503 응답은 WARN 판정, `error=` 없음 |
| 경로 | 1 | 쿼리스트링 기본 비기록, 켜면 기록 · 기본 제외 패턴 무기록 · 제외 패턴 null 이면 모두 기록 |
| 폴백 | 1 | 속성이 없으면 `ServerHttpRequest.getId()` 와 원격 주소, userId `-` |
| 격리 | 1 | `emit` 이 예외를 던져도 요청은 정상 완료(200) |

**수동 확인**: 현재 `main`(`cc2b332`) 위에서 `fdl.reactive` 모듈 빌드·테스트가 통과함을 Windows 와 Linux 에서 확인했습니다.

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

해당 없음 — 라이브러리 클래스 추가입니다.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

해당 없음 — 위 JUnit 테스트 결과로 갈음합니다.

---

<sub>base: `eGovFramework:main` @ `cc2b332` (2026-09-10 fetch 기준, #366~#379 머지 후) · 단일 커밋</sub>
