### PR TITLE
feat: 배치 중복 실행·동시 실행 수를 통제하는 EgovJobExecutionPolicyLauncher 추가

### DIFF
--- a/Batch/org.egovframe.rte.bat.core/src/main/java/org/egovframe/rte/bat/core/operation/EgovBatchPolicyViolationException.java
+++ b/Batch/org.egovframe.rte.bat.core/src/main/java/org/egovframe/rte/bat/core/operation/EgovBatchPolicyViolationException.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2009-2026 MOIS(Ministry of the Interior and Safety).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.egovframe.rte.bat.core.operation;
+
+/**
+ * 배치 실행 정책(동시 실행 수 제한 등) 위반 예외.
+ *
+ * <p>{@link EgovJobExecutionPolicyLauncher} 가 정책 위반으로 실행을 거부할 때 던진다. Spring Batch 의
+ * {@code JobLauncher.run} 시그니처가 허용하는 checked 예외에 해당하지 않는 정책이므로 unchecked 로 둔다.</p>
+ *
+ * @author 실행환경 개발팀
+ * @since 5.1
+ * @version 1.0
+ * <pre>
+ * 개정이력(Modification Information)
+ *
+ * 수정일		수정자				수정내용
+ * ----------------------------------------------
+ * 2026.09.10	실행환경 개발팀		최초 생성
+ * </pre>
+ */
+public class EgovBatchPolicyViolationException extends RuntimeException {
+
+    private static final long serialVersionUID = 1L;
+
+    public EgovBatchPolicyViolationException(String message) {
+        super(message);
+    }
+
+    public EgovBatchPolicyViolationException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+}

