### PR TITLE
feat: 멀티서버 배치의 자원 배타 락 EgovJdbcResourceLock 과 Step 리스너 추가

### DIFF
--- a/Batch/org.egovframe.rte.bat.core/src/main/java/org/egovframe/rte/bat/core/operation/lock/EgovJdbcResourceLock.java
+++ b/Batch/org.egovframe.rte.bat.core/src/main/java/org/egovframe/rte/bat/core/operation/lock/EgovJdbcResourceLock.java
@@ -1,0 +1,234 @@
+/*
+ * Copyright 2009-2026 MOIS(Ministry of the Interior and Safety).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.egovframe.rte.bat.core.operation.lock;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import javax.sql.DataSource;
+import java.sql.Timestamp;
+import java.util.List;
+import java.util.regex.Pattern;
+
+/**
+ * DB 기반 멀티서버 배치 자원 배타 락.
+ *
+ * <p>여러 서버의 배치가 같은 파일·자원을 동시에 조작하는 것을 막는다. 락 테이블의 PK INSERT 성공·실패의 원자성으로 락을
+ * 판정하므로 표준 JDBC 만 쓰며 DBMS 에 중립적이다.</p>
+ *
+ * <p>테이블 규약(DBMS 에 맞게 타입 조정):</p>
+ * <pre>
+ * CREATE TABLE EGOV_BATCH_RESOURCE_LOCK (
+ *     RESOURCE_ID   VARCHAR(200) NOT NULL PRIMARY KEY,
+ *     OWNER_ID      VARCHAR(200) NOT NULL,
+ *     ACQUIRED_TIME TIMESTAMP    NOT NULL
+ * );
+ * </pre>
+ *
+ * <ul>
+ *   <li>같은 소유자의 재획득(재진입)은 성공으로 처리하고 획득 시각을 갱신한다.</li>
+ *   <li>{@code expireMillis > 0} 이면 획득 후 그 시간이 지난 락(서버 다운 등으로 남은 고아 락)을 지우고 탈취를 시도한다.</li>
+ * </ul>
+ *
+ * @author 실행환경 개발팀
+ * @since 5.1
+ * @version 1.0
+ * <pre>
+ * 개정이력(Modification Information)
+ *
+ * 수정일		수정자				수정내용
+ * ----------------------------------------------
+ * 2026.09.10	실행환경 개발팀		최초 생성
+ * </pre>
+ */
+public class EgovJdbcResourceLock {
+
+    /** 기본 락 테이블명 */
+    public static final String DEFAULT_TABLE_NAME = "EGOV_BATCH_RESOURCE_LOCK";
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(EgovJdbcResourceLock.class);
+
+    /** SQL 에 그대로 이어 붙이는 테이블명은 식별자 문자만 허용한다. */
+    private static final Pattern TABLE_NAME_PATTERN = Pattern.compile("[A-Za-z0-9_.]+");
+
+    private final JdbcTemplate jdbcTemplate;
+    private final String tableName;
+
+    /** 고아 락 만료 시간(ms). 0 이하이면 만료 탈취를 하지 않는다. */
+    private long expireMillis = 0L;
+
+    public EgovJdbcResourceLock(DataSource dataSource) {
+        this(dataSource, DEFAULT_TABLE_NAME);
+    }
+
+    /**
+     * @param dataSource 락 테이블이 있는 DataSource
+     * @param tableName  락 테이블명(null 또는 빈 값이면 {@value #DEFAULT_TABLE_NAME})
+     * @throws IllegalArgumentException dataSource 가 null 이거나 테이블명에 식별자 문자 외의 문자가 있는 경우
+     */
+    public EgovJdbcResourceLock(DataSource dataSource, String tableName) {
+        if (dataSource == null) {
+            throw new IllegalArgumentException("dataSource must not be null");
+        }
+        String name = (tableName == null || tableName.isEmpty()) ? DEFAULT_TABLE_NAME : tableName;
+        if (!TABLE_NAME_PATTERN.matcher(name).matches()) {
+            throw new IllegalArgumentException("tableName must consist of identifier characters only: " + name);
+        }
+        this.jdbcTemplate = new JdbcTemplate(dataSource);
+        this.tableName = name;
+    }
+
+    /**
+     * 고아 락 만료 시간(ms). 0 이하이면 만료 탈취를 하지 않는다(기본 0).
+     */
+    public void setExpireMillis(long expireMillis) {
+        this.expireMillis = expireMillis;
+    }
+
+    /**
+     * 락 획득을 1회 시도한다(비대기).
+     *
+     * @param resourceId 자원 식별자(예: 파일 경로, 논리 자원명)
+     * @param ownerId    소유자 식별자(예: jobName#executionId, 호스트명)
+     * @return 획득 성공 여부
+     */
+    public boolean tryAcquire(String resourceId, String ownerId) {
+        requireText(resourceId, "resourceId");
+        requireText(ownerId, "ownerId");
+
+        if (insertLock(resourceId, ownerId)) {
+            LOGGER.debug("Resource lock acquired: {} by {}", resourceId, ownerId);
+            return true;
+        }
+        // 같은 소유자의 재진입 — 획득 시각을 갱신하고 성공 처리
+        List<String> owners = jdbcTemplate.queryForList(
+                "SELECT OWNER_ID FROM " + tableName + " WHERE RESOURCE_ID = ?", String.class, resourceId);
+        if (owners.size() == 1 && ownerId.equals(owners.get(0))) {
+            int refreshed = jdbcTemplate.update(
+                    "UPDATE " + tableName + " SET ACQUIRED_TIME = ? WHERE RESOURCE_ID = ? AND OWNER_ID = ?",
+                    now(), resourceId, ownerId);
+            if (refreshed > 0) {
+                return true;
+            }
+            // SELECT 와 UPDATE 사이에 소유권이 바뀌었다(만료 탈취·forceRelease). 영향 행 0건을 보유로 보고하면 두 프로세스가
+            // 동시에 락을 가졌다고 믿게 된다. 빈 자리면 다시 잡고, 다른 소유자가 잡았으면 아래 만료 탈취 판정으로 넘어간다.
+            LOGGER.warn("Resource lock ownership changed during reentrant refresh: {} (owner {})", resourceId, ownerId);
+            if (insertLock(resourceId, ownerId)) {
+                return true;
+            }
+        }
+        // 고아 락 만료 탈취 시도
+        if (expireMillis > 0) {
+            Timestamp cutoff = new Timestamp(System.currentTimeMillis() - expireMillis);
+            int expired = jdbcTemplate.update(
+                    "DELETE FROM " + tableName + " WHERE RESOURCE_ID = ? AND ACQUIRED_TIME < ?", resourceId, cutoff);
+            if (expired > 0 && insertLock(resourceId, ownerId)) {
+                LOGGER.warn("Resource lock taken over from expired owner: {} by {}", resourceId, ownerId);
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * 락을 얻을 때까지 대기하며 시도한다.
+     *
+     * @param resourceId 자원 식별자
+     * @param ownerId    소유자 식별자
+     * @param waitMillis 최대 대기 시간(ms)
+     * @param pollMillis 재시도 간격(ms, 최소 10)
+     * @return 획득 성공 여부(대기 시간 안에 실패하거나 인터럽트되면 false)
+     */
+    public boolean acquire(String resourceId, String ownerId, long waitMillis, long pollMillis) {
+        long deadline = System.currentTimeMillis() + Math.max(waitMillis, 0);
+        long interval = Math.max(pollMillis, 10);
+        while (true) {
+            if (tryAcquire(resourceId, ownerId)) {
+                return true;
+            }
+            if (System.currentTimeMillis() >= deadline) {
+                return false;
+            }
+            try {
+                Thread.sleep(interval);
+            } catch (InterruptedException ex) {
+                Thread.currentThread().interrupt();
+                return false;
+            }
+        }
+    }
+
+    /**
+     * 소유한 락을 해제한다.
+     *
+     * @param resourceId 자원 식별자
+     * @param ownerId    소유자 식별자
+     * @return 해제되었으면 true(소유자가 아니거나 락이 없으면 false)
+     */
+    public boolean release(String resourceId, String ownerId) {
+        int deleted = jdbcTemplate.update(
+                "DELETE FROM " + tableName + " WHERE RESOURCE_ID = ? AND OWNER_ID = ?", resourceId, ownerId);
+        if (deleted > 0) {
+            LOGGER.debug("Resource lock released: {} by {}", resourceId, ownerId);
+        }
+        return deleted > 0;
+    }
+
+    /**
+     * 소유자와 무관하게 락을 강제로 해제한다(운영 조치용).
+     *
+     * @param resourceId 자원 식별자
+     * @return 해제되었으면 true
+     */
+    public boolean forceRelease(String resourceId) {
+        return jdbcTemplate.update("DELETE FROM " + tableName + " WHERE RESOURCE_ID = ?", resourceId) > 0;
+    }
+
+    /**
+     * 자원이 잠겨 있는지 확인한다.
+     *
+     * @param resourceId 자원 식별자
+     * @return 락 행이 있으면 true
+     */
+    public boolean isLocked(String resourceId) {
+        Integer count = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM " + tableName + " WHERE RESOURCE_ID = ?", Integer.class, resourceId);
+        return count != null && count > 0;
+    }
+
+    private boolean insertLock(String resourceId, String ownerId) {
+        try {
+            jdbcTemplate.update("INSERT INTO " + tableName + " (RESOURCE_ID, OWNER_ID, ACQUIRED_TIME) VALUES (?, ?, ?)",
+                    resourceId, ownerId, now());
+            return true;
+        } catch (DataIntegrityViolationException ex) {
+            return false;
+        }
+    }
+
+    private static Timestamp now() {
+        return new Timestamp(System.currentTimeMillis());
+    }
+
+    private static void requireText(String value, String name) {
+        if (value == null || value.trim().isEmpty()) {
+            throw new IllegalArgumentException(name + " must not be empty");
+        }
+    }
+
+}

--- a/Batch/org.egovframe.rte.bat.core/src/main/java/org/egovframe/rte/bat/core/operation/lock/EgovResourceLockException.java
+++ b/Batch/org.egovframe.rte.bat.core/src/main/java/org/egovframe/rte/bat/core/operation/lock/EgovResourceLockException.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2009-2026 MOIS(Ministry of the Interior and Safety).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.egovframe.rte.bat.core.operation.lock;
+
+/**
+ * 배치 자원 락을 대기 시간 안에 얻지 못했을 때 던지는 예외.
+ *
+ * <p>{@link EgovResourceLockStepListener} 가 Step 시작 전에 던져 Step 을 실패시킨다. Spring Batch 리스너 계약이
+ * checked 예외를 허용하지 않으므로 unchecked 로 둔다.</p>
+ *
+ * @author 실행환경 개발팀
+ * @since 5.1
+ * @version 1.0
+ * <pre>
+ * 개정이력(Modification Information)
+ *
+ * 수정일		수정자				수정내용
+ * ----------------------------------------------
+ * 2026.09.10	실행환경 개발팀		최초 생성
+ * </pre>
+ */
+public class EgovResourceLockException extends RuntimeException {
+
+    private static final long serialVersionUID = 1L;
+
+    public EgovResourceLockException(String message) {
+        super(message);
+    }
+
+    public EgovResourceLockException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+}

--- a/Batch/org.egovframe.rte.bat.core/src/main/java/org/egovframe/rte/bat/core/operation/lock/EgovResourceLockStepListener.java
+++ b/Batch/org.egovframe.rte.bat.core/src/main/java/org/egovframe/rte/bat/core/operation/lock/EgovResourceLockStepListener.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2009-2026 MOIS(Ministry of the Interior and Safety).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.egovframe.rte.bat.core.operation.lock;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.batch.core.ExitStatus;
+import org.springframework.batch.core.StepExecution;
+import org.springframework.batch.core.StepExecutionListener;
+
+/**
+ * Step 시작 전에 자원 락을 얻고 종료 시 해제하는 {@link StepExecutionListener}.
+ *
+ * <p>소유자 식별자는 {@code jobName#jobExecutionId} 로 자동 구성되어 실행 단위로 구분된다. 대기 시간 안에 얻지 못하면
+ * {@link EgovResourceLockException} 으로 Step 을 실패시키고, Step 성공·실패와 무관하게 종료 시 락을 해제한다.</p>
+ *
+ * <pre>
+ * &lt;bean class="org.egovframe.rte.bat.core.operation.lock.EgovResourceLockStepListener"&gt;
+ *     &lt;constructor-arg ref="egovResourceLock"/&gt;
+ *     &lt;constructor-arg value="/data/batch/out/daily.dat"/&gt;   &lt;!-- resourceId --&gt;
+ *     &lt;property name="waitMillis" value="10000"/&gt;
+ * &lt;/bean&gt;
+ * </pre>
+ *
+ * @author 실행환경 개발팀
+ * @since 5.1
+ * @version 1.0
+ * <pre>
+ * 개정이력(Modification Information)
+ *
+ * 수정일		수정자				수정내용
+ * ----------------------------------------------
+ * 2026.09.10	실행환경 개발팀		최초 생성
+ * </pre>
+ */
+public class EgovResourceLockStepListener implements StepExecutionListener {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(EgovResourceLockStepListener.class);
+
+    private final EgovJdbcResourceLock resourceLock;
+    private final String resourceId;
+
+    private long waitMillis = 0L;
+    private long pollMillis = 500L;
+
+    /**
+     * @param resourceLock 락 구현
+     * @param resourceId   이 Step 이 배타적으로 쓰는 자원 식별자
+     * @throws IllegalArgumentException 인자가 null 이거나 비어 있는 경우
+     */
+    public EgovResourceLockStepListener(EgovJdbcResourceLock resourceLock, String resourceId) {
+        if (resourceLock == null) {
+            throw new IllegalArgumentException("resourceLock must not be null");
+        }
+        if (resourceId == null || resourceId.trim().isEmpty()) {
+            throw new IllegalArgumentException("resourceId must not be empty");
+        }
+        this.resourceLock = resourceLock;
+        this.resourceId = resourceId;
+    }
+
+    /**
+     * 락 획득 최대 대기 시간(ms). 기본 0 = 즉시 1회 시도.
+     */
+    public void setWaitMillis(long waitMillis) {
+        this.waitMillis = waitMillis;
+    }
+
+    /**
+     * 락 획득 재시도 간격(ms). 기본 500.
+     */
+    public void setPollMillis(long pollMillis) {
+        this.pollMillis = pollMillis;
+    }
+
+    @Override
+    public void beforeStep(StepExecution stepExecution) {
+        String ownerId = ownerId(stepExecution);
+        boolean acquired = resourceLock.acquire(resourceId, ownerId, waitMillis, pollMillis);
+        if (!acquired) {
+            throw new EgovResourceLockException("Failed to acquire batch resource lock '" + resourceId + "' for "
+                    + ownerId + " within " + waitMillis + "ms; another execution is using the resource");
+        }
+        LOGGER.info("Batch resource lock acquired: '{}' by {}", resourceId, ownerId);
+    }
+
+    @Override
+    public ExitStatus afterStep(StepExecution stepExecution) {
+        String ownerId = ownerId(stepExecution);
+        if (resourceLock.release(resourceId, ownerId)) {
+            LOGGER.info("Batch resource lock released: '{}' by {}", resourceId, ownerId);
+        }
+        return stepExecution.getExitStatus();
+    }
+
+    private String ownerId(StepExecution stepExecution) {
+        return stepExecution.getJobExecution().getJobInstance() == null
+                ? "job#" + stepExecution.getJobExecutionId()
+                : stepExecution.getJobExecution().getJobInstance().getJobName() + "#" + stepExecution.getJobExecutionId();
+    }
+
+}

--- a/Batch/org.egovframe.rte.bat.core/src/test/java/org/egovframe/rte/bat/core/operation/lock/EgovJdbcResourceLockTest.java
+++ b/Batch/org.egovframe.rte.bat.core/src/test/java/org/egovframe/rte/bat/core/operation/lock/EgovJdbcResourceLockTest.java
@@ -1,0 +1,200 @@
+package org.egovframe.rte.bat.core.operation.lock;
+
+import org.hsqldb.jdbc.JDBCDataSource;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.JobInstance;
+import org.springframework.batch.core.StepExecution;
+
+import javax.sql.DataSource;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.sql.Connection;
+import java.sql.Statement;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * EgovJdbcResourceLock 의 배타 획득·재진입·해제, 고아 락 탈취, 대기 획득, Step 리스너, 재진입 갱신 경합을 검증한다.
+ */
+public class EgovJdbcResourceLockTest {
+
+    private static JDBCDataSource dataSource;
+
+    @BeforeAll
+    public static void setUpDatabase() throws Exception {
+        dataSource = new JDBCDataSource();
+        dataSource.setUrl("jdbc:hsqldb:mem:batchlock");
+        dataSource.setUser("sa");
+        dataSource.setPassword("");
+        try (Connection connection = dataSource.getConnection();
+                Statement statement = connection.createStatement()) {
+            statement.execute("DROP TABLE EGOV_BATCH_RESOURCE_LOCK IF EXISTS");
+            statement.execute("CREATE TABLE EGOV_BATCH_RESOURCE_LOCK ("
+                    + "RESOURCE_ID VARCHAR(200) NOT NULL PRIMARY KEY,"
+                    + "OWNER_ID VARCHAR(200) NOT NULL,"
+                    + "ACQUIRED_TIME TIMESTAMP NOT NULL)");
+        }
+    }
+
+    @BeforeEach
+    public void clearLocks() throws Exception {
+        try (Connection connection = dataSource.getConnection();
+                Statement statement = connection.createStatement()) {
+            statement.execute("DELETE FROM EGOV_BATCH_RESOURCE_LOCK");
+        }
+    }
+
+    @Test
+    public void testExclusiveAcquireReentryAndRelease() {
+        EgovJdbcResourceLock lock = new EgovJdbcResourceLock(dataSource);
+
+        assertTrue(lock.tryAcquire("/data/out/daily.dat", "jobA#1"));
+        assertTrue(lock.isLocked("/data/out/daily.dat"));
+        assertFalse(lock.tryAcquire("/data/out/daily.dat", "jobB#2"));
+        assertTrue(lock.tryAcquire("/data/out/daily.dat", "jobA#1"));
+        assertFalse(lock.release("/data/out/daily.dat", "jobB#2"));
+        assertTrue(lock.release("/data/out/daily.dat", "jobA#1"));
+        assertFalse(lock.isLocked("/data/out/daily.dat"));
+        assertTrue(lock.tryAcquire("/data/out/daily.dat", "jobB#2"));
+    }
+
+    @Test
+    public void testExpiredOrphanLockIsTakenOver() throws Exception {
+        EgovJdbcResourceLock lock = new EgovJdbcResourceLock(dataSource);
+        lock.setExpireMillis(1000L);
+        assertTrue(lock.tryAcquire("orphaned", "deadServer#1"));
+        try (Connection connection = dataSource.getConnection();
+                Statement statement = connection.createStatement()) {
+            statement.execute("UPDATE EGOV_BATCH_RESOURCE_LOCK SET ACQUIRED_TIME = TIMESTAMP '2000-01-01 00:00:00'"
+                    + " WHERE RESOURCE_ID = 'orphaned'");
+        }
+
+        assertTrue(lock.tryAcquire("orphaned", "aliveServer#2"));
+        assertFalse(lock.tryAcquire("orphaned", "deadServer#1"));
+    }
+
+    @Test
+    public void testAcquireWaitsUntilReleased() throws Exception {
+        EgovJdbcResourceLock lock = new EgovJdbcResourceLock(dataSource);
+        assertTrue(lock.tryAcquire("waited", "holder#1"));
+
+        assertFalse(lock.acquire("waited", "waiter#2", 300L, 50L));
+
+        Thread releaser = new Thread(() -> {
+            try {
+                Thread.sleep(300L);
+            } catch (InterruptedException ignored) {
+                Thread.currentThread().interrupt();
+            }
+            lock.release("waited", "holder#1");
+        });
+        releaser.start();
+        assertTrue(lock.acquire("waited", "waiter#2", 5000L, 50L));
+        releaser.join();
+    }
+
+    @Test
+    public void testStepListenerAcquiresBeforeStepAndReleasesAfterStep() {
+        EgovJdbcResourceLock lock = new EgovJdbcResourceLock(dataSource);
+        EgovResourceLockStepListener listener = new EgovResourceLockStepListener(lock, "step-resource");
+        JobExecution jobExecution = new JobExecution(7L);
+        jobExecution.setJobInstance(new JobInstance(3L, "lockJob"));
+        StepExecution stepExecution = new StepExecution("s1", jobExecution);
+
+        listener.beforeStep(stepExecution);
+        assertTrue(lock.isLocked("step-resource"));
+
+        listener.afterStep(stepExecution);
+        assertFalse(lock.isLocked("step-resource"));
+    }
+
+    @Test
+    public void testStepListenerFailsFastWhenResourceIsHeldByAnotherExecution() {
+        EgovJdbcResourceLock lock = new EgovJdbcResourceLock(dataSource);
+        assertTrue(lock.tryAcquire("busy-resource", "otherJob#99"));
+        EgovResourceLockStepListener listener = new EgovResourceLockStepListener(lock, "busy-resource");
+        listener.setWaitMillis(200L);
+        listener.setPollMillis(50L);
+        JobExecution jobExecution = new JobExecution(8L);
+        jobExecution.setJobInstance(new JobInstance(4L, "blockedJob"));
+        StepExecution stepExecution = new StepExecution("s1", jobExecution);
+
+        assertThrows(EgovResourceLockException.class, () -> listener.beforeStep(stepExecution));
+    }
+
+    @Test
+    public void testInvalidTableNameIsRejected() {
+        assertThrows(IllegalArgumentException.class, () -> new EgovJdbcResourceLock(dataSource, "LOCK; DROP TABLE X"));
+        assertThrows(IllegalArgumentException.class, () -> new EgovJdbcResourceLock(null));
+    }
+
+    /**
+     * SELECT 로 자신이 소유자임을 확인한 직후 다른 프로세스가 만료 탈취·forceRelease 로 소유권을 가져가는 경쟁을
+     * UPDATE 직전 훅으로 재현한다. 재진입 갱신이 0건이면 락을 보유했다고 보고하면 안 된다.
+     */
+    @Test
+    public void testReentrantRefreshDoesNotReportOwnershipWhenUpdateAffectsNoRow() throws Exception {
+        String resourceId = "/data/out/race.dat";
+        AtomicBoolean raceArmed = new AtomicBoolean(false);
+        DataSource racing = racingDataSource(dataSource, sql -> {
+            if (sql.startsWith("UPDATE") && raceArmed.compareAndSet(true, false)) {
+                try (Connection connection = dataSource.getConnection();
+                        Statement statement = connection.createStatement()) {
+                    statement.execute("DELETE FROM EGOV_BATCH_RESOURCE_LOCK WHERE RESOURCE_ID = '" + resourceId + "'");
+                    statement.execute("INSERT INTO EGOV_BATCH_RESOURCE_LOCK (RESOURCE_ID, OWNER_ID, ACQUIRED_TIME) VALUES ('"
+                            + resourceId + "', 'jobC#9', CURRENT_TIMESTAMP)");
+                }
+            }
+        });
+        EgovJdbcResourceLock lock = new EgovJdbcResourceLock(racing);
+        assertTrue(lock.tryAcquire(resourceId, "jobA#1"));
+
+        raceArmed.set(true);
+        assertFalse(lock.tryAcquire(resourceId, "jobA#1"));
+
+        assertFalse(raceArmed.get());
+        assertFalse(lock.release(resourceId, "jobA#1"));
+        assertTrue(lock.release(resourceId, "jobC#9"));
+    }
+
+    /** 특정 SQL 이 준비되기 직전에 훅을 실행하는 DataSource 프록시(경쟁 조건 재현용). */
+    private static DataSource racingDataSource(DataSource target, SqlHook beforePrepare) {
+        return (DataSource) Proxy.newProxyInstance(DataSource.class.getClassLoader(), new Class<?>[] {DataSource.class},
+                (proxy, method, args) -> {
+                    Object result = invoke(target, method, args);
+                    if ("getConnection".equals(method.getName())) {
+                        Connection connection = (Connection) result;
+                        return Proxy.newProxyInstance(Connection.class.getClassLoader(), new Class<?>[] {Connection.class},
+                                (connectionProxy, connectionMethod, connectionArgs) -> {
+                                    if ("prepareStatement".equals(connectionMethod.getName()) && connectionArgs != null
+                                            && connectionArgs.length > 0) {
+                                        beforePrepare.beforePrepare(String.valueOf(connectionArgs[0]));
+                                    }
+                                    return invoke(connection, connectionMethod, connectionArgs);
+                                });
+                    }
+                    return result;
+                });
+    }
+
+    private static Object invoke(Object target, Method method, Object[] args) throws Throwable {
+        try {
+            return method.invoke(target, args);
+        } catch (InvocationTargetException e) {
+            throw e.getCause();
+        }
+    }
+
+    @FunctionalInterface
+    private interface SqlHook {
+        void beforePrepare(String sql) throws Exception;
+    }
+
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [ ] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [X] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

### 배경

여러 서버에서 도는 배치가 같은 파일·자원을 동시에 조작하는 것을 막을 수단이 실행환경에 없습니다. JVM 안의 락은 서버 하나에서만
유효해 이중 기동을 막지 못하고, 사이트마다 DB 테이블로 임시 구현하고 있습니다.

### 추가한 것

**1. `operation/lock/EgovJdbcResourceLock`** — DB 기반 멀티서버 배타 락

락 테이블의 PK INSERT 성공·실패의 **원자성**으로 락을 판정합니다. 표준 JDBC 만 쓰므로 DBMS 에 중립적입니다.

| API | 내용 |
|---|---|
| `tryAcquire(resourceId, ownerId)` | 1회 시도(비대기). 같은 소유자의 재진입은 획득 시각을 갱신해 성공 처리 |
| `acquire(resourceId, ownerId, waitMillis, pollMillis)` | 대기 시간 안에 재시도 |
| `release(resourceId, ownerId)` / `forceRelease(resourceId)` | 소유자 해제 / 운영 조치용 강제 해제 |
| `isLocked(resourceId)` | 잠김 여부 |
| `setExpireMillis(ms)` | 서버 다운으로 남은 **고아 락**을 만료 시각 기준으로 지우고 탈취 시도(0 = 사용 안 함) |

```sql
CREATE TABLE EGOV_BATCH_RESOURCE_LOCK (
    RESOURCE_ID   VARCHAR(200) NOT NULL PRIMARY KEY,
    OWNER_ID      VARCHAR(200) NOT NULL,
    ACQUIRED_TIME TIMESTAMP    NOT NULL
);
```

**2. `operation/lock/EgovResourceLockStepListener`** — Step 시작 전 획득, 종료 시 해제

소유자는 `jobName#jobExecutionId` 로 자동 구성되어 실행 단위로 구분됩니다. 대기 시간 안에 얻지 못하면
`EgovResourceLockException`(unchecked, 신규)으로 Step 을 실패시키고, Step 성공·실패와 무관하게 종료 시 해제합니다.

```xml
<bean id="egovResourceLock" class="org.egovframe.rte.bat.core.operation.lock.EgovJdbcResourceLock">
    <constructor-arg ref="dataSource"/>
    <property name="expireMillis" value="3600000"/>
</bean>
<bean class="org.egovframe.rte.bat.core.operation.lock.EgovResourceLockStepListener">
    <constructor-arg ref="egovResourceLock"/>
    <constructor-arg value="/data/batch/out/daily.dat"/>
    <property name="waitMillis" value="10000"/>
</bean>
```

### 설계 메모

- **기존 클래스는 수정하지 않았고 의존도 추가하지 않았습니다.** 테이블 DDL 은 javadoc 에 규약으로 안내합니다(DBMS 에 맞게
  타입 조정).
- 재진입 갱신(UPDATE)이 0건이면 — SELECT 와 UPDATE 사이에 만료 탈취나 강제 해제로 소유권이 바뀐 경우 — 보유로 보고하지
  않고 다시 판정합니다. 두 프로세스가 동시에 락을 가졌다고 믿는 상황을 막습니다.
- 테이블명은 식별자 문자만 허용해 SQL 조립에 안전하게 씁니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

`EgovJdbcResourceLockTest` **7건 신규**(HSQLDB 인메모리), `bat.core` 모듈은 Linux 전건 통과, Windows 는 기존 테스트 1건이 `main` 에서도 실패(아래 표).

| 환경 | 기본 로케일(Locale) | 모듈 실행 건수 | 결과 |
|---|---|---:|---|
| **Windows** | ko_KR | **108** | `Tests run: 108, Failures: 1, Errors: 0, Skipped: 0` — 실패 1건은 이 PR 과 무관한 기존 테스트 `DefaultItemGuidanceKeyTest.writerDelimitedFileGuidance` 로, 변경 없는 `main`(`cc2b332`) 에서도 Windows 에서만 같은 실패가 납니다(Linux 는 통과). 신규 7건은 통과 |
| **Linux** (Ubuntu 22.04 / OpenJDK 17) | C.UTF-8 | **108** | `Tests run: 108, Failures: 0, Errors: 0, Skipped: 0` |

| 구분 | 건수 | 내용 |
|---|---:|---|
| 배타·재진입·해제 | 1 | 다른 소유자 획득 실패, 같은 소유자 재진입 성공, 소유자가 아니면 해제 불가, 해제 후 획득 가능 |
| 고아 락 | 1 | 획득 시각을 과거로 바꾼 락은 만료 탈취되고 기존 소유자는 잃는다 |
| 대기 획득 | 1 | 대기 시간 안에 해제되지 않으면 실패, 해제되면 성공 |
| Step 리스너 | 2 | beforeStep 획득·afterStep 해제 · 점유 중이면 `EgovResourceLockException` |
| 경합 | 1 | 재진입 갱신 직전 소유권이 바뀌면 보유로 보고하지 않는다(`DataSource` 프록시로 재현) |
| 인자 | 1 | 식별자 문자 외의 테이블명·null DataSource 는 `IllegalArgumentException` |

**수동 확인**: 현재 `main`(`cc2b332`) 위에서 `bat.core` 모듈 빌드·테스트가 Linux 에서 전건 통과함을 확인했습니다. Windows 에서 실패하는 `DefaultItemGuidanceKeyTest.writerDelimitedFileGuidance` 1건은 변경 전 `main` 에서도 같은 방식으로 실패해 이 PR 과 무관합니다.

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

해당 없음 — 배치 라이브러리 클래스 추가입니다.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

해당 없음 — 위 JUnit 테스트 결과로 갈음합니다.

---

<sub>base: `eGovFramework:main` @ `cc2b332` (2026-09-10 fetch 기준, #366~#379 머지 후) · 단일 커밋</sub>
