### PR TITLE
feat: 배치 Job·Step 식별자를 MDC 에 싣는 리스너와 실행 요약 로그 리스너 추가

### DIFF
--- a/Batch/org.egovframe.rte.bat.core/src/main/java/org/egovframe/rte/bat/core/operation/EgovBatchMdcListener.java
+++ b/Batch/org.egovframe.rte.bat.core/src/main/java/org/egovframe/rte/bat/core/operation/EgovBatchMdcListener.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2009-2026 MOIS(Ministry of the Interior and Safety).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.egovframe.rte.bat.core.operation;
+
+import org.slf4j.MDC;
+import org.springframework.batch.core.ExitStatus;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.JobExecutionListener;
+import org.springframework.batch.core.StepExecution;
+import org.springframework.batch.core.StepExecutionListener;
+
+/**
+ * Job·Step 식별자를 SLF4J MDC 에 싣는 리스너.
+ *
+ * <p>Log4j2 RoutingAppender 와 조합하면 <b>Job 별 로그 파일 분리</b>를 재기동 없이 구성할 수 있다.</p>
+ *
+ * <pre>
+ * &lt;Routing name="batchRouting"&gt;
+ *     &lt;Routes pattern="$${ctx:batchJobName}"&gt;
+ *         &lt;Route&gt;
+ *             &lt;File name="job-${ctx:batchJobName}" fileName="logs/batch/${ctx:batchJobName}.log"&gt;...&lt;/File&gt;
+ *         &lt;/Route&gt;
+ *     &lt;/Routes&gt;
+ * &lt;/Routing&gt;
+ * </pre>
+ *
+ * <p>MDC 키: {@value #MDC_JOB_NAME}, {@value #MDC_JOB_EXECUTION_ID}, {@value #MDC_STEP_NAME}.
+ * 멀티스레드 Step(taskExecutor)에서는 MDC 가 워커 스레드로 자동 전파되지 않는다.</p>
+ *
+ * @author 실행환경 개발팀
+ * @since 5.1
+ * @version 1.0
+ * <pre>
+ * 개정이력(Modification Information)
+ *
+ * 수정일		수정자				수정내용
+ * ----------------------------------------------
+ * 2026.09.10	실행환경 개발팀		최초 생성
+ * </pre>
+ */
+public class EgovBatchMdcListener implements JobExecutionListener, StepExecutionListener {
+
+    /** Job 이름 MDC 키 */
+    public static final String MDC_JOB_NAME = "batchJobName";
+    /** JobExecution ID MDC 키 */
+    public static final String MDC_JOB_EXECUTION_ID = "batchJobExecutionId";
+    /** Step 이름 MDC 키 */
+    public static final String MDC_STEP_NAME = "batchStepName";
+
+    @Override
+    public void beforeJob(JobExecution jobExecution) {
+        MDC.put(MDC_JOB_NAME, jobExecution.getJobInstance().getJobName());
+        MDC.put(MDC_JOB_EXECUTION_ID, String.valueOf(jobExecution.getId()));
+    }
+
+    @Override
+    public void afterJob(JobExecution jobExecution) {
+        MDC.remove(MDC_JOB_NAME);
+        MDC.remove(MDC_JOB_EXECUTION_ID);
+        MDC.remove(MDC_STEP_NAME);
+    }
+
+    @Override
+    public void beforeStep(StepExecution stepExecution) {
+        MDC.put(MDC_STEP_NAME, stepExecution.getStepName());
+    }
+
+    @Override
+    public ExitStatus afterStep(StepExecution stepExecution) {
+        MDC.remove(MDC_STEP_NAME);
+        return stepExecution.getExitStatus();
+    }
+
+}

