### PR TITLE
feat: JPA 감사 필드 기본 엔티티·소프트 삭제 계약·공통 CRUD 리포지토리 추가

### DIFF
--- a/Persistence/org.egovframe.rte.psl.data.jpa/pom.xml
+++ b/Persistence/org.egovframe.rte.psl.data.jpa/pom.xml
@@ -90,6 +90,14 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <!-- @EnableJpaAuditing(EgovBaseEntity 감사 필드)은 spring-aspects 의 AnnotationBeanConfigurerAspect 를 요구한다.
+             optional 이므로 감사 기능을 켜는 애플리케이션이 직접 추가한다. -->
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-aspects</artifactId>
+            <version>${spring.framework.version}</version>
+            <optional>true</optional>
+        </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-test</artifactId>

--- a/Persistence/org.egovframe.rte.psl.data.jpa/src/main/java/org/egovframe/rte/psl/data/jpa/entity/EgovBaseEntity.java
+++ b/Persistence/org.egovframe.rte.psl.data.jpa/src/main/java/org/egovframe/rte/psl/data/jpa/entity/EgovBaseEntity.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2009-2026 MOIS(Ministry of the Interior and Safety).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.egovframe.rte.psl.data.jpa.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import org.springframework.data.annotation.CreatedBy;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedBy;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+/**
+ * 감사 필드 공통 상위 엔티티 — 등록자·등록일시·수정자·수정일시를 자동으로 기록한다.
+ *
+ * <p>Spring Data JPA Auditing 이 저장·수정 시점에 값을 채운다. 활성화 조건:</p>
+ * <ul>
+ *   <li>구성 클래스에 {@code @EnableJpaAuditing} 선언. 이 기능은 {@code spring-aspects} 가 클래스패스에 있어야 하므로
+ *       애플리케이션 의존에 추가한다(이 모듈은 optional 로만 선언한다)</li>
+ *   <li>등록자·수정자를 쓰려면 {@code AuditorAware<String>} 빈 제공(예: 인증 사용자 ID 반환). 없으면 일시만 기록된다</li>
+ * </ul>
+ *
+ * <p>setter 를 두지 않는다. 감사 값은 {@link AuditingEntityListener} 가 채우며 업무 코드가 임의로 바꿀 수 없다.
+ * 컬럼명은 사이트 표준에 맞게 하위 엔티티에서 {@code @AttributeOverride} 로 재정의할 수 있다.</p>
+ *
+ * <pre>
+ * &#64;Entity
+ * public class Employee extends EgovBaseEntity {
+ *     &#64;Id &#64;GeneratedValue(strategy = GenerationType.IDENTITY)
+ *     private Integer id;
+ *     ...
+ * }
+ * </pre>
+ *
+ * @author 실행환경 개발팀
+ * @since 5.1
+ * @version 1.0
+ * <pre>
+ * 개정이력(Modification Information)
+ *
+ * 수정일		수정자				수정내용
+ * ----------------------------------------------
+ * 2026.09.10	실행환경 개발팀		최초 생성
+ * </pre>
+ */
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class EgovBaseEntity {
+
+    /** 등록자 */
+    @CreatedBy
+    @Column(name = "created_by", updatable = false, length = 100)
+    private String createdBy;
+
+    /** 등록일시 */
+    @CreatedDate
+    @Column(name = "created_date", updatable = false)
+    private LocalDateTime createdDate;
+
+    /** 수정자 */
+    @LastModifiedBy
+    @Column(name = "modified_by", length = 100)
+    private String modifiedBy;
+
+    /** 수정일시 */
+    @LastModifiedDate
+    @Column(name = "modified_date")
+    private LocalDateTime modifiedDate;
+
+    public String getCreatedBy() {
+        return createdBy;
+    }
+
+    public LocalDateTime getCreatedDate() {
+        return createdDate;
+    }
+
+    public String getModifiedBy() {
+        return modifiedBy;
+    }
+
+    public LocalDateTime getModifiedDate() {
+        return modifiedDate;
+    }
+
+}