--- a/Batch/org.egovframe.rte.bat.core/src/main/java/org/egovframe/rte/bat/core/operation/EgovJobExecutionPolicyLauncher.java
+++ b/Batch/org.egovframe.rte.bat.core/src/main/java/org/egovframe/rte/bat/core/operation/EgovJobExecutionPolicyLauncher.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright 2009-2026 MOIS(Ministry of the Interior and Safety).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.egovframe.rte.bat.core.operation;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.JobParametersInvalidException;
+import org.springframework.batch.core.explore.JobExplorer;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.batch.core.repository.JobExecutionAlreadyRunningException;
+import org.springframework.batch.core.repository.JobInstanceAlreadyCompleteException;
+import org.springframework.batch.core.repository.JobRestartException;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.Set;
+
+/**
+ * 실행 정책을 적용하는 {@link JobLauncher} 데코레이터.
+ *
+ * <p>Spring Batch 기본 동작은 <b>같은 JobInstance(같은 파라미터)</b>의 중복만 막으므로, 다른 파라미터로 같은 Job 을 동시에
+ * 또 띄우는 것은 막지 못한다. 이 데코레이터는 실행 시작 전에 {@link JobExplorer}(배치 메타테이블)를 조회해 다음 정책을
+ * 적용한다. 메타테이블을 공유하는 멀티서버 환경에서도 같은 기준으로 동작한다.</p>
+ * <ul>
+ *   <li><b>같은 Job 이름 중복 실행 차단</b>({@code blockDuplicateJobName}, 기본 true) — 위반 시 Spring Batch 표준
+ *       {@link JobExecutionAlreadyRunningException}</li>
+ *   <li><b>전체 동시 실행 Job 수 제한</b>({@code maxConcurrentJobs}, 기본 0 = 무제한) — 위반 시
+ *       {@link EgovBatchPolicyViolationException}</li>
+ *   <li><b>고아 RUNNING 무시</b>({@code staleExecutionTimeoutMillis}, 기본 0 = 사용 안 함) — 서버 다운 등으로 RUNNING 으로
+ *       남은 실행이 lastUpdated 기준 임계를 넘으면 집계에서 제외한다</li>
+ * </ul>
+ *
+ * <pre>
+ * &lt;bean id="policyJobLauncher" class="org.egovframe.rte.bat.core.operation.EgovJobExecutionPolicyLauncher"&gt;
+ *     &lt;constructor-arg ref="jobLauncher"/&gt;
+ *     &lt;constructor-arg ref="jobExplorer"/&gt;
+ *     &lt;property name="maxConcurrentJobs" value="5"/&gt;
+ *     &lt;property name="staleExecutionTimeoutMillis" value="3600000"/&gt;
+ * &lt;/bean&gt;
+ * </pre>
+ *
+ * <p>조회와 실행 사이에 다른 서버가 같은 Job 을 띄우는 경합까지 막지는 않는다. 그 수준의 배타 실행이 필요하면 DB 락 같은
+ * 별도 수단을 함께 쓴다.</p>
+ *
+ * @author 실행환경 개발팀
+ * @since 5.1
+ * @version 1.0
+ * <pre>
+ * 개정이력(Modification Information)
+ *
+ * 수정일		수정자				수정내용
+ * ----------------------------------------------
+ * 2026.09.10	실행환경 개발팀		최초 생성
+ * </pre>
+ */
+public class EgovJobExecutionPolicyLauncher implements JobLauncher {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(EgovJobExecutionPolicyLauncher.class);
+
+    private final JobLauncher delegate;
+    private final JobExplorer jobExplorer;
+
+    private boolean blockDuplicateJobName = true;
+    private int maxConcurrentJobs = 0;
+    private long staleExecutionTimeoutMillis = 0L;
+
+    /**
+     * @param delegate    실제 실행을 맡길 JobLauncher
+     * @param jobExplorer 실행 중 JobExecution 을 조회할 JobExplorer
+     * @throws IllegalArgumentException 인자가 null 인 경우
+     */
+    public EgovJobExecutionPolicyLauncher(JobLauncher delegate, JobExplorer jobExplorer) {
+        if (delegate == null || jobExplorer == null) {
+            throw new IllegalArgumentException("delegate and jobExplorer must not be null");
+        }
+        this.delegate = delegate;
+        this.jobExplorer = jobExplorer;
+    }
+
+    /**
+     * 같은 Job 이름 중복 실행 차단 여부(기본 true).
+     */
+    public void setBlockDuplicateJobName(boolean blockDuplicateJobName) {
+        this.blockDuplicateJobName = blockDuplicateJobName;
+    }
+
+    /**
+     * 전체 동시 실행 Job 수 상한(기본 0 = 무제한).
+     */
+    public void setMaxConcurrentJobs(int maxConcurrentJobs) {
+        this.maxConcurrentJobs = maxConcurrentJobs;
+    }
+
+    /**
+     * lastUpdated 가 이 시간(ms) 이상 갱신되지 않은 RUNNING 실행을 고아로 보아 집계에서 제외한다(기본 0 = 사용 안 함).
+     */
+    public void setStaleExecutionTimeoutMillis(long staleExecutionTimeoutMillis) {
+        this.staleExecutionTimeoutMillis = staleExecutionTimeoutMillis;
+    }
+
+    @Override
+    public JobExecution run(Job job, JobParameters jobParameters) throws JobExecutionAlreadyRunningException,
+            JobRestartException, JobInstanceAlreadyCompleteException, JobParametersInvalidException {
+
+        if (blockDuplicateJobName) {
+            long runningSameName = countRunning(job.getName());
+            if (runningSameName > 0) {
+                throw new JobExecutionAlreadyRunningException(
+                        "Job '" + job.getName() + "' is already running (" + runningSameName
+                                + " execution(s)); duplicate launch is blocked by policy");
+            }
+        }
+
+        if (maxConcurrentJobs > 0) {
+            long totalRunning = 0;
+            for (String jobName : jobExplorer.getJobNames()) {
+                totalRunning += countRunning(jobName);
+            }
+            if (totalRunning >= maxConcurrentJobs) {
+                throw new EgovBatchPolicyViolationException(
+                        "Max concurrent jobs exceeded: running=" + totalRunning + ", max=" + maxConcurrentJobs
+                                + " (launch of '" + job.getName() + "' rejected)");
+            }
+        }
+
+        LOGGER.debug("Execution policy passed - launching job '{}'", job.getName());
+        return delegate.run(job, jobParameters);
+    }
+
+    private long countRunning(String jobName) {
+        Set<JobExecution> running = jobExplorer.findRunningJobExecutions(jobName);
+        if (running == null || running.isEmpty()) {
+            return 0;
+        }
+        if (staleExecutionTimeoutMillis <= 0) {
+            return running.size();
+        }
+        long count = 0;
+        for (JobExecution execution : running) {
+            if (!isStale(execution)) {
+                count++;
+            }
+        }
+        return count;
+    }
+
+    private boolean isStale(JobExecution execution) {
+        LocalDateTime lastUpdated = execution.getLastUpdated();
+        if (lastUpdated == null) {
+            lastUpdated = execution.getStartTime();
+        }
+        if (lastUpdated == null) {
+            return false;
+        }
+        boolean stale = Duration.between(lastUpdated, LocalDateTime.now()).toMillis() > staleExecutionTimeoutMillis;
+        if (stale) {
+            LOGGER.warn("Ignoring stale RUNNING execution id={} of job '{}' (lastUpdated={})", execution.getId(),
+                    execution.getJobInstance() == null ? "?" : execution.getJobInstance().getJobName(), lastUpdated);
+        }
+        return stale;
+    }
+
+}