--- a/Batch/org.egovframe.rte.bat.core/src/main/java/org/egovframe/rte/bat/core/operation/EgovBatchSummaryListener.java
+++ b/Batch/org.egovframe.rte.bat.core/src/main/java/org/egovframe/rte/bat/core/operation/EgovBatchSummaryListener.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2009-2026 MOIS(Ministry of the Interior and Safety).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.egovframe.rte.bat.core.operation;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.JobExecutionListener;
+import org.springframework.batch.core.StepExecution;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+
+/**
+ * Job 종료 시 실행 결과를 key=value 한 줄로 남기는 리스너.
+ *
+ * <p>전용 로거 {@value #SUMMARY_LOGGER_NAME}(INFO)로 출력하므로 로깅 설정에서 관제·수집 시스템으로 라우팅하기 쉽다.
+ * 상세 시계열 지표는 Spring Batch 5 에 내장된 Micrometer 관측(spring.batch.job / spring.batch.step 타이머)을 쓰고,
+ * 이 리스너는 실행 단위 요약 한 줄만 담당한다.</p>
+ *
+ * <p>출력 예:</p>
+ * <pre>
+ * job=dailyStatsJob executionId=42 status=COMPLETED exitCode=COMPLETED durationMs=15320 steps=2 read=10000 written=9987 skipped=13 filtered=0
+ * </pre>
+ *
+ * @author 실행환경 개발팀
+ * @since 5.1
+ * @version 1.0
+ * <pre>
+ * 개정이력(Modification Information)
+ *
+ * 수정일		수정자				수정내용
+ * ----------------------------------------------
+ * 2026.09.10	실행환경 개발팀		최초 생성
+ * </pre>
+ */
+public class EgovBatchSummaryListener implements JobExecutionListener {
+
+    /** 실행 요약 전용 로거명 */
+    public static final String SUMMARY_LOGGER_NAME = "EGOV_BATCH_SUMMARY";
+
+    private static final Logger SUMMARY = LoggerFactory.getLogger(SUMMARY_LOGGER_NAME);
+
+    @Override
+    public void afterJob(JobExecution jobExecution) {
+        SUMMARY.info(buildSummary(jobExecution));
+    }
+
+    /**
+     * JobExecution 의 실행 요약 문자열(key=value 한 줄)을 만든다. 건수는 Step 실행 결과를 합산한다.
+     *
+     * @param jobExecution 요약할 JobExecution
+     * @return 요약 한 줄
+     */
+    static String buildSummary(JobExecution jobExecution) {
+        long readCount = 0;
+        long writeCount = 0;
+        long skipCount = 0;
+        long filterCount = 0;
+        for (StepExecution stepExecution : jobExecution.getStepExecutions()) {
+            readCount += stepExecution.getReadCount();
+            writeCount += stepExecution.getWriteCount();
+            skipCount += stepExecution.getSkipCount();
+            filterCount += stepExecution.getFilterCount();
+        }
+
+        StringBuilder builder = new StringBuilder();
+        builder.append("job=").append(jobExecution.getJobInstance() == null
+                ? "?" : jobExecution.getJobInstance().getJobName());
+        builder.append(" executionId=").append(jobExecution.getId());
+        builder.append(" status=").append(jobExecution.getStatus());
+        builder.append(" exitCode=").append(jobExecution.getExitStatus() == null
+                ? "?" : jobExecution.getExitStatus().getExitCode());
+        builder.append(" durationMs=").append(durationMillis(jobExecution.getStartTime(), jobExecution.getEndTime()));
+        builder.append(" steps=").append(jobExecution.getStepExecutions().size());
+        builder.append(" read=").append(readCount);
+        builder.append(" written=").append(writeCount);
+        builder.append(" skipped=").append(skipCount);
+        builder.append(" filtered=").append(filterCount);
+        return builder.toString();
+    }
+
+    private static long durationMillis(LocalDateTime startTime, LocalDateTime endTime) {
+        if (startTime == null || endTime == null) {
+            return -1;
+        }
+        return Duration.between(startTime, endTime).toMillis();
+    }
+
+}