--- a/Persistence/org.egovframe.rte.psl.data.jpa/src/main/java/org/egovframe/rte/psl/data/jpa/entity/EgovSoftDeletable.java
+++ b/Persistence/org.egovframe.rte.psl.data.jpa/src/main/java/org/egovframe/rte/psl/data/jpa/entity/EgovSoftDeletable.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2009-2026 MOIS(Ministry of the Interior and Safety).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.egovframe.rte.psl.data.jpa.entity;
+
+import java.time.LocalDateTime;
+
+/**
+ * 소프트 삭제(논리 삭제) 지원 엔티티 계약.
+ *
+ * <p>삭제일시가 null 이면 활성, 값이 있으면 삭제된 행으로 본다.
+ * {@code EgovCrudRepository.softDelete*}·{@code restore} 가 이 계약으로 동작한다.</p>
+ *
+ * @author 실행환경 개발팀
+ * @since 5.1
+ * @version 1.0
+ * <pre>
+ * 개정이력(Modification Information)
+ *
+ * 수정일		수정자				수정내용
+ * ----------------------------------------------
+ * 2026.09.10	실행환경 개발팀		최초 생성
+ * </pre>
+ */
+public interface EgovSoftDeletable {
+
+    /**
+     * 삭제일시(null 이면 활성)를 돌려준다.
+     *
+     * @return 삭제일시
+     */
+    LocalDateTime getDeletedDate();
+
+    /**
+     * 삭제일시를 설정한다(null 로 설정하면 복구).
+     *
+     * @param deletedDate 삭제일시
+     */
+    void setDeletedDate(LocalDateTime deletedDate);
+
+    /**
+     * 삭제 여부를 돌려준다.
+     *
+     * @return 삭제일시가 있으면 true
+     */
+    default boolean isDeleted() {
+        return getDeletedDate() != null;
+    }
+
+}

--- a/Persistence/org.egovframe.rte.psl.data.jpa/src/main/java/org/egovframe/rte/psl/data/jpa/entity/EgovSoftDeletableEntity.java
+++ b/Persistence/org.egovframe.rte.psl.data.jpa/src/main/java/org/egovframe/rte/psl/data/jpa/entity/EgovSoftDeletableEntity.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2009-2026 MOIS(Ministry of the Interior and Safety).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.egovframe.rte.psl.data.jpa.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.MappedSuperclass;
+
+import java.time.LocalDateTime;
+
+/**
+ * 감사 필드 + 소프트 삭제 공통 상위 엔티티.
+ *
+ * <p>{@link EgovBaseEntity} 의 감사 필드에 삭제일시({@code deleted_date}) 컬럼을 더한 형태다.
+ * 활성 행 조회는 리포지토리 파생 쿼리({@code findByDeletedDateIsNull()} 등)로 선언한다.</p>
+ *
+ * @author 실행환경 개발팀
+ * @since 5.1
+ * @version 1.0
+ * <pre>
+ * 개정이력(Modification Information)
+ *
+ * 수정일		수정자				수정내용
+ * ----------------------------------------------
+ * 2026.09.10	실행환경 개발팀		최초 생성
+ * </pre>
+ */
+@MappedSuperclass
+public abstract class EgovSoftDeletableEntity extends EgovBaseEntity implements EgovSoftDeletable {
+
+    /** 삭제일시(null 이면 활성) */
+    @Column(name = "deleted_date")
+    private LocalDateTime deletedDate;
+
+    @Override
+    public LocalDateTime getDeletedDate() {
+        return deletedDate;
+    }
+
+    @Override
+    public void setDeletedDate(LocalDateTime deletedDate) {
+        this.deletedDate = deletedDate;
+    }
+
+}

