### PR TITLE
feat: 임시 파일에 쓰고 완료 시에만 교체하는 EgovSafeFlatFileItemWriter 추가

### DIFF
--- a/Batch/org.egovframe.rte.bat.core/src/main/java/org/egovframe/rte/bat/core/item/file/EgovSafeFlatFileItemWriter.java
+++ b/Batch/org.egovframe.rte.bat.core/src/main/java/org/egovframe/rte/bat/core/item/file/EgovSafeFlatFileItemWriter.java
@@ -1,0 +1,205 @@
+/*
+ * Copyright 2009-2026 MOIS(Ministry of the Interior and Safety).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.egovframe.rte.bat.core.item.file;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.batch.core.BatchStatus;
+import org.springframework.batch.core.ExitStatus;
+import org.springframework.batch.core.StepExecution;
+import org.springframework.batch.core.StepExecutionListener;
+import org.springframework.batch.item.Chunk;
+import org.springframework.batch.item.ExecutionContext;
+import org.springframework.batch.item.ItemStreamException;
+import org.springframework.batch.item.WriteFailedException;
+import org.springframework.batch.item.file.FlatFileItemWriter;
+import org.springframework.batch.item.file.transform.LineAggregator;
+import org.springframework.core.io.FileSystemResource;
+import org.springframework.core.io.WritableResource;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
+
+/**
+ * 파일 운영 안전장치가 적용된 {@link FlatFileItemWriter}.
+ *
+ * <ol>
+ *   <li><b>원자적 완료</b> — 임시 파일({@code <파일명>.egovtmp})에 쓰고 Step 이 COMPLETED 일 때만 최종 파일명으로 옮긴다.
+ *       후속 시스템이 미완성 파일을 집어가는 사고를 막는다.</li>
+ *   <li><b>실패 시 정리</b> — Step 이 완료되지 않으면 임시 파일을 지워 불완전 산출물을 남기지 않는다.</li>
+ *   <li><b>최대 크기 가드</b> — {@code maxFileSizeBytes} 초과가 예상되는 청크는 쓰기 전에 거부해 Step 을 실패시킨다
+ *       (라인 집계 결과의 인코딩 바이트 수로 미리 계산, 위반 시 {@link WriteFailedException}).</li>
+ * </ol>
+ *
+ * <p>Step 의 writer 로 등록하면 ItemStream 과 StepExecutionListener 가 함께 등록되어 별도 설정이 없다.
+ * <b>주의:</b> 실패 시 임시 파일을 지우는 정책상 재시작 이어쓰기(saveState)와 함께 쓸 수 없어 saveState 는 false 로 고정된다
+ * (실패하면 처음부터 다시 실행하는 전제).</p>
+ *
+ * <pre>
+ * &lt;bean id="safeWriter" class="org.egovframe.rte.bat.core.item.file.EgovSafeFlatFileItemWriter" scope="step"&gt;
+ *     &lt;property name="resource" value="file:/data/batch/out/daily.dat"/&gt;
+ *     &lt;property name="lineAggregator" ref="lineAggregator"/&gt;
+ *     &lt;property name="maxFileSizeBytes" value="1073741824"/&gt;
+ * &lt;/bean&gt;
+ * </pre>
+ *
+ * @param <T> 항목 타입
+ * @author 실행환경 개발팀
+ * @since 5.1
+ * @version 1.0
+ * <pre>
+ * 개정이력(Modification Information)
+ *
+ * 수정일		수정자				수정내용
+ * ----------------------------------------------
+ * 2026.09.10	실행환경 개발팀		최초 생성
+ * </pre>
+ */
+public class EgovSafeFlatFileItemWriter<T> extends FlatFileItemWriter<T> implements StepExecutionListener {
+
+    /** 임시 파일 접미사 */
+    public static final String TMP_SUFFIX = ".egovtmp";
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(EgovSafeFlatFileItemWriter.class);
+
+    private WritableResource finalResource;
+    private LineAggregator<T> sizeCheckAggregator;
+    private String encoding = StandardCharsets.UTF_8.name();
+    private String lineSeparator = FlatFileItemWriter.DEFAULT_LINE_SEPARATOR;
+    private long maxFileSizeBytes = 0L;
+    private long writtenBytes = 0L;
+
+    private File finalFile;
+    private File tmpFile;
+
+    public EgovSafeFlatFileItemWriter() {
+        // 실패 시 임시 파일을 지우는 정책과 재시작 이어쓰기는 양립하지 않는다 — 전체 재실행 전제
+        setSaveState(false);
+        super.setEncoding(encoding);
+    }
+
+    /**
+     * 최종 산출 파일. 쓰기는 같은 디렉터리의 {@code .egovtmp} 임시 파일에 한다.
+     */
+    @Override
+    public void setResource(WritableResource resource) {
+        this.finalResource = resource;
+    }
+
+    @Override
+    public void setLineAggregator(LineAggregator<T> lineAggregator) {
+        this.sizeCheckAggregator = lineAggregator;
+        super.setLineAggregator(lineAggregator);
+    }
+
+    @Override
+    public void setEncoding(String newEncoding) {
+        this.encoding = newEncoding;
+        super.setEncoding(newEncoding);
+    }
+
+    @Override
+    public void setLineSeparator(String lineSeparator) {
+        this.lineSeparator = lineSeparator;
+        super.setLineSeparator(lineSeparator);
+    }
+
+    /**
+     * 산출 파일 최대 크기(byte). 초과가 예상되는 청크는 쓰기 전에 거부된다(기본 0 = 제한 없음).
+     */
+    public void setMaxFileSizeBytes(long maxFileSizeBytes) {
+        this.maxFileSizeBytes = maxFileSizeBytes;
+    }
+
+    @Override
+    public void open(ExecutionContext executionContext) throws ItemStreamException {
+        if (finalResource == null) {
+            throw new ItemStreamException("resource must be set on EgovSafeFlatFileItemWriter");
+        }
+        try {
+            finalFile = finalResource.getFile();
+        } catch (IOException ex) {
+            throw new ItemStreamException("Failed to resolve output file from resource", ex);
+        }
+        File parentDirectory = finalFile.getParentFile();
+        if (parentDirectory != null && !parentDirectory.exists() && !parentDirectory.mkdirs() && !parentDirectory.exists()) {
+            throw new ItemStreamException("Failed to create output directory: " + parentDirectory);
+        }
+        tmpFile = new File(parentDirectory, finalFile.getName() + TMP_SUFFIX);
+        if (tmpFile.exists() && !tmpFile.delete()) {
+            throw new ItemStreamException("Failed to delete stale temporary file: " + tmpFile);
+        }
+        writtenBytes = 0L;
+        super.setResource(new FileSystemResource(tmpFile));
+        super.open(executionContext);
+        LOGGER.debug("EgovSafeFlatFileItemWriter writing to temporary file: {}", tmpFile);
+    }
+
+    @Override
+    public void write(Chunk<? extends T> items) throws Exception {
+        if (maxFileSizeBytes > 0) {
+            long chunkBytes = estimateChunkBytes(items);
+            if (writtenBytes + chunkBytes > maxFileSizeBytes) {
+                throw new WriteFailedException("Output file size limit exceeded for '" + finalFile.getName()
+                        + "': written=" + writtenBytes + "B, chunk=" + chunkBytes + "B, max=" + maxFileSizeBytes + "B");
+            }
+            super.write(items);
+            writtenBytes += chunkBytes;
+        } else {
+            super.write(items);
+        }
+    }
+
+    @Override
+    public ExitStatus afterStep(StepExecution stepExecution) {
+        close();
+        if (tmpFile == null) {
+            return stepExecution.getExitStatus();
+        }
+        if (stepExecution.getStatus() == BatchStatus.COMPLETED) {
+            try {
+                try {
+                    Files.move(tmpFile.toPath(), finalFile.toPath(),
+                            StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE);
+                } catch (IOException atomicUnsupported) {
+                    Files.move(tmpFile.toPath(), finalFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
+                }
+                LOGGER.info("Batch output committed: {} -> {}", tmpFile.getName(), finalFile);
+            } catch (IOException ex) {
+                throw new ItemStreamException("Failed to commit output file: " + finalFile, ex);
+            }
+        } else {
+            if (tmpFile.exists() && tmpFile.delete()) {
+                LOGGER.warn("Batch step not completed (status={}); incomplete output removed: {}",
+                        stepExecution.getStatus(), tmpFile);
+            }
+        }
+        return stepExecution.getExitStatus();
+    }
+
+    private long estimateChunkBytes(Chunk<? extends T> items) throws IOException {
+        long separatorBytes = lineSeparator.getBytes(encoding).length;
+        long bytes = 0;
+        for (T item : items) {
+            bytes += sizeCheckAggregator.aggregate(item).getBytes(encoding).length + separatorBytes;
+        }
+        return bytes;
+    }
+
+}

--- a/Batch/org.egovframe.rte.bat.core/src/test/java/org/egovframe/rte/bat/core/item/file/EgovSafeFlatFileItemWriterTest.java
+++ b/Batch/org.egovframe.rte.bat.core/src/test/java/org/egovframe/rte/bat/core/item/file/EgovSafeFlatFileItemWriterTest.java
@@ -1,0 +1,132 @@
+package org.egovframe.rte.bat.core.item.file;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.batch.core.BatchStatus;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.StepExecution;
+import org.springframework.batch.item.Chunk;
+import org.springframework.batch.item.ExecutionContext;
+import org.springframework.batch.item.ItemStreamException;
+import org.springframework.batch.item.WriteFailedException;
+import org.springframework.batch.item.file.transform.PassThroughLineAggregator;
+import org.springframework.core.io.FileSystemResource;
+
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * EgovSafeFlatFileItemWriter 의 임시 파일 쓰기와 완료 시 원자적 교체, 실패 시 정리, 최대 크기 가드를 검증한다.
+ */
+public class EgovSafeFlatFileItemWriterTest {
+
+    @TempDir
+    Path tempDir;
+
+    private EgovSafeFlatFileItemWriter<String> writer(File destination, long maxBytes) throws Exception {
+        EgovSafeFlatFileItemWriter<String> writer = new EgovSafeFlatFileItemWriter<>();
+        writer.setResource(new FileSystemResource(destination));
+        writer.setLineAggregator(new PassThroughLineAggregator<>());
+        writer.setLineSeparator("\n");
+        if (maxBytes > 0) {
+            writer.setMaxFileSizeBytes(maxBytes);
+        }
+        writer.afterPropertiesSet();
+        return writer;
+    }
+
+    private StepExecution stepExecution(BatchStatus status) {
+        StepExecution stepExecution = new StepExecution("safeWriteStep", new JobExecution(1L));
+        stepExecution.setStatus(status);
+        return stepExecution;
+    }
+
+    @Test
+    public void testCompletedStepMovesTemporaryFileToFinalName() throws Exception {
+        File destination = tempDir.resolve("out.dat").toFile();
+        File tmp = tempDir.resolve("out.dat" + EgovSafeFlatFileItemWriter.TMP_SUFFIX).toFile();
+        EgovSafeFlatFileItemWriter<String> writer = writer(destination, 0);
+
+        writer.open(new ExecutionContext());
+        writer.write(new Chunk<>(List.of("LINE-1", "LINE-2")));
+        assertTrue(tmp.exists());
+        assertFalse(destination.exists());
+
+        writer.afterStep(stepExecution(BatchStatus.COMPLETED));
+
+        assertTrue(destination.exists());
+        assertFalse(tmp.exists());
+        assertEquals(List.of("LINE-1", "LINE-2"), Files.readAllLines(destination.toPath(), StandardCharsets.UTF_8));
+    }
+
+    @Test
+    public void testFailedStepRemovesIncompleteOutput() throws Exception {
+        File destination = tempDir.resolve("fail.dat").toFile();
+        File tmp = tempDir.resolve("fail.dat" + EgovSafeFlatFileItemWriter.TMP_SUFFIX).toFile();
+        EgovSafeFlatFileItemWriter<String> writer = writer(destination, 0);
+
+        writer.open(new ExecutionContext());
+        writer.write(new Chunk<>(List.of("PARTIAL")));
+        writer.afterStep(stepExecution(BatchStatus.FAILED));
+
+        assertFalse(destination.exists());
+        assertFalse(tmp.exists());
+    }
+
+    @Test
+    public void testCompletedStepReplacesExistingOutput() throws Exception {
+        File destination = tempDir.resolve("replace.dat").toFile();
+        Files.write(destination.toPath(), List.of("OLD-CONTENT"), StandardCharsets.UTF_8);
+        EgovSafeFlatFileItemWriter<String> writer = writer(destination, 0);
+
+        writer.open(new ExecutionContext());
+        writer.write(new Chunk<>(List.of("NEW-CONTENT")));
+        writer.afterStep(stepExecution(BatchStatus.COMPLETED));
+
+        assertEquals(List.of("NEW-CONTENT"), Files.readAllLines(destination.toPath(), StandardCharsets.UTF_8));
+    }
+
+    @Test
+    public void testMaxFileSizeGuardRejectsOversizedChunkBeforeWriting() throws Exception {
+        File destination = tempDir.resolve("limited.dat").toFile();
+        File tmp = tempDir.resolve("limited.dat" + EgovSafeFlatFileItemWriter.TMP_SUFFIX).toFile();
+        // "12345678" + "\n" = 9 bytes 허용, 이어지는 "X" + "\n" = 2 bytes 로 한도 10 초과
+        EgovSafeFlatFileItemWriter<String> writer = writer(destination, 10);
+
+        writer.open(new ExecutionContext());
+        writer.write(new Chunk<>(List.of("12345678")));
+        WriteFailedException ex = assertThrows(WriteFailedException.class, () -> writer.write(new Chunk<>(List.of("X"))));
+        assertTrue(ex.getMessage().contains("size limit"), ex.getMessage());
+
+        writer.afterStep(stepExecution(BatchStatus.FAILED));
+        assertFalse(tmp.exists());
+        assertFalse(destination.exists());
+    }
+
+    @Test
+    public void testOpenWithoutResourceIsRejectedAndStaleTemporaryFileIsReplaced() throws Exception {
+        EgovSafeFlatFileItemWriter<String> noResource = new EgovSafeFlatFileItemWriter<>();
+        noResource.setLineAggregator(new PassThroughLineAggregator<>());
+        assertThrows(ItemStreamException.class, () -> noResource.open(new ExecutionContext()));
+
+        File destination = tempDir.resolve("stale.dat").toFile();
+        File tmp = tempDir.resolve("stale.dat" + EgovSafeFlatFileItemWriter.TMP_SUFFIX).toFile();
+        Files.write(tmp.toPath(), List.of("LEFTOVER"), StandardCharsets.UTF_8);
+        EgovSafeFlatFileItemWriter<String> writer = writer(destination, 0);
+
+        writer.open(new ExecutionContext());
+        writer.write(new Chunk<>(List.of("FRESH")));
+        writer.afterStep(stepExecution(BatchStatus.COMPLETED));
+
+        assertEquals(List.of("FRESH"), Files.readAllLines(destination.toPath(), StandardCharsets.UTF_8));
+    }
+
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [ ] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [X] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

### 배경

`FlatFileItemWriter` 는 최종 파일명에 바로 씁니다. Step 이 중간에 실패하면 **불완전한 산출물이 최종 파일명으로 남고**, 후속
시스템(전송·적재 배치)이 미완성 파일을 집어가는 사고가 생깁니다. 산출 파일의 크기를 통제할 수단도 없어 잘못된 입력이
디스크를 채우는 것을 막지 못합니다.

### 추가한 것

**`item/file/EgovSafeFlatFileItemWriter<T>`** — `FlatFileItemWriter<T>` + `StepExecutionListener`

| 안전장치 | 내용 |
|---|---|
| 원자적 완료 | 임시 파일(`<파일명>.egovtmp`)에 쓰고 Step 이 **COMPLETED 일 때만** 최종 파일명으로 옮긴다(`ATOMIC_MOVE`, 미지원 파일시스템은 일반 이동). 기존 파일은 교체 |
| 실패 시 정리 | Step 이 완료되지 않으면 임시 파일을 지워 불완전 산출물을 남기지 않는다 |
| 최대 크기 가드 | `maxFileSizeBytes`(기본 0 = 제한 없음) 초과가 예상되는 청크를 쓰기 전에 거부한다. 라인 집계 결과의 인코딩 바이트 수로 미리 계산하며, 위반 시 표준 `WriteFailedException` |

```xml
<bean id="safeWriter" class="org.egovframe.rte.bat.core.item.file.EgovSafeFlatFileItemWriter" scope="step">
    <property name="resource" value="file:/data/batch/out/daily.dat"/>
    <property name="lineAggregator" ref="lineAggregator"/>
    <property name="maxFileSizeBytes" value="1073741824"/>
</bean>
```

### 설계 메모

- **기존 클래스는 수정하지 않았고 의존도 추가하지 않았습니다.** Step 의 writer 로 등록하면 `ItemStream` 과
  `StepExecutionListener` 가 함께 등록되어 별도 설정이 없습니다.
- 실패 시 임시 파일을 지우는 정책은 재시작 이어쓰기(`saveState`)와 양립하지 않으므로 `saveState` 는 false 로 고정됩니다
  (실패하면 처음부터 다시 실행하는 전제). javadoc 에 명시했습니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

`EgovSafeFlatFileItemWriterTest` **5건 신규**(`@TempDir`), `bat.core` 모듈은 Linux 전건 통과, Windows 는 기존 테스트 1건이 `main` 에서도 실패(아래 표).

| 환경 | 기본 로케일(Locale) | 모듈 실행 건수 | 결과 |
|---|---|---:|---|
| **Windows** | ko_KR | **106** | `Tests run: 106, Failures: 1, Errors: 0, Skipped: 0` — 실패 1건은 이 PR 과 무관한 기존 테스트 `DefaultItemGuidanceKeyTest.writerDelimitedFileGuidance` 로, 변경 없는 `main`(`cc2b332`) 에서도 Windows 에서만 같은 실패가 납니다(Linux 는 통과). 신규 5건은 통과 |
| **Linux** (Ubuntu 22.04 / OpenJDK 17) | C.UTF-8 | **106** | `Tests run: 106, Failures: 0, Errors: 0, Skipped: 0` |

| 구분 | 건수 | 내용 |
|---|---:|---|
| 원자적 완료 | 2 | 쓰는 동안은 임시 파일만 있고, 완료 시 최종 파일명으로 옮겨진다 · 기존 파일은 교체된다 |
| 실패 정리 | 1 | 실패한 Step 의 임시 파일이 지워지고 최종 파일은 만들어지지 않는다 |
| 크기 가드 | 1 | 한도(10B)를 넘는 청크는 `WriteFailedException` 으로 거부되고 실패 정리까지 이어진다 |
| 계약 | 1 | resource 없이 open 하면 `ItemStreamException` · 이전 실행이 남긴 임시 파일은 새 내용으로 교체 |

**수동 확인**: 현재 `main`(`cc2b332`) 위에서 `bat.core` 모듈 빌드·테스트가 Linux 에서 전건 통과함을 확인했습니다. Windows 에서 실패하는 `DefaultItemGuidanceKeyTest.writerDelimitedFileGuidance` 1건은 변경 전 `main` 에서도 같은 방식으로 실패해 이 PR 과 무관합니다.

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

해당 없음 — 배치 라이브러리 클래스 추가입니다.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

해당 없음 — 위 JUnit 테스트 결과로 갈음합니다.

---

<sub>base: `eGovFramework:main` @ `cc2b332` (2026-09-10 fetch 기준, #366~#379 머지 후) · 단일 커밋</sub>
