### PR TITLE
feat: 순수 한글만 판정하는 RteGenericValidator.isHangul 추가

### DIFF
--- a/Presentation/org.egovframe.rte.ptl.mvc/src/main/java/org/egovframe/rte/ptl/mvc/validation/RteGenericValidator.java
+++ b/Presentation/org.egovframe.rte.ptl.mvc/src/main/java/org/egovframe/rte/ptl/mvc/validation/RteGenericValidator.java
@@ -44,6 +44,7 @@ import java.util.regex.Pattern;
  * 2013.03.22	한성곤				패스워드 관련 점검 메소드 추가
  * 2017.02.28	장동한				시큐어코딩(ES)-오류 메시지를 통한 정보노출[CWE-209]
  * 2020.07.20	윤주호				패스워드 점검 강화 관련 메소드 수정
+ * 2026.09.10	실행환경 개발팀		순수 한글 판정 isHangul 추가, isKorean 의 판정 범위(다른 CJK 문자 통과)를 javadoc 에 명시
  * </pre>
  * @since 2009.06.01
  */
@@ -57,6 +58,8 @@ public final class RteGenericValidator implements Serializable {
     // (특수문자 집합 ~!@#$%^&*? 은 고정이므로 조합 검증 패턴도 상수다.)
     private static final String ALLOWED_SPECIAL_CHAR = "~!@#$%^&*?";
     private static final Pattern HTML_TAG_PATTERN = Pattern.compile("<[^<|>]*>");
+    /** 순수 한글(자모 ㄱ-ㅎ·ㅏ-ㅣ + 완성형 가-힣) 판정 패턴 */
+    private static final Pattern HANGUL_PATTERN = Pattern.compile("^[ㄱ-ㅎㅏ-ㅣ가-힣]*$");
     private static final Pattern MORE_THAN_2_TYPE_PATTERN =
             Pattern.compile("^(?=.*[A-Za-z])(?=.*\\d)(?=.*[" + ALLOWED_SPECIAL_CHAR + "])[A-Za-z\\d" + ALLOWED_SPECIAL_CHAR + "]+$");
     private static final Pattern MORE_THAN_3_TYPE_PATTERN =
@@ -129,6 +132,10 @@ public final class RteGenericValidator implements Serializable {
     /**
      * 한글여부 체크
      *
+     * <p><b>주의:</b> {@code Character.getType() == OTHER_LETTER} 판정이라 한자·가나 등 다른 CJK 문자도 통과한다
+     * (인명용 한자 등 기존 사용처 호환을 위해 동작은 유지한다). 순수 한글만 허용해야 하면 {@link #isHangul(String)} 을
+     * 사용하라.</p>
+     *
      * @param value
      * @return
      */
@@ -140,6 +147,21 @@ public final class RteGenericValidator implements Serializable {
             }
         }
         return true;
+    }
+
+    /**
+     * 순수 한글(자모 ㄱ-ㅎ·ㅏ-ㅣ + 완성형 가-힣)만으로 구성되었는지 검사한다.
+     * {@link #isKorean(String)} 과 달리 한자·가나 등 다른 CJK 문자는 거부한다. 빈 문자열은 {@code isKorean} 과 같이 true,
+     * null 은 false 다.
+     *
+     * @param value 검사할 문자열
+     * @return 한글 자모·완성형만으로 되어 있으면 true
+     */
+    public static boolean isHangul(String value) {
+        if (value == null) {
+            return false;
+        }
+        return HANGUL_PATTERN.matcher(value).matches();
     }
 
     /**

--- a/Presentation/org.egovframe.rte.ptl.mvc/src/test/java/org/egovframe/rte/ptl/mvc/validation/RteGenericValidatorHangulTest.java
+++ b/Presentation/org.egovframe.rte.ptl.mvc/src/test/java/org/egovframe/rte/ptl/mvc/validation/RteGenericValidatorHangulTest.java
@@ -1,0 +1,50 @@
+package org.egovframe.rte.ptl.mvc.validation;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * RteGenericValidator.isHangul 의 순수 한글 판정과 isKorean 과의 차이(다른 CJK 문자 통과)를 검증한다.
+ */
+public class RteGenericValidatorHangulTest {
+
+    @Test
+    public void testHangulSyllablesAndJamoAreAccepted() {
+        assertTrue(RteGenericValidator.isHangul("한글"));
+        assertTrue(RteGenericValidator.isHangul("가나다라"));
+        assertTrue(RteGenericValidator.isHangul("ㄱㄴㄷ"));
+        assertTrue(RteGenericValidator.isHangul("ㅏㅑㅓ"));
+        assertTrue(RteGenericValidator.isHangul("홍ㄱ길동ㅏ"));
+    }
+
+    @Test
+    public void testOtherCjkLettersAreRejectedByIsHangulButPassIsKorean() {
+        assertTrue(RteGenericValidator.isKorean("漢字"));
+        assertFalse(RteGenericValidator.isHangul("漢字"));
+
+        assertTrue(RteGenericValidator.isKorean("ひらがな"));
+        assertFalse(RteGenericValidator.isHangul("ひらがな"));
+
+        assertTrue(RteGenericValidator.isKorean("한글漢字"));
+        assertFalse(RteGenericValidator.isHangul("한글漢字"));
+    }
+
+    @Test
+    public void testAsciiDigitsSpacesAndMixedInputAreRejected() {
+        assertFalse(RteGenericValidator.isHangul("abc"));
+        assertFalse(RteGenericValidator.isHangul("한a"));
+        assertFalse(RteGenericValidator.isHangul("한글123"));
+        assertFalse(RteGenericValidator.isHangul("한 글"));
+        assertFalse(RteGenericValidator.isHangul("한글!"));
+    }
+
+    @Test
+    public void testEmptyIsTrueLikeIsKoreanAndNullIsFalse() {
+        assertTrue(RteGenericValidator.isKorean(""));
+        assertTrue(RteGenericValidator.isHangul(""));
+        assertFalse(RteGenericValidator.isHangul(null));
+    }
+
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [ ] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [X] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

### 배경

`RteGenericValidator.isKorean` 은 `Character.getType() == OTHER_LETTER` 로 판정하므로 한글뿐 아니라 **한자·가나 등 다른
CJK 문자도 통과**합니다. 인명용 한자처럼 이 동작에 기대는 사용처가 있어 바꿀 수는 없지만, 한글만 받아야 하는 입력(순수 한글
이름·검색어 등)에 쓸 판정 메서드가 없었고 javadoc 도 이 범위를 설명하지 않았습니다.

### 변경한 것

| 항목 | 내용 |
|---|---|
| `isHangul(String value)` 신규 | 자모(ㄱ-ㅎ·ㅏ-ㅣ)와 완성형(가-힣)만으로 된 문자열이면 true. 한자·가나·영숫자·공백·기호는 false. 빈 문자열은 `isKorean` 과 같이 true, null 은 false |
| `HANGUL_PATTERN` 상수 | 기존 패턴 상수들과 같이 클래스 로딩 시 1회 컴파일 |
| `isKorean` javadoc | 판정 범위(다른 CJK 문자 통과)와 `isHangul` 안내를 명시. **동작 변경 없음** |

```java
RteGenericValidator.isKorean("漢字");   // true  (기존 그대로)
RteGenericValidator.isHangul("漢字");   // false
RteGenericValidator.isHangul("홍ㄱ길동"); // true
```

### 호환성

- 기존 메서드의 시그니처·동작은 그대로입니다. 추가만 했습니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

`RteGenericValidatorHangulTest` **4건 신규**, `ptl.mvc` 모듈 전건 통과(기존 `RteGenericValidatorCoverageTest` 포함).

| 환경 | 기본 로케일(Locale) | 모듈 실행 건수 | 결과 |
|---|---|---:|---|
| **Windows** | ko_KR | **46** | `Tests run: 46, Failures: 0, Errors: 0, Skipped: 0` |
| **Linux** (Ubuntu 22.04 / OpenJDK 17) | C.UTF-8 | **46** | `Tests run: 46, Failures: 0, Errors: 0, Skipped: 0` |

| 구분 | 건수 | 내용 |
|---|---:|---|
| 통과 | 1 | 완성형·자모·혼합 한글 |
| CJK 구분 | 1 | 한자·히라가나·한글+한자는 `isKorean` 통과, `isHangul` 거부 |
| 거부 | 1 | 영문·숫자·공백·기호 혼합 |
| 경계 | 1 | 빈 문자열 true(`isKorean` 과 동일), null false |

**수동 확인**: 현재 `main`(`cc2b332`) 위에서 `ptl.mvc` 모듈 빌드·테스트가 통과함을 Windows 와 Linux 에서 확인했습니다.

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

해당 없음 — 검증 유틸 메서드 추가입니다.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

해당 없음 — 위 JUnit 테스트 결과로 갈음합니다.

---

<sub>base: `eGovFramework:main` @ `cc2b332` (2026-09-10 fetch 기준, #366~#379 머지 후) · 단일 커밋</sub>