--- a/Persistence/org.egovframe.rte.psl.data.jpa/src/main/java/org/egovframe/rte/psl/data/jpa/repository/EgovCrudRepository.java
+++ b/Persistence/org.egovframe.rte.psl.data.jpa/src/main/java/org/egovframe/rte/psl/data/jpa/repository/EgovCrudRepository.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2009-2026 MOIS(Ministry of the Interior and Safety).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.egovframe.rte.psl.data.jpa.repository;
+
+import org.egovframe.rte.psl.data.jpa.entity.EgovSoftDeletable;
+import org.springframework.data.repository.NoRepositoryBean;
+
+import java.time.LocalDateTime;
+
+/**
+ * 소프트 삭제를 지원하는 공통 CRUD 리포지토리.
+ *
+ * <p>{@link EgovJpaRepository} 에 논리 삭제 연산을 더한다. 엔티티가 {@link EgovSoftDeletable}
+ * (예: {@code EgovSoftDeletableEntity} 상속)을 구현하면 물리 삭제 대신 삭제일시 기록으로 삭제를 표현할 수 있다.
+ * 활성 행 조회는 파생 쿼리({@code findByDeletedDateIsNull()} 등)로 선언한다.</p>
+ *
+ * <pre>
+ * public interface EmployeeRepository extends EgovCrudRepository&lt;Employee, Integer&gt; {
+ *     List&lt;Employee&gt; findByDeletedDateIsNull();   // 활성 행 목록
+ * }
+ * </pre>
+ *
+ * <p>여기서 던지는 {@code IllegalArgumentException} 은 리포지토리 프록시를 통해 호출될 때 Spring 예외 변환에 의해
+ * {@code InvalidDataAccessApiUsageException} 으로 감싸져 전파된다.</p>
+ *
+ * @param <T>  엔티티 타입
+ * @param <ID> 식별자 타입
+ * @author 실행환경 개발팀
+ * @since 5.1
+ * @version 1.0
+ * <pre>
+ * 개정이력(Modification Information)
+ *
+ * 수정일		수정자				수정내용
+ * ----------------------------------------------
+ * 2026.09.10	실행환경 개발팀		최초 생성
+ * </pre>
+ */
+@NoRepositoryBean
+public interface EgovCrudRepository<T, ID> extends EgovJpaRepository<T, ID> {
+
+    /**
+     * 엔티티를 논리 삭제한다(삭제일시 기록 후 저장).
+     *
+     * @param entity 삭제할 엔티티
+     * @return 저장된 엔티티
+     * @throws IllegalArgumentException 엔티티가 {@link EgovSoftDeletable} 이 아닌 경우
+     */
+    default <S extends T> S softDelete(S entity) {
+        requireSoftDeletable(entity).setDeletedDate(LocalDateTime.now());
+        return save(entity);
+    }
+
+    /**
+     * 식별자로 조회해 논리 삭제한다.
+     *
+     * @param id 식별자
+     * @return 저장된 엔티티
+     * @throws IllegalArgumentException 대상이 없거나 {@link EgovSoftDeletable} 이 아닌 경우
+     */
+    default T softDeleteById(ID id) {
+        T entity = findById(id).orElseThrow(
+                () -> new IllegalArgumentException("Entity to soft-delete not found: id=" + id));
+        return softDelete(entity);
+    }
+
+    /**
+     * 논리 삭제된 엔티티를 복구한다(삭제일시 제거 후 저장).
+     *
+     * @param entity 복구할 엔티티
+     * @return 저장된 엔티티
+     * @throws IllegalArgumentException 엔티티가 {@link EgovSoftDeletable} 이 아닌 경우
+     */
+    default <S extends T> S restore(S entity) {
+        requireSoftDeletable(entity).setDeletedDate(null);
+        return save(entity);
+    }
+
+    private static EgovSoftDeletable requireSoftDeletable(Object entity) {
+        if (entity instanceof EgovSoftDeletable deletable) {
+            return deletable;
+        }
+        throw new IllegalArgumentException("Entity does not implement EgovSoftDeletable: "
+                + (entity == null ? "null" : entity.getClass().getName()));
+    }
+
+}

--- a/Persistence/org.egovframe.rte.psl.data.jpa/src/test/java/org/egovframe/rte/psl/data/jpa/JpaConfiguration.java
+++ b/Persistence/org.egovframe.rte.psl.data.jpa/src/test/java/org/egovframe/rte/psl/data/jpa/JpaConfiguration.java
@@ -6,6 +6,8 @@ import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.Environment;
 import org.springframework.dao.annotation.PersistenceExceptionTranslationPostProcessor;
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseBuilder;
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseType;
@@ -14,12 +16,20 @@ import org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean;
 import org.springframework.orm.jpa.vendor.HibernateJpaVendorAdapter;
 
 import javax.sql.DataSource;
+import java.util.Optional;
 import java.util.Properties;
 
 @Configuration
 @ComponentScan(basePackages = "org.egovframe.rte.psl.data.jpa")
 @EnableJpaRepositories(basePackages = "org.egovframe.rte.psl.data.jpa")