--- a/Batch/org.egovframe.rte.bat.core/src/test/java/org/egovframe/rte/bat/core/operation/EgovBatchListenersTest.java
+++ b/Batch/org.egovframe.rte.bat.core/src/test/java/org/egovframe/rte/bat/core/operation/EgovBatchListenersTest.java
@@ -1,0 +1,90 @@
+package org.egovframe.rte.bat.core.operation;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.MDC;
+import org.springframework.batch.core.BatchStatus;
+import org.springframework.batch.core.ExitStatus;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.JobInstance;
+import org.springframework.batch.core.StepExecution;
+
+import java.time.LocalDateTime;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * EgovBatchMdcListener 의 MDC 키 주입·제거와 EgovBatchSummaryListener 의 실행 요약 형식을 검증한다.
+ */
+public class EgovBatchListenersTest {
+
+    @AfterEach
+    public void clearMdc() {
+        MDC.clear();
+    }
+
+    private JobExecution jobExecution(String jobName, long executionId) {
+        JobExecution jobExecution = new JobExecution(executionId);
+        jobExecution.setJobInstance(new JobInstance(1L, jobName));
+        return jobExecution;
+    }
+
+    @Test
+    public void testMdcListenerPutsAndClearsJobAndStepKeys() {
+        EgovBatchMdcListener listener = new EgovBatchMdcListener();
+        JobExecution jobExecution = jobExecution("mdcJob", 11L);
+
+        listener.beforeJob(jobExecution);
+        assertEquals("mdcJob", MDC.get(EgovBatchMdcListener.MDC_JOB_NAME));
+        assertEquals("11", MDC.get(EgovBatchMdcListener.MDC_JOB_EXECUTION_ID));
+
+        StepExecution stepExecution = new StepExecution("step1", jobExecution);
+        listener.beforeStep(stepExecution);
+        assertEquals("step1", MDC.get(EgovBatchMdcListener.MDC_STEP_NAME));
+
+        listener.afterStep(stepExecution);
+        assertNull(MDC.get(EgovBatchMdcListener.MDC_STEP_NAME));
+        assertEquals("mdcJob", MDC.get(EgovBatchMdcListener.MDC_JOB_NAME));
+
+        listener.afterJob(jobExecution);
+        assertNull(MDC.get(EgovBatchMdcListener.MDC_JOB_NAME));
+        assertNull(MDC.get(EgovBatchMdcListener.MDC_JOB_EXECUTION_ID));
+    }
+
+    @Test
+    public void testSummaryAggregatesStepCounts() {
+        JobExecution jobExecution = jobExecution("dailyStatsJob", 42L);
+        jobExecution.setStatus(BatchStatus.COMPLETED);
+        jobExecution.setExitStatus(ExitStatus.COMPLETED);
+        jobExecution.setStartTime(LocalDateTime.now().minusSeconds(15));
+        jobExecution.setEndTime(LocalDateTime.now());
+        StepExecution step1 = jobExecution.createStepExecution("step1");
+        step1.setReadCount(10000);
+        step1.setWriteCount(9987);
+        step1.setReadSkipCount(13);
+        StepExecution step2 = jobExecution.createStepExecution("step2");
+        step2.setReadCount(500);
+        step2.setWriteCount(500);
+        step2.setFilterCount(7);
+
+        String summary = EgovBatchSummaryListener.buildSummary(jobExecution);
+
+        assertTrue(summary.startsWith("job=dailyStatsJob executionId=42 status=COMPLETED exitCode=COMPLETED durationMs="), summary);
+        assertTrue(summary.endsWith(" steps=2 read=10500 written=10487 skipped=13 filtered=7"), summary);
+    }
+
+    @Test
+    public void testSummaryHandlesMissingTimesAndInstance() {
+        JobExecution jobExecution = new JobExecution(7L);
+        jobExecution.setStatus(BatchStatus.FAILED);
+
+        String summary = EgovBatchSummaryListener.buildSummary(jobExecution);
+
+        assertTrue(summary.startsWith("job=? executionId=7 status=FAILED"), summary);
+        assertTrue(summary.contains(" durationMs=-1 "), summary);
+        assertTrue(summary.endsWith(" steps=0 read=0 written=0 skipped=0 filtered=0"), summary);
+    }
+
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [ ] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [X] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

### 배경

배치 로그는 여러 Job 이 한 파일에 섞여 Job 별로 나누거나 실행 단위(JobExecution)로 추적하기 어렵습니다. 실행이 끝났을 때
읽기·쓰기·건너뜀 건수를 한 줄로 남기는 표준 지점도 없어 관제·수집 시스템이 상세 로그를 파싱해야 합니다.

### 추가한 것

**1. `operation/EgovBatchMdcListener`** — `JobExecutionListener` + `StepExecutionListener`

Job 이름·JobExecution ID·Step 이름을 SLF4J MDC 에 넣고 종료 시 지웁니다.

| MDC 키 | 값 | 주입/제거 |
|---|---|---|
| `batchJobName` | Job 이름 | beforeJob / afterJob |
| `batchJobExecutionId` | JobExecution ID | beforeJob / afterJob |
| `batchStepName` | Step 이름 | beforeStep / afterStep |

Log4j2 `RoutingAppender` 와 조합하면 **Job 별 로그 파일 분리**를 재기동 없이 구성할 수 있습니다.

```xml
<Routing name="batchRouting">
    <Routes pattern="$${ctx:batchJobName}">
        <Route>
            <File name="job-${ctx:batchJobName}" fileName="logs/batch/${ctx:batchJobName}.log">...</File>
        </Route>
    </Routes>
</Routing>
```

**2. `operation/EgovBatchSummaryListener`** — `JobExecutionListener`

Job 종료 시 전용 로거 `EGOV_BATCH_SUMMARY`(INFO)에 실행 결과를 key=value 한 줄로 남깁니다. 값은 Step 실행 결과를 합산합니다.

```
job=dailyStatsJob executionId=42 status=COMPLETED exitCode=COMPLETED durationMs=15320 steps=2 read=10000 written=9987 skipped=13 filtered=0
```

### 설계 메모

- **기존 클래스는 수정하지 않았고 의존도 추가하지 않았습니다.** 두 리스너 모두 빈으로 등록해 Job 에 붙이는 방식이라
  등록하지 않은 애플리케이션에는 영향이 없습니다.
- 멀티스레드 Step(`taskExecutor`)에서는 MDC 가 워커 스레드로 자동 전파되지 않는 점을 javadoc 에 명시했습니다.
- 상세 시계열 지표는 Spring Batch 5 에 내장된 Micrometer 관측(`spring.batch.job` / `spring.batch.step`)을 쓰고, 이 리스너는
  실행 단위 요약 한 줄만 담당합니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

`EgovBatchListenersTest` **3건 신규**, `bat.core` 모듈은 Linux 전건 통과, Windows 는 기존 테스트 1건이 `main` 에서도 실패(아래 표).

| 환경 | 기본 로케일(Locale) | 모듈 실행 건수 | 결과 |
|---|---|---:|---|
| **Windows** | ko_KR | **104** | `Tests run: 104, Failures: 1, Errors: 0, Skipped: 0` — 실패 1건은 이 PR 과 무관한 기존 테스트 `DefaultItemGuidanceKeyTest.writerDelimitedFileGuidance` 로, 변경 없는 `main`(`cc2b332`) 에서도 Windows 에서만 같은 실패가 납니다(Linux 는 통과). 신규 3건은 통과 |
| **Linux** (Ubuntu 22.04 / OpenJDK 17) | C.UTF-8 | **104** | `Tests run: 104, Failures: 0, Errors: 0, Skipped: 0` |

| 구분 | 건수 | 내용 |
|---|---:|---|
| MDC | 1 | beforeJob·beforeStep 에서 키가 들어가고 afterStep 은 Step 키만, afterJob 은 전부 지운다 |
| 요약 | 1 | Step 2개의 read·written·skipped·filtered 합산과 job·executionId·status·steps·durationMs 항목 |
| 경계 | 1 | 시작·종료 시각이 없으면 `durationMs=-1`, JobInstance 가 없으면 `job=?` |

**수동 확인**: 현재 `main`(`cc2b332`) 위에서 `bat.core` 모듈 빌드·테스트가 Linux 에서 전건 통과함을 확인했습니다. Windows 에서 실패하는 `DefaultItemGuidanceKeyTest.writerDelimitedFileGuidance` 1건은 변경 전 `main` 에서도 같은 방식으로 실패해 이 PR 과 무관합니다.

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

해당 없음 — 배치 라이브러리 클래스 추가입니다.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

해당 없음 — 위 JUnit 테스트 결과로 갈음합니다.

---

<sub>base: `eGovFramework:main` @ `cc2b332` (2026-09-10 fetch 기준, #366~#379 머지 후) · 단일 커밋</sub>
