### PR TITLE
feat: 페이징 라벨을 MessageSource 로 가져오는 MessageSourcePaginationRenderer 추가

### DIFF
--- a/Presentation/org.egovframe.rte.ptl.mvc/src/main/java/org/egovframe/rte/ptl/mvc/tags/ui/pagination/AbstractPaginationRenderer.java
+++ b/Presentation/org.egovframe.rte.ptl.mvc/src/main/java/org/egovframe/rte/ptl/mvc/tags/ui/pagination/AbstractPaginationRenderer.java
@@ -45,6 +45,7 @@ import java.text.MessageFormat;
  * 수정일		수정자				수정내용
  * ----------------------------------------------
  * 2009.05.30	함철				최초 생성
+ * 2026.09.10	실행환경 개발팀		라벨 setter 와 라벨 파라미터형 doRender() 추가(로케일별 라벨 렌더러 지원)
  * </pre>
  * @since 2009.06.01
  */
@@ -57,7 +58,42 @@ public abstract class AbstractPaginationRenderer implements PaginationRenderer {
     protected String nextPageLabel;
     protected String lastPageLabel;
 
+    public void setFirstPageLabel(String firstPageLabel) {
+        this.firstPageLabel = firstPageLabel;
+    }
+
+    public void setPreviousPageLabel(String previousPageLabel) {
+        this.previousPageLabel = previousPageLabel;
+    }
+
+    public void setCurrentPageLabel(String currentPageLabel) {
+        this.currentPageLabel = currentPageLabel;
+    }
+
+    public void setOtherPageLabel(String otherPageLabel) {
+        this.otherPageLabel = otherPageLabel;
+    }
+
+    public void setNextPageLabel(String nextPageLabel) {
+        this.nextPageLabel = nextPageLabel;
+    }
+
+    public void setLastPageLabel(String lastPageLabel) {
+        this.lastPageLabel = lastPageLabel;
+    }
+
     public String renderPagination(PaginationInfo paginationInfo, String jsFunction) {
+        return doRender(paginationInfo, jsFunction,
+                firstPageLabel, previousPageLabel, currentPageLabel, otherPageLabel, nextPageLabel, lastPageLabel);
+    }
+
+    /**
+     * 라벨 템플릿을 파라미터로 받아 렌더링한다.
+     * 요청 로케일(Locale)마다 라벨이 달라지는 렌더러가 공유 필드를 바꾸지 않고(스레드 안전) 재사용하는 렌더링 지점이다.
+     */
+    protected String doRender(PaginationInfo paginationInfo, String jsFunction,
+            String firstPageLabel, String previousPageLabel, String currentPageLabel,
+            String otherPageLabel, String nextPageLabel, String lastPageLabel) {
 
         StringBuilder stringBuilder = new StringBuilder();
 

--- a/Presentation/org.egovframe.rte.ptl.mvc/src/main/java/org/egovframe/rte/ptl/mvc/tags/ui/pagination/MessageSourcePaginationRenderer.java
+++ b/Presentation/org.egovframe.rte.ptl.mvc/src/main/java/org/egovframe/rte/ptl/mvc/tags/ui/pagination/MessageSourcePaginationRenderer.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2009-2026 MOIS(Ministry of the Interior and Safety).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.egovframe.rte.ptl.mvc.tags.ui.pagination;
+
+import org.springframework.context.MessageSource;
+import org.springframework.context.MessageSourceAware;
+import org.springframework.context.i18n.LocaleContextHolder;
+
+import java.util.Locale;
+
+/**
+ * MessageSource 로 라벨을 가져오는 다국어 페이징 렌더러.
+ *
+ * <p>기존 렌더러는 [처음]/[이전]/[다음]/[마지막] 라벨이 한국어로 고정되어 다국어 화면에서 바꿀 수 없다. 이 렌더러는 요청
+ * 로케일(Locale)({@link LocaleContextHolder}) 기준으로 {@link MessageSource} 에서 라벨 문구를 가져오고, 메시지가 없으면
+ * 기존 한국어 라벨로 돌아간다. 라벨은 렌더링 시점에 지역 변수로만 다루므로 스레드 안전하다.</p>
+ *
+ * <p>메시지 키: {@value #KEY_FIRST}, {@value #KEY_PREVIOUS}, {@value #KEY_NEXT}, {@value #KEY_LAST}</p>
+ *
+ * <pre>
+ * &lt;bean id="imageRenderer" class="org.egovframe.rte.ptl.mvc.tags.ui.pagination.MessageSourcePaginationRenderer"/&gt;
+ * &lt;!-- messages_en.properties: pagination.link.first=First ... --&gt;
+ * </pre>
+ *
+ * @author 실행환경 개발팀
+ * @since 5.1
+ * @version 1.0
+ * <pre>
+ * 개정이력(Modification Information)
+ *
+ * 수정일		수정자				수정내용
+ * ----------------------------------------------
+ * 2026.09.10	실행환경 개발팀		최초 생성
+ * </pre>
+ */
+public class MessageSourcePaginationRenderer extends AbstractPaginationRenderer implements MessageSourceAware {
+
+    /** 처음 페이지 라벨 메시지 키 */
+    public static final String KEY_FIRST = "pagination.link.first";
+    /** 이전 페이지 라벨 메시지 키 */
+    public static final String KEY_PREVIOUS = "pagination.link.previous";
+    /** 다음 페이지 라벨 메시지 키 */
+    public static final String KEY_NEXT = "pagination.link.next";
+    /** 마지막 페이지 라벨 메시지 키 */
+    public static final String KEY_LAST = "pagination.link.last";
+
+    private static final String DEFAULT_FIRST = "처음";
+    private static final String DEFAULT_PREVIOUS = "이전";
+    private static final String DEFAULT_NEXT = "다음";
+    private static final String DEFAULT_LAST = "마지막";
+
+    private MessageSource messageSource;
+
+    public MessageSourcePaginationRenderer() {
+        firstPageLabel = linkTemplate(DEFAULT_FIRST);
+        previousPageLabel = linkTemplate(DEFAULT_PREVIOUS);
+        currentPageLabel = "<strong>{0}</strong>&#160;";
+        otherPageLabel = "<a href=\"#\" onclick=\"{0}({1}); return false;\">{2}</a>&#160;";
+        nextPageLabel = linkTemplate(DEFAULT_NEXT);
+        lastPageLabel = linkTemplate(DEFAULT_LAST);
+    }
+
+    @Override
+    public void setMessageSource(MessageSource messageSource) {
+        this.messageSource = messageSource;
+    }
+
+    @Override
+    public String renderPagination(PaginationInfo paginationInfo, String jsFunction) {
+        if (messageSource == null) {
+            return super.renderPagination(paginationInfo, jsFunction);
+        }
+        Locale locale = LocaleContextHolder.getLocale();
+        String first = messageSource.getMessage(KEY_FIRST, null, DEFAULT_FIRST, locale);
+        String previous = messageSource.getMessage(KEY_PREVIOUS, null, DEFAULT_PREVIOUS, locale);
+        String next = messageSource.getMessage(KEY_NEXT, null, DEFAULT_NEXT, locale);
+        String last = messageSource.getMessage(KEY_LAST, null, DEFAULT_LAST, locale);
+        return doRender(paginationInfo, jsFunction,
+                linkTemplate(first), linkTemplate(previous), currentPageLabel, otherPageLabel,
+                linkTemplate(next), linkTemplate(last));
+    }
+
+    private static String linkTemplate(String labelText) {
+        return "<a href=\"#\" onclick=\"{0}({1}); return false;\">[" + escapeForMessageFormat(labelText) + "]</a>&#160;";
+    }
+
+    /**
+     * 라벨 문구를 MessageFormat 템플릿에 안전하게 넣는다(작은따옴표·중괄호 이스케이프).
+     */
+    private static String escapeForMessageFormat(String text) {
+        if (text == null) {
+            return "";
+        }
+        return text.replace("'", "''").replace("{", "'{'").replace("}", "'}'");
+    }
+
+}

--- a/Presentation/org.egovframe.rte.ptl.mvc/src/test/java/org/egovframe/rte/ptl/mvc/tags/ui/pagination/MessageSourcePaginationRendererTest.java
+++ b/Presentation/org.egovframe.rte.ptl.mvc/src/test/java/org/egovframe/rte/ptl/mvc/tags/ui/pagination/MessageSourcePaginationRendererTest.java
@@ -1,0 +1,115 @@
+package org.egovframe.rte.ptl.mvc.tags.ui.pagination;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.i18n.LocaleContextHolder;
+import org.springframework.context.support.StaticMessageSource;
+
+import java.util.Locale;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * MessageSourcePaginationRenderer 의 로케일별 라벨 조회·폴백과 AbstractPaginationRenderer 의 라벨 setter 를 검증한다.
+ */
+public class MessageSourcePaginationRendererTest {
+
+    @AfterEach
+    public void resetLocale() {
+        LocaleContextHolder.resetLocaleContext();
+    }
+
+    private PaginationInfo paginationInfo() {
+        PaginationInfo paginationInfo = new PaginationInfo();
+        paginationInfo.setCurrentPageNo(15);
+        paginationInfo.setRecordCountPerPage(10);
+        paginationInfo.setPageSize(10);
+        paginationInfo.setTotalRecordCount(500);
+        return paginationInfo;
+    }
+
+    private static StaticMessageSource englishMessages() {
+        StaticMessageSource messageSource = new StaticMessageSource();
+        messageSource.addMessage(MessageSourcePaginationRenderer.KEY_FIRST, Locale.ENGLISH, "First");
+        messageSource.addMessage(MessageSourcePaginationRenderer.KEY_PREVIOUS, Locale.ENGLISH, "Prev");
+        messageSource.addMessage(MessageSourcePaginationRenderer.KEY_NEXT, Locale.ENGLISH, "Next");
+        messageSource.addMessage(MessageSourcePaginationRenderer.KEY_LAST, Locale.ENGLISH, "Last");
+        return messageSource;
+    }
+
+    @Test
+    public void testLabelsAreResolvedFromMessageSourceForTheRequestLocale() {
+        MessageSourcePaginationRenderer renderer = new MessageSourcePaginationRenderer();
+        renderer.setMessageSource(englishMessages());
+        LocaleContextHolder.setLocale(Locale.ENGLISH);
+
+        String rendered = renderer.renderPagination(paginationInfo(), "goPage");
+
+        assertTrue(rendered.contains("[First]"), rendered);
+        assertTrue(rendered.contains("[Prev]"), rendered);
+        assertTrue(rendered.contains("[Next]"), rendered);
+        assertTrue(rendered.contains("[Last]"), rendered);
+        assertFalse(rendered.contains("[처음]"), rendered);
+        assertTrue(rendered.contains("goPage(1)"), rendered);
+        assertTrue(rendered.contains("<strong>15</strong>"), rendered);
+    }
+
+    @Test
+    public void testRenderingIsIdenticalToDefaultRendererForKoreanLocale() {
+        MessageSourcePaginationRenderer renderer = new MessageSourcePaginationRenderer();
+        renderer.setMessageSource(englishMessages());
+        LocaleContextHolder.setLocale(Locale.KOREAN);
+
+        assertEquals(new DefaultPaginationRenderer().renderPagination(paginationInfo(), "goPage"),
+                renderer.renderPagination(paginationInfo(), "goPage"));
+    }
+
+    @Test
+    public void testFallsBackToKoreanDefaultsWhenMessageIsMissing() {
+        MessageSourcePaginationRenderer renderer = new MessageSourcePaginationRenderer();
+        renderer.setMessageSource(new StaticMessageSource());
+        LocaleContextHolder.setLocale(Locale.FRENCH);
+
+        String rendered = renderer.renderPagination(paginationInfo(), "goPage");
+
+        assertTrue(rendered.contains("[처음]"), rendered);
+        assertTrue(rendered.contains("[마지막]"), rendered);
+    }
+
+    @Test
+    public void testWorksWithoutMessageSource() {
+        MessageSourcePaginationRenderer renderer = new MessageSourcePaginationRenderer();
+
+        String rendered = renderer.renderPagination(paginationInfo(), "goPage");
+
+        assertTrue(rendered.contains("[처음]"), rendered);
+        assertTrue(rendered.contains("[다음]"), rendered);
+    }
+
+    @Test
+    public void testLabelTextWithMessageFormatSpecialCharactersIsRenderedLiterally() {
+        StaticMessageSource messageSource = new StaticMessageSource();
+        messageSource.addMessage(MessageSourcePaginationRenderer.KEY_NEXT, Locale.FRENCH, "Suivant {1} d'accord");
+        MessageSourcePaginationRenderer renderer = new MessageSourcePaginationRenderer();
+        renderer.setMessageSource(messageSource);
+        LocaleContextHolder.setLocale(Locale.FRENCH);
+
+        String rendered = renderer.renderPagination(paginationInfo(), "goPage");
+
+        assertTrue(rendered.contains("[Suivant {1} d'accord]"), rendered);
+    }
+
+    @Test
+    public void testLabelSettersAllowCustomizationOfExistingRenderers() {
+        DefaultPaginationRenderer renderer = new DefaultPaginationRenderer();
+        renderer.setFirstPageLabel("<a href=\"#\" onclick=\"{0}({1}); return false;\">&lt;&lt;</a>");
+
+        String rendered = renderer.renderPagination(paginationInfo(), "goPage");
+
+        assertTrue(rendered.contains("&lt;&lt;"), rendered);
+        assertFalse(rendered.contains("[처음]"), rendered);
+    }
+
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [ ] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [X] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

### 배경

페이징 렌더러의 [처음]/[이전]/[다음]/[마지막] 라벨은 `DefaultPaginationRenderer` 생성자에 한국어로 고정되어 있어
다국어 화면에서 로케일(Locale)에 맞게 바꿀 수 없습니다. 라벨 템플릿을 바꾸려면 렌더러를 상속해 protected 필드를 덮어써야
하고, 렌더러는 싱글톤 빈이라 요청마다 라벨을 바꾸는 방식은 스레드 안전하지 않습니다.

### 변경한 것

**1. `pagination/MessageSourcePaginationRenderer` 신규** — `AbstractPaginationRenderer` + `MessageSourceAware`

| 항목 | 내용 |
|---|---|
| 라벨 조회 | 요청 로케일(`LocaleContextHolder`) 기준으로 `MessageSource` 에서 `pagination.link.first` / `.previous` / `.next` / `.last` 를 가져온다 |
| 폴백 | 메시지가 없거나 `MessageSource` 가 주입되지 않으면 기존 한국어 라벨과 같은 결과 |
| 안전 | 라벨 문구의 작은따옴표·중괄호는 `MessageFormat` 에 안전하게 이스케이프. 라벨은 렌더링 시점의 지역 변수로만 다룬다 |

```xml
<bean id="imageRenderer" class="org.egovframe.rte.ptl.mvc.tags.ui.pagination.MessageSourcePaginationRenderer"/>
```
```properties
# messages_en.properties
pagination.link.first=First
pagination.link.previous=Prev
pagination.link.next=Next
pagination.link.last=Last
```

**2. `AbstractPaginationRenderer` — 라벨 setter 6종 + `protected doRender(...)`**

`renderPagination()` 은 이제 필드 6개를 넘겨 `doRender()` 를 호출합니다. 출력은 그대로이며, 로케일마다 라벨이 달라지는
렌더러가 공유 필드를 바꾸지 않고 렌더링할 수 있는 지점입니다. setter 는 XML 설정으로 기존 렌더러의 라벨 템플릿을 바꿀 수
있게 합니다(상속 불필요).

### 호환성

- **기존 렌더러의 출력은 동일합니다.** 한국어 로케일에서 새 렌더러의 출력이 `DefaultPaginationRenderer` 와 완전히 같음을
  테스트로 확인했습니다.
- `renderPagination()` 을 오버라이드한 하위 클래스가 있어도 그 오버라이드가 그대로 적용됩니다.
- `AbstractKrdsPaginationRenderer` 는 별개 계층(`PaginationRenderer` 직접 구현)이라 건드리지 않았습니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

`MessageSourcePaginationRendererTest` **6건 신규**, `ptl.mvc` 모듈 전건 통과.

| 환경 | 기본 로케일 | 모듈 실행 건수 | 결과 |
|---|---|---:|---|
| **Windows** | ko_KR | **48** | `Tests run: 48, Failures: 0, Errors: 0, Skipped: 0` |
| **Linux** (Ubuntu 22.04 / OpenJDK 17) | C.UTF-8 | **48** | `Tests run: 48, Failures: 0, Errors: 0, Skipped: 0` |

| 구분 | 건수 | 내용 |
|---|---:|---|
| 로케일 조회 | 1 | 영어 로케일에서 First/Prev/Next/Last 로 렌더링, 한국어 라벨 없음, 페이지 이동 호출·현재 페이지 표시 유지 |
| 동일성 | 1 | 한국어 로케일 출력이 `DefaultPaginationRenderer` 와 완전히 같다 |
| 폴백 | 2 | 메시지 없는 로케일은 한국어 라벨 · `MessageSource` 없이도 동작 |
| 이스케이프 | 1 | `Suivant {1} d'accord` 같은 라벨이 그대로 렌더링된다 |
| setter | 1 | `DefaultPaginationRenderer` 의 라벨 템플릿을 setter 로 교체 |

**수동 확인**: 현재 `main`(`cc2b332`) 위에서 `ptl.mvc` 모듈 빌드·테스트가 통과함을 Windows 와 Linux 에서 확인했습니다.

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

해당 없음 — 렌더링 결과 문자열은 JUnit 으로 검증했습니다.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

해당 없음 — 위 JUnit 테스트 결과로 갈음합니다.

---

<sub>base: `eGovFramework:main` @ `cc2b332` (2026-09-10 fetch 기준, #366~#379 머지 후) · 단일 커밋</sub>