+@EnableJpaAuditing
 public class JpaConfiguration {
+
+    /** EgovBaseEntity 감사 필드의 등록자·수정자 공급원 */
+    @Bean
+    public AuditorAware<String> auditorProvider() {
+        return () -> Optional.of("testUser");
+    }
 
     private final Environment env;
 

--- a/Persistence/org.egovframe.rte.psl.data.jpa/src/test/java/org/egovframe/rte/psl/data/jpa/crud/EgovCrudRepositoryTest.java
+++ b/Persistence/org.egovframe.rte.psl.data.jpa/src/test/java/org/egovframe/rte/psl/data/jpa/crud/EgovCrudRepositoryTest.java
@@ -1,0 +1,89 @@
+package org.egovframe.rte.psl.data.jpa.crud;
+
+import org.egovframe.rte.psl.data.jpa.JpaConfiguration;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.InvalidDataAccessApiUsageException;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * EgovBaseEntity 의 감사 필드 자동 기록과 EgovCrudRepository 의 소프트 삭제·복구를 검증한다.
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = JpaConfiguration.class)
+@Transactional
+public class EgovCrudRepositoryTest {
+
+    @Autowired
+    private EmployeeRepository repository;
+
+    @Test
+    public void testAuditFieldsAreFilledOnSave() {
+        Employee employee = repository.saveAndFlush(new Employee("홍길동", "총무과"));
+
+        assertEquals("testUser", employee.getCreatedBy());
+        assertNotNull(employee.getCreatedDate());
+        assertEquals("testUser", employee.getModifiedBy());
+        assertNotNull(employee.getModifiedDate());
+        assertNull(employee.getDeletedDate());
+        assertFalse(employee.isDeleted());
+    }
+
+    @Test
+    public void testCreatedDateIsImmutableAndModifiedDateIsRefreshedOnUpdate() {
+        Employee employee = repository.saveAndFlush(new Employee("김철수", "기획과"));
+        LocalDateTime createdDate = employee.getCreatedDate();
+
+        employee.setDept("인사과");
+        Employee updated = repository.saveAndFlush(employee);
+
+        assertEquals(createdDate, updated.getCreatedDate());
+        assertNotNull(updated.getModifiedDate());
+        assertFalse(updated.getModifiedDate().isBefore(createdDate));
+    }
+
+    @Test
+    public void testSoftDeleteHidesRowFromActiveQueryAndRestoreBringsItBack() {
+        Employee active1 = repository.save(new Employee("EMP-1", "DEV"));
+        Employee target = repository.save(new Employee("EMP-2", "DEV"));
+        Employee active2 = repository.save(new Employee("EMP-3", "OPS"));
+        repository.flush();
+
+        Employee deleted = repository.softDeleteById(target.getId());
+
+        assertTrue(deleted.isDeleted());
+        assertNotNull(deleted.getDeletedDate());
+        List<Employee> activeRows = repository.findByDeletedDateIsNull();
+        assertEquals(2, activeRows.size());
+        assertTrue(activeRows.stream().noneMatch(e -> e.getId().equals(target.getId())));
+        assertEquals(3, repository.findAll().size());
+
+        repository.restore(deleted);
+
+        assertEquals(3, repository.findByDeletedDateIsNull().size());
+        assertNotNull(active1.getId());
+        assertNotNull(active2.getId());
+    }
+
+    @Test
+    public void testSoftDeleteOfMissingIdIsReportedAsInvalidApiUsage() {
+        InvalidDataAccessApiUsageException ex = assertThrows(InvalidDataAccessApiUsageException.class,
+                () -> repository.softDeleteById(-999));
+
+        assertTrue(ex.getMostSpecificCause().getMessage().contains("-999"), ex.getMostSpecificCause().getMessage());
+    }
+
+}

--- a/Persistence/org.egovframe.rte.psl.data.jpa/src/test/java/org/egovframe/rte/psl/data/jpa/crud/Employee.java
+++ b/Persistence/org.egovframe.rte.psl.data.jpa/src/test/java/org/egovframe/rte/psl/data/jpa/crud/Employee.java
@@ -1,0 +1,56 @@
+package org.egovframe.rte.psl.data.jpa.crud;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import org.egovframe.rte.psl.data.jpa.entity.EgovSoftDeletableEntity;
+
+/**
+ * 감사 필드 + 소프트 삭제 공통 엔티티 검증용 테스트 엔티티.
+ */
+@Entity
+@Table(name = "crud_employee")
+public class Employee extends EgovSoftDeletableEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+
+    @Column(name = "name", length = 50)
+    private String name;
+
+    @Column(name = "dept", length = 50)
+    private String dept;
+
+    protected Employee() {
+    }
+
+    public Employee(String name, String dept) {
+        this.name = name;
+        this.dept = dept;
+    }
+
+    public Integer getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getDept() {
+        return dept;
+    }
+
+    public void setDept(String dept) {
+        this.dept = dept;
+    }
+
+}