--- a/Batch/org.egovframe.rte.bat.core/src/test/java/org/egovframe/rte/bat/core/operation/EgovJobExecutionPolicyLauncherTest.java
+++ b/Batch/org.egovframe.rte.bat.core/src/test/java/org/egovframe/rte/bat/core/operation/EgovJobExecutionPolicyLauncherTest.java
@@ -1,0 +1,154 @@
+package org.egovframe.rte.bat.core.operation;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.batch.core.BatchStatus;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.explore.support.SimpleJobExplorer;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.batch.core.repository.JobExecutionAlreadyRunningException;
+
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * EgovJobExecutionPolicyLauncher 의 중복 실행 차단, 동시 실행 수 제한, 고아 RUNNING 제외를 검증한다.
+ */
+public class EgovJobExecutionPolicyLauncherTest {
+
+    /** 실행 중 JobExecution 을 조작할 수 있는 JobExplorer 스텁 */
+    static class StubJobExplorer extends SimpleJobExplorer {
+        final Map<String, Set<JobExecution>> running = new HashMap<>();
+
+        StubJobExplorer() {
+            super(null, null, null, null);
+        }
+
+        void addRunning(String jobName, long executionId, LocalDateTime lastUpdated) {
+            JobExecution execution = new JobExecution(executionId);
+            execution.setStatus(BatchStatus.STARTED);
+            execution.setLastUpdated(lastUpdated);
+            running.computeIfAbsent(jobName, key -> new HashSet<>()).add(execution);
+        }
+
+        @Override
+        public Set<JobExecution> findRunningJobExecutions(String jobName) {
+            return running.getOrDefault(jobName, new HashSet<>());
+        }
+
+        @Override
+        public List<String> getJobNames() {
+            return List.copyOf(running.keySet());
+        }
+    }
+
+    /** 위임 호출 횟수를 기록하는 JobLauncher 스텁 */
+    static class RecordingLauncher implements JobLauncher {
+        final AtomicInteger invocations = new AtomicInteger();
+
+        @Override
+        public JobExecution run(Job job, JobParameters jobParameters) {
+            invocations.incrementAndGet();
+            return new JobExecution(999L);
+        }
+    }
+
+    private static Job job(String name) {
+        return new Job() {
+            @Override
+            public String getName() {
+                return name;
+            }
+
+            @Override
+            public void execute(JobExecution execution) {
+            }
+        };
+    }
+
+    @Test
+    public void testSameJobNameAlreadyRunningIsBlockedEvenWithDifferentParameters() {
+        StubJobExplorer explorer = new StubJobExplorer();
+        explorer.addRunning("jobA", 1L, LocalDateTime.now());
+        RecordingLauncher delegate = new RecordingLauncher();
+        EgovJobExecutionPolicyLauncher launcher = new EgovJobExecutionPolicyLauncher(delegate, explorer);
+
+        assertThrows(JobExecutionAlreadyRunningException.class, () -> launcher.run(job("jobA"), new JobParameters()));
+        assertEquals(0, delegate.invocations.get());
+    }
+
+    @Test
+    public void testDuplicateIsAllowedWhenPolicyDisabled() throws Exception {
+        StubJobExplorer explorer = new StubJobExplorer();
+        explorer.addRunning("jobA", 1L, LocalDateTime.now());
+        RecordingLauncher delegate = new RecordingLauncher();
+        EgovJobExecutionPolicyLauncher launcher = new EgovJobExecutionPolicyLauncher(delegate, explorer);
+        launcher.setBlockDuplicateJobName(false);
+
+        launcher.run(job("jobA"), new JobParameters());
+
+        assertEquals(1, delegate.invocations.get());
+    }
+
+    @Test
+    public void testStaleRunningExecutionIsIgnored() throws Exception {
+        StubJobExplorer explorer = new StubJobExplorer();
+        explorer.addRunning("jobA", 1L, LocalDateTime.now().minusHours(1));
+        RecordingLauncher delegate = new RecordingLauncher();
+        EgovJobExecutionPolicyLauncher launcher = new EgovJobExecutionPolicyLauncher(delegate, explorer);
+        launcher.setStaleExecutionTimeoutMillis(60_000L);
+
+        launcher.run(job("jobA"), new JobParameters());
+
+        assertEquals(1, delegate.invocations.get());
+    }
+
+    @Test
+    public void testMaxConcurrentJobsIsEnforced() {
+        StubJobExplorer explorer = new StubJobExplorer();
+        explorer.addRunning("jobA", 1L, LocalDateTime.now());
+        explorer.addRunning("jobB", 2L, LocalDateTime.now());
+        RecordingLauncher delegate = new RecordingLauncher();
+        EgovJobExecutionPolicyLauncher launcher = new EgovJobExecutionPolicyLauncher(delegate, explorer);
+        launcher.setMaxConcurrentJobs(2);
+
+        EgovBatchPolicyViolationException ex = assertThrows(EgovBatchPolicyViolationException.class,
+                () -> launcher.run(job("jobC"), new JobParameters()));
+
+        assertTrue(ex.getMessage().contains("Max concurrent jobs exceeded"), ex.getMessage());
+        assertEquals(0, delegate.invocations.get());
+    }
+
+    @Test
+    public void testUnderConcurrencyLimitIsLaunched() throws Exception {
+        StubJobExplorer explorer = new StubJobExplorer();
+        explorer.addRunning("jobA", 1L, LocalDateTime.now());
+        RecordingLauncher delegate = new RecordingLauncher();
+        EgovJobExecutionPolicyLauncher launcher = new EgovJobExecutionPolicyLauncher(delegate, explorer);
+        launcher.setMaxConcurrentJobs(3);
+
+        launcher.run(job("jobC"), new JobParameters());
+
+        assertEquals(1, delegate.invocations.get());
+    }
+
+    @Test
+    public void testNullDelegateOrExplorerIsRejected() {
+        StubJobExplorer explorer = new StubJobExplorer();
+        RecordingLauncher delegate = new RecordingLauncher();
+
+        assertThrows(IllegalArgumentException.class, () -> new EgovJobExecutionPolicyLauncher(null, explorer));
+        assertThrows(IllegalArgumentException.class, () -> new EgovJobExecutionPolicyLauncher(delegate, null));
+    }
+
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [ ] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [X] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

### 배경

Spring Batch 기본 `JobLauncher` 는 **같은 JobInstance(같은 파라미터)** 의 중복 실행만 막습니다. 운영에서 자주 생기는
"다른 파라미터(실행 일시 등)로 같은 Job 을 동시에 또 띄움", "여러 Job 이 한꺼번에 몰려 자원을 과점" 은 통제할 수단이 없어
스케줄러 설정이나 애플리케이션 코드로 각자 해결하고 있습니다.

### 추가한 것

**`operation/EgovJobExecutionPolicyLauncher`** — `JobLauncher` 데코레이터. 실행 전에 `JobExplorer`(배치 메타테이블)를
조회해 정책을 적용하며, 메타테이블을 공유하는 **멀티서버 환경에서도 같은 기준**으로 동작합니다.

| 정책 | 속성(기본값) | 위반 시 |
|---|---|---|
| 같은 Job 이름 중복 실행 차단 | `blockDuplicateJobName` (true) | Spring Batch 표준 `JobExecutionAlreadyRunningException` |
| 전체 동시 실행 Job 수 상한 | `maxConcurrentJobs` (0 = 무제한) | `EgovBatchPolicyViolationException`(unchecked, 신규) |
| 고아 RUNNING 무시 | `staleExecutionTimeoutMillis` (0 = 사용 안 함) | lastUpdated 가 임계를 넘은 RUNNING 은 집계에서 제외(WARN 로그) |

```xml
<bean id="policyJobLauncher" class="org.egovframe.rte.bat.core.operation.EgovJobExecutionPolicyLauncher">
    <constructor-arg ref="jobLauncher"/>
    <constructor-arg ref="jobExplorer"/>
    <property name="maxConcurrentJobs" value="5"/>
    <property name="staleExecutionTimeoutMillis" value="3600000"/>
</bean>
```

### 설계 메모

- **기존 클래스는 수정하지 않았고 의존도 추가하지 않았습니다.** 빈으로 등록해 기존 `jobLauncher` 를 감싸는 방식이라
  등록하지 않은 애플리케이션에는 영향이 없습니다.
- 조회와 실행 사이에 다른 서버가 같은 Job 을 띄우는 경합까지 막지는 않습니다. 그 수준의 배타 실행이 필요하면 DB 락 같은
  별도 수단을 함께 써야 하며, javadoc 에 명시했습니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

`EgovJobExecutionPolicyLauncherTest` **6건 신규**(`JobExplorer`·`JobLauncher` 스텁, DB 불필요), `bat.core` 모듈은 Linux 전건 통과, Windows 는 기존 테스트 1건이 `main` 에서도 실패(아래 표).

| 환경 | 기본 로케일(Locale) | 모듈 실행 건수 | 결과 |
|---|---|---:|---|
| **Windows** | ko_KR | **107** | `Tests run: 107, Failures: 1, Errors: 0, Skipped: 0` — 실패 1건은 이 PR 과 무관한 기존 테스트 `DefaultItemGuidanceKeyTest.writerDelimitedFileGuidance` 로, 변경 없는 `main`(`cc2b332`) 에서도 Windows 에서만 같은 실패가 납니다(Linux 는 통과). 신규 6건은 통과 |
| **Linux** (Ubuntu 22.04 / OpenJDK 17) | C.UTF-8 | **107** | `Tests run: 107, Failures: 0, Errors: 0, Skipped: 0` |

| 구분 | 건수 | 내용 |
|---|---:|---|
| 중복 차단 | 2 | 같은 이름이 실행 중이면 파라미터가 달라도 차단(위임 0회) · 정책을 끄면 허용 |
| 고아 제외 | 1 | 1시간 전 lastUpdated 의 RUNNING 은 임계(60초) 초과로 제외되어 실행 |
| 동시 상한 | 2 | 2건 실행 중 + 상한 2 → 거부(메시지 확인) · 상한 3 → 실행 |
| 인자 | 1 | null delegate·explorer 는 `IllegalArgumentException` |

**수동 확인**: 현재 `main`(`cc2b332`) 위에서 `bat.core` 모듈 빌드·테스트가 Linux 에서 전건 통과함을 확인했습니다. Windows 에서 실패하는 `DefaultItemGuidanceKeyTest.writerDelimitedFileGuidance` 1건은 변경 전 `main` 에서도 같은 방식으로 실패해 이 PR 과 무관합니다(별도 확인 예정).

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

해당 없음 — 배치 라이브러리 클래스 추가입니다.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

해당 없음 — 위 JUnit 테스트 결과로 갈음합니다.

---

<sub>base: `eGovFramework:main` @ `cc2b332` (2026-09-10 fetch 기준, #366~#379 머지 후) · 단일 커밋</sub>