--- a/Persistence/org.egovframe.rte.psl.data.jpa/src/test/java/org/egovframe/rte/psl/data/jpa/crud/EmployeeRepository.java
+++ b/Persistence/org.egovframe.rte.psl.data.jpa/src/test/java/org/egovframe/rte/psl/data/jpa/crud/EmployeeRepository.java
@@ -1,0 +1,17 @@
+package org.egovframe.rte.psl.data.jpa.crud;
+
+import org.egovframe.rte.psl.data.jpa.repository.EgovCrudRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+/**
+ * 공통 CRUD 리포지토리 검증용 — 상속 선언과 활성 행 파생 쿼리만으로 완성된다.
+ */
+@Repository
+public interface EmployeeRepository extends EgovCrudRepository<Employee, Integer> {
+
+    /** 활성(미삭제) 행 목록 */
+    List<Employee> findByDeletedDateIsNull();
+
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [ ] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [X] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

### 배경

`psl.data.jpa` 모듈은 `EgovJpaRepository` 인터페이스 하나만 제공합니다. 공공 시스템 엔티티에 거의 항상 필요한 등록자·등록일시·
수정자·수정일시 감사 필드와 논리 삭제(소프트 삭제)를 애플리케이션마다 따로 구현하고 있습니다.

### 추가한 것

| 클래스 | 내용 |
|---|---|
| `entity/EgovBaseEntity` (`@MappedSuperclass`) | `created_by`·`created_date`·`modified_by`·`modified_date` 를 Spring Data JPA Auditing(`AuditingEntityListener`)이 자동 기록. setter 없음(업무 코드가 바꿀 수 없음), 컬럼명은 `@AttributeOverride` 로 재정의 |
| `entity/EgovSoftDeletable` | 삭제일시(null 이면 활성) 기반 논리 삭제 계약. `isDeleted()` default 제공 |
| `entity/EgovSoftDeletableEntity` (`@MappedSuperclass`) | 감사 필드 + `deleted_date` |
| `repository/EgovCrudRepository` (`@NoRepositoryBean`) | `EgovJpaRepository` 에 `softDelete(entity)` / `softDeleteById(id)` / `restore(entity)` default 메서드 추가. 대상이 없거나 계약을 구현하지 않으면 `IllegalArgumentException`(리포지토리 프록시 경유 시 Spring 예외 변환으로 `InvalidDataAccessApiUsageException`) |

```java
@Entity
public class Employee extends EgovSoftDeletableEntity { @Id @GeneratedValue Integer id; ... }

public interface EmployeeRepository extends EgovCrudRepository<Employee, Integer> {
    List<Employee> findByDeletedDateIsNull();   // 활성 행 목록은 파생 쿼리로
}

@Configuration
@EnableJpaAuditing
public class JpaConfig {
    @Bean AuditorAware<String> auditorProvider() { return () -> Optional.of(currentUserId()); }
}
```

### 의존과 호환성

- **기존 클래스는 수정하지 않았습니다.** 모두 추가입니다.
- `@EnableJpaAuditing` 은 `spring-aspects`(`AnnotationBeanConfigurerAspect`)가 클래스패스에 있어야 합니다. 이 모듈은
  spring-aspects 를 **optional** 로만 선언해 **전이 의존은 바뀌지 않으며**, 감사 기능을 켜는 애플리케이션이 직접 추가합니다.
  (Spring Boot 의 data-jpa 스타터는 이를 기본 포함합니다.)
- 등록자·수정자는 `AuditorAware<String>` 빈이 있을 때만 채워지고, 없으면 일시만 기록됩니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

`EgovCrudRepositoryTest` **4건 신규**(HSQLDB 인메모리, `Employee` 픽스처, 테스트 구성에 `@EnableJpaAuditing` + `AuditorAware`),
`psl.data.jpa` 모듈 전건 통과.

| 환경 | 기본 로케일(Locale) | 모듈 실행 건수 | 결과 |
|---|---|---:|---|
| **Windows** | ko_KR | **5** | `Tests run: 5, Failures: 0, Errors: 0, Skipped: 0` |
| **Linux** (Ubuntu 22.04 / OpenJDK 17) | C.UTF-8 | **5** | `Tests run: 5, Failures: 0, Errors: 0, Skipped: 0` |

| 구분 | 건수 | 내용 |
|---|---:|---|
| 감사 기록 | 2 | 저장 시 등록자·등록일시·수정자·수정일시 기록 · 수정 시 등록일시 불변, 수정일시 갱신 |
| 소프트 삭제 | 1 | `softDeleteById` 후 활성 행 조회에서 빠지고 물리 행은 유지, `restore` 로 복귀 |
| 예외 | 1 | 없는 식별자는 `InvalidDataAccessApiUsageException`(원인 메시지에 식별자 포함) |

**수동 확인**: 현재 `main`(`cc2b332`) 위에서 `psl.data.jpa` 모듈 빌드·테스트가 통과함을 Windows 와 Linux 에서 확인했습니다.

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

해당 없음 — 영속 계층 클래스 추가입니다.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

해당 없음 — 위 JUnit 테스트 결과로 갈음합니다.

---

<sub>base: `eGovFramework:main` @ `cc2b332` (2026-09-10 fetch 기준, #366~#379 머지 후) · 단일 커밋</sub>
