### PR TITLE
feat: 연계 메타데이터를 Hibernate 없이 쓰는 InMemory·JDBC 저장소 추가

### DIFF
--- a/Integration/org.egovframe.rte.itl.integration/pom.xml
+++ b/Integration/org.egovframe.rte.itl.integration/pom.xml
@@ -56,6 +56,13 @@
             <artifactId>spring-orm</artifactId>
             <version>${spring.framework.version}</version>
         </dependency>
+        <!-- 연계 메타데이터 JDBC 저장소(EgovJdbcIntegrationMetadataStore)가 직접 쓴다. spring-orm 을 통해 이미 전이되므로 optional -->
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-jdbc</artifactId>
+            <version>${spring.framework.version}</version>
+            <optional>true</optional>
+        </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-test</artifactId>

--- a/Integration/org.egovframe.rte.itl.integration/src/main/java/org/egovframe/rte/itl/integration/metadata/store/EgovInMemoryIntegrationMetadataStore.java
+++ b/Integration/org.egovframe.rte.itl.integration/src/main/java/org/egovframe/rte/itl/integration/metadata/store/EgovInMemoryIntegrationMetadataStore.java
@@ -1,0 +1,231 @@
+/*
+ * Copyright 2009-2026 MOIS(Ministry of the Interior and Safety).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.egovframe.rte.itl.integration.metadata.store;
+
+import org.egovframe.rte.itl.integration.metadata.IntegrationDefinition;
+import org.egovframe.rte.itl.integration.metadata.OrganizationDefinition;
+import org.egovframe.rte.itl.integration.metadata.RecordTypeDefinition;
+import org.egovframe.rte.itl.integration.metadata.ServiceDefinition;
+import org.egovframe.rte.itl.integration.metadata.SystemDefinition;
+import org.egovframe.rte.itl.integration.metadata.dao.IntegrationDefinitionDao;
+import org.egovframe.rte.itl.integration.metadata.dao.OrganizationDefinitionDao;
+import org.egovframe.rte.itl.integration.metadata.dao.RecordTypeDefinitionDao;
+import org.egovframe.rte.itl.integration.metadata.dao.ServiceDefinitionDao;
+import org.egovframe.rte.itl.integration.metadata.dao.SystemDefinitionDao;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * 연계 메타데이터 InMemory 저장소 — DAO 5종 계약을 Hibernate 없이 한 클래스로 구현한다.
+ *
+ * <p>연계 정의(기관→시스템→서비스 그래프, 연계, 레코드타입)를 프로그램이나 설정으로 등록해 쓴다. 메타데이터 로딩에 ORM 을
+ * 요구하는 {@code dao.hibernate.*} 의 대체 구현이며, 다른 저장소(JDBC 등)는
+ * {@link #reload(Collection, Collection, Collection)} 로 스냅숏을 교체하는 방식으로 이 클래스를 확장한다.</p>
+ *
+ * <p><b>불변 스냅숏 교체</b>: 조회는 volatile 스냅숏(불변 인덱스)에서 잠금 없이 하고, reload 는 새 인덱스를 조립해
+ * 원자적으로 교체한다. 조회 중인 스레드는 이전 스냅숏을, 이후 스레드는 새 스냅숏을 본다.</p>
+ *
+ * @author 실행환경 개발팀
+ * @since 5.1
+ * @version 1.0
+ * <pre>
+ * 개정이력(Modification Information)
+ *
+ * 수정일		수정자				수정내용
+ * ----------------------------------------------
+ * 2026.09.10	실행환경 개발팀		최초 생성
+ * </pre>
+ */
+public class EgovInMemoryIntegrationMetadataStore implements OrganizationDefinitionDao,
+        SystemDefinitionDao, ServiceDefinitionDao, IntegrationDefinitionDao, RecordTypeDefinitionDao {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(EgovInMemoryIntegrationMetadataStore.class);
+
+    private static final String KEY_SEPARATOR = " ";
+
+    /** 불변 조회 인덱스 스냅숏 */
+    private static final class Snapshot {
+        private static final Snapshot EMPTY = new Snapshot(Map.of(), Map.of(), Map.of(),
+                Map.of(), Map.of(), Map.of(), Map.of(), List.of(), Map.of());
+
+        private final Map<String, OrganizationDefinition> organizationsById;
+        private final Map<String, SystemDefinition> systemsByKey;
+        private final Map<String, SystemDefinition> systemsByOrgAndId;
+        private final Map<String, ServiceDefinition> servicesByKey;
+        private final Map<String, ServiceDefinition> servicesBySystemKeyAndId;
+        private final Map<String, ServiceDefinition> servicesByOrgSystemService;
+        private final Map<String, IntegrationDefinition> integrationsById;
+        private final List<IntegrationDefinition> integrations;
+        private final Map<String, RecordTypeDefinition> recordTypesById;
+
+        private Snapshot(Map<String, OrganizationDefinition> organizationsById,
+                Map<String, SystemDefinition> systemsByKey,
+                Map<String, SystemDefinition> systemsByOrgAndId,
+                Map<String, ServiceDefinition> servicesByKey,
+                Map<String, ServiceDefinition> servicesBySystemKeyAndId,
+                Map<String, ServiceDefinition> servicesByOrgSystemService,
+                Map<String, IntegrationDefinition> integrationsById,
+                List<IntegrationDefinition> integrations,
+                Map<String, RecordTypeDefinition> recordTypesById) {
+            this.organizationsById = Collections.unmodifiableMap(organizationsById);
+            this.systemsByKey = Collections.unmodifiableMap(systemsByKey);
+            this.systemsByOrgAndId = Collections.unmodifiableMap(systemsByOrgAndId);
+            this.servicesByKey = Collections.unmodifiableMap(servicesByKey);
+            this.servicesBySystemKeyAndId = Collections.unmodifiableMap(servicesBySystemKeyAndId);
+            this.servicesByOrgSystemService = Collections.unmodifiableMap(servicesByOrgSystemService);
+            this.integrationsById = Collections.unmodifiableMap(integrationsById);
+            this.integrations = Collections.unmodifiableList(integrations);
+            this.recordTypesById = Collections.unmodifiableMap(recordTypesById);
+        }
+    }
+
+    private volatile Snapshot snapshot = Snapshot.EMPTY;
+
+    /**
+     * 연계 정의로 조회 인덱스를 새로 조립해 원자적으로 교체한다.
+     *
+     * @param organizations 기관 정의(소속 시스템·서비스 그래프 포함, null 허용)
+     * @param integrations  연계 정의(null 허용)
+     * @param recordTypes   레코드타입 정의(null 허용)
+     */
+    public final void reload(Collection<OrganizationDefinition> organizations,
+            Collection<IntegrationDefinition> integrations,
+            Collection<RecordTypeDefinition> recordTypes) {
+        Map<String, OrganizationDefinition> organizationsById = new HashMap<>();
+        Map<String, SystemDefinition> systemsByKey = new HashMap<>();
+        Map<String, SystemDefinition> systemsByOrgAndId = new HashMap<>();
+        Map<String, ServiceDefinition> servicesByKey = new HashMap<>();
+        Map<String, ServiceDefinition> servicesBySystemKeyAndId = new HashMap<>();
+        Map<String, ServiceDefinition> servicesByOrgSystemService = new HashMap<>();
+        if (organizations != null) {
+            for (OrganizationDefinition organization : organizations) {
+                organizationsById.put(organization.getId(), organization);
+                for (SystemDefinition system : organization.getSystems().values()) {
+                    systemsByKey.put(system.getKey(), system);
+                    systemsByOrgAndId.put(key(organization.getId(), system.getId()), system);
+                    for (ServiceDefinition service : system.getServices().values()) {
+                        servicesByKey.put(service.getKey(), service);
+                        servicesBySystemKeyAndId.put(key(system.getKey(), service.getId()), service);
+                        servicesByOrgSystemService.put(
+                                key(organization.getId(), system.getId(), service.getId()), service);
+                    }
+                }
+            }
+        }
+        Map<String, IntegrationDefinition> integrationsById = new HashMap<>();
+        List<IntegrationDefinition> integrationList = new ArrayList<>();
+        if (integrations != null) {
+            for (IntegrationDefinition integration : integrations) {
+                integrationsById.put(integration.getId(), integration);
+                integrationList.add(integration);
+            }
+        }
+        Map<String, RecordTypeDefinition> recordTypesById = new HashMap<>();
+        if (recordTypes != null) {
+            for (RecordTypeDefinition recordType : recordTypes) {
+                recordTypesById.put(recordType.getId(), recordType);
+            }
+        }
+        this.snapshot = new Snapshot(organizationsById, systemsByKey, systemsByOrgAndId,
+                servicesByKey, servicesBySystemKeyAndId, servicesByOrgSystemService,
+                integrationsById, integrationList, recordTypesById);
+        LOGGER.info("Integration metadata snapshot replaced: organizations={}, systems={}, services={}, integrations={}",
+                organizationsById.size(), systemsByKey.size(), servicesByKey.size(), integrationList.size());
+    }
+
+    private static String key(String... parts) {
+        return String.join(KEY_SEPARATOR, parts);
+    }
+
+    @Override
+    public OrganizationDefinition getOrganizationDefinition(String id) {
+        return snapshot.organizationsById.get(id);
+    }
+
+    @Override
+    public SystemDefinition getSystemDefinition(String systemKey) {
+        return snapshot.systemsByKey.get(systemKey);
+    }
+
+    @Override
+    public SystemDefinition getSystemDefinition(String organizationId, String systemId) {
+        return snapshot.systemsByOrgAndId.get(key(organizationId, systemId));
+    }
+
+    @Override
+    public ServiceDefinition getServiceDefinition(String serviceKey) {
+        return snapshot.servicesByKey.get(serviceKey);
+    }
+
+    @Override
+    public ServiceDefinition getServiceDefinition(String systemKey, String serviceId) {
+        return snapshot.servicesBySystemKeyAndId.get(key(systemKey, serviceId));
+    }
+
+    @Override
+    public ServiceDefinition getServiceDefinition(String organizationId, String systemId, String serviceId) {
+        return snapshot.servicesByOrgSystemService.get(key(organizationId, systemId, serviceId));
+    }
+
+    @Override
+    public IntegrationDefinition getIntegrationDefinition(String id) {
+        return snapshot.integrationsById.get(id);
+    }
+
+    @Override
+    public List<IntegrationDefinition> getIntegrationDefinitionOfConsumer(String consumerOrganizationId,
+            String consumerSystemId) {
+        List<IntegrationDefinition> result = new ArrayList<>();
+        for (IntegrationDefinition integration : snapshot.integrations) {
+            SystemDefinition consumer = integration.getConsumer();
+            if (consumer != null && consumer.getOrganization() != null
+                    && consumer.getOrganization().getId().equals(consumerOrganizationId)
+                    && consumer.getId().equals(consumerSystemId)) {
+                result.add(integration);
+            }
+        }
+        return result;
+    }
+
+    @Override
+    public List<IntegrationDefinition> getIntegrationDefinitionOfProvider(String providerOrganizationId,
+            String providerSystemId) {
+        List<IntegrationDefinition> result = new ArrayList<>();
+        for (IntegrationDefinition integration : snapshot.integrations) {
+            ServiceDefinition provider = integration.getProvider();
+            SystemDefinition providerSystem = (provider != null) ? provider.getSystem() : null;
+            if (providerSystem != null && providerSystem.getOrganization() != null
+                    && providerSystem.getOrganization().getId().equals(providerOrganizationId)
+                    && providerSystem.getId().equals(providerSystemId)) {
+                result.add(integration);
+            }
+        }
+        return result;
+    }
+
+    @Override
+    public RecordTypeDefinition getRecordTypeDefinition(String id) {
+        return snapshot.recordTypesById.get(id);
+    }
+
+}

--- a/Integration/org.egovframe.rte.itl.integration/src/main/java/org/egovframe/rte/itl/integration/metadata/store/EgovJdbcIntegrationMetadataStore.java
+++ b/Integration/org.egovframe.rte.itl.integration/src/main/java/org/egovframe/rte/itl/integration/metadata/store/EgovJdbcIntegrationMetadataStore.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2009-2026 MOIS(Ministry of the Interior and Safety).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.egovframe.rte.itl.integration.metadata.store;
+
+import org.egovframe.rte.itl.integration.metadata.IntegrationDefinition;
+import org.egovframe.rte.itl.integration.metadata.OrganizationDefinition;
+import org.egovframe.rte.itl.integration.metadata.ServiceDefinition;
+import org.egovframe.rte.itl.integration.metadata.SystemDefinition;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import javax.sql.DataSource;
+import java.sql.Timestamp;
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * 연계 메타데이터 JDBC 저장소 — 표준 테이블(EGOV_ITL_*)에서 정의 그래프를 읽는다.
+ *
+ * <p>Hibernate 매핑 없이 표준 JDBC 로 연계 정의를 읽는 구현이다. 조회는 {@link EgovInMemoryIntegrationMetadataStore} 의
+ * 불변 스냅숏에서 하고, {@link #reload()} 를 부르면 DB 를 다시 읽어 원자적으로 교체한다(재기동 없이 연계 정의 반영).</p>
+ *
+ * <p>표준 테이블(기존 Hibernate 매핑 테이블과 무관한 별도 스키마, DBMS 에 맞게 타입 조정):</p>
+ * <pre>
+ * EGOV_ITL_ORGANIZATION (ORGANIZATION_ID PK, ORGANIZATION_NAME)
+ * EGOV_ITL_SYSTEM       (SYSTEM_KEY PK, ORGANIZATION_ID, SYSTEM_ID, SYSTEM_NAME, STANDARD_YN)
+ * EGOV_ITL_SERVICE      (SERVICE_KEY PK, SYSTEM_KEY, SERVICE_ID, SERVICE_NAME,
+ *                        REQUEST_MESSAGE_TYPE_ID, RESPONSE_MESSAGE_TYPE_ID,
+ *                        SERVICE_PROVIDER_BEAN_ID, STANDARD_YN, USING_YN)
+ * EGOV_ITL_INTEGRATION  (INTEGRATION_ID PK, PROVIDER_SERVICE_KEY, CONSUMER_SYSTEM_KEY,
+ *                        DEFAULT_TIMEOUT, USING_YN, VALIDATE_FROM, VALIDATE_TO)
+ * </pre>
+ *
+ * <p>레코드타입 정의는 이 저장소의 범위 밖이다. 필요하면 {@link #reload(java.util.Collection, java.util.Collection,
+ * java.util.Collection)} 로 따로 등록한다.</p>
+ *
+ * @author 실행환경 개발팀
+ * @since 5.1
+ * @version 1.0
+ * <pre>
+ * 개정이력(Modification Information)
+ *
+ * 수정일		수정자				수정내용
+ * ----------------------------------------------
+ * 2026.09.10	실행환경 개발팀		최초 생성
+ * </pre>
+ */
+public class EgovJdbcIntegrationMetadataStore extends EgovInMemoryIntegrationMetadataStore {
+
+    private final JdbcTemplate jdbcTemplate;
+
+    /**
+     * 저장소를 만들고 최초 로딩을 한다.
+     *
+     * @param dataSource 표준 테이블이 있는 DataSource
+     * @throws IllegalArgumentException dataSource 가 null 인 경우
+     */
+    public EgovJdbcIntegrationMetadataStore(DataSource dataSource) {
+        if (dataSource == null) {
+            throw new IllegalArgumentException("dataSource must not be null");
+        }
+        this.jdbcTemplate = new JdbcTemplate(dataSource);
+        reload();
+    }
+
+    /**
+     * 표준 테이블에서 연계 정의 그래프를 다시 읽어 스냅숏을 교체한다.
+     */
+    public final void reload() {
+        Map<String, OrganizationDefinition> organizations = new HashMap<>();
+        jdbcTemplate.query("SELECT ORGANIZATION_ID, ORGANIZATION_NAME FROM EGOV_ITL_ORGANIZATION", rs -> {
+            OrganizationDefinition organization = new OrganizationDefinition(
+                    rs.getString("ORGANIZATION_ID"), rs.getString("ORGANIZATION_NAME"));
+            organizations.put(organization.getId(), organization);
+        });
+
+        Map<String, SystemDefinition> systemsByKey = new HashMap<>();
+        jdbcTemplate.query("SELECT SYSTEM_KEY, ORGANIZATION_ID, SYSTEM_ID, SYSTEM_NAME, STANDARD_YN"
+                + " FROM EGOV_ITL_SYSTEM", rs -> {
+            OrganizationDefinition organization = organizations.get(rs.getString("ORGANIZATION_ID"));
+            SystemDefinition system = new SystemDefinition(rs.getString("SYSTEM_KEY"), organization,
+                    rs.getString("SYSTEM_ID"), rs.getString("SYSTEM_NAME"), yn(rs.getString("STANDARD_YN")));
+            systemsByKey.put(system.getKey(), system);
+            if (organization != null) {
+                organization.getSystems().put(system.getId(), system);
+            }
+        });
+
+        Map<String, ServiceDefinition> servicesByKey = new HashMap<>();
+        jdbcTemplate.query("SELECT SERVICE_KEY, SYSTEM_KEY, SERVICE_ID, SERVICE_NAME,"
+                + " REQUEST_MESSAGE_TYPE_ID, RESPONSE_MESSAGE_TYPE_ID, SERVICE_PROVIDER_BEAN_ID,"
+                + " STANDARD_YN, USING_YN FROM EGOV_ITL_SERVICE", rs -> {
+            SystemDefinition system = systemsByKey.get(rs.getString("SYSTEM_KEY"));
+            ServiceDefinition service = new ServiceDefinition(rs.getString("SERVICE_KEY"), system,
+                    rs.getString("SERVICE_ID"), rs.getString("SERVICE_NAME"),
+                    rs.getString("REQUEST_MESSAGE_TYPE_ID"), rs.getString("RESPONSE_MESSAGE_TYPE_ID"),
+                    rs.getString("SERVICE_PROVIDER_BEAN_ID"),
+                    yn(rs.getString("STANDARD_YN")), yn(rs.getString("USING_YN")));
+            servicesByKey.put(service.getKey(), service);
+            if (system != null) {
+                system.getServices().put(service.getId(), service);
+            }
+        });
+
+        List<IntegrationDefinition> integrations = new ArrayList<>();
+        jdbcTemplate.query("SELECT INTEGRATION_ID, PROVIDER_SERVICE_KEY, CONSUMER_SYSTEM_KEY,"
+                + " DEFAULT_TIMEOUT, USING_YN, VALIDATE_FROM, VALIDATE_TO FROM EGOV_ITL_INTEGRATION", rs -> {
+            integrations.add(new IntegrationDefinition(rs.getString("INTEGRATION_ID"),
+                    servicesByKey.get(rs.getString("PROVIDER_SERVICE_KEY")),
+                    systemsByKey.get(rs.getString("CONSUMER_SYSTEM_KEY")),
+                    rs.getLong("DEFAULT_TIMEOUT"), yn(rs.getString("USING_YN")),
+                    toCalendar(rs.getTimestamp("VALIDATE_FROM")), toCalendar(rs.getTimestamp("VALIDATE_TO"))));
+        });
+
+        reload(organizations.values(), integrations, null);
+    }
+
+    private static boolean yn(String value) {
+        return "Y".equalsIgnoreCase(value);
+    }
+
+    private static Calendar toCalendar(Timestamp timestamp) {
+        if (timestamp == null) {
+            return null;
+        }
+        Calendar calendar = Calendar.getInstance();
+        calendar.setTimeInMillis(timestamp.getTime());
+        return calendar;
+    }
+
+}

--- a/Integration/org.egovframe.rte.itl.integration/src/test/java/org/egovframe/rte/itl/integration/metadata/store/EgovInMemoryIntegrationMetadataStoreTest.java
+++ b/Integration/org.egovframe.rte.itl.integration/src/test/java/org/egovframe/rte/itl/integration/metadata/store/EgovInMemoryIntegrationMetadataStoreTest.java
@@ -1,0 +1,85 @@
+package org.egovframe.rte.itl.integration.metadata.store;
+
+import org.egovframe.rte.itl.integration.metadata.IntegrationDefinition;
+import org.egovframe.rte.itl.integration.metadata.OrganizationDefinition;
+import org.egovframe.rte.itl.integration.metadata.ServiceDefinition;
+import org.egovframe.rte.itl.integration.metadata.SystemDefinition;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * EgovInMemoryIntegrationMetadataStore 의 DAO 5종 계약과 스냅숏 교체를 검증한다.
+ */
+public class EgovInMemoryIntegrationMetadataStoreTest {
+
+    private EgovInMemoryIntegrationMetadataStore store;
+    private OrganizationDefinition providerOrganization;
+    private SystemDefinition providerSystem;
+    private ServiceDefinition providerService;
+    private SystemDefinition consumerSystem;
+    private IntegrationDefinition integration;
+
+    @BeforeEach
+    public void setUpGraph() {
+        providerOrganization = new OrganizationDefinition("ORG1", "행정안전부");
+        providerSystem = new SystemDefinition("SYS-KEY-1", providerOrganization, "SYS1", "인사시스템", true);
+        providerOrganization.getSystems().put(providerSystem.getId(), providerSystem);
+        providerService = new ServiceDefinition("SVC-KEY-1", providerSystem, "SVC1", "직원조회",
+                "reqType", "resType", "employeeServiceProvider", true, true);
+        providerSystem.getServices().put(providerService.getId(), providerService);
+
+        OrganizationDefinition consumerOrganization = new OrganizationDefinition("ORG2", "국세청");
+        consumerSystem = new SystemDefinition("SYS-KEY-2", consumerOrganization, "SYS2", "세정시스템", false);
+        consumerOrganization.getSystems().put(consumerSystem.getId(), consumerSystem);
+
+        integration = new IntegrationDefinition("INT-001", providerService, consumerSystem, 5000, true, null, null);
+
+        store = new EgovInMemoryIntegrationMetadataStore();
+        store.reload(List.of(providerOrganization, consumerOrganization), List.of(integration), null);
+    }
+
+    @Test
+    public void testOrganizationSystemAndServiceLookupsByKeyAndAlternativeKeys() {
+        assertSame(providerOrganization, store.getOrganizationDefinition("ORG1"));
+        assertSame(providerSystem, store.getSystemDefinition("SYS-KEY-1"));
+        assertSame(providerSystem, store.getSystemDefinition("ORG1", "SYS1"));
+        assertSame(providerService, store.getServiceDefinition("SVC-KEY-1"));
+        assertSame(providerService, store.getServiceDefinition("SYS-KEY-1", "SVC1"));
+        assertSame(providerService, store.getServiceDefinition("ORG1", "SYS1", "SVC1"));
+        assertNull(store.getOrganizationDefinition("ORG-X"));
+        assertNull(store.getServiceDefinition("ORG1", "SYS1", "SVC-X"));
+    }
+
+    @Test
+    public void testIntegrationLookupAndConsumerProviderFilters() {
+        assertSame(integration, store.getIntegrationDefinition("INT-001"));
+
+        List<IntegrationDefinition> ofConsumer = store.getIntegrationDefinitionOfConsumer("ORG2", "SYS2");
+        assertEquals(1, ofConsumer.size());
+        assertSame(integration, ofConsumer.get(0));
+        assertTrue(store.getIntegrationDefinitionOfConsumer("ORG1", "SYS1").isEmpty());
+
+        List<IntegrationDefinition> ofProvider = store.getIntegrationDefinitionOfProvider("ORG1", "SYS1");
+        assertEquals(1, ofProvider.size());
+        assertSame(integration, ofProvider.get(0));
+        assertTrue(store.getIntegrationDefinitionOfProvider("ORG2", "SYS2").isEmpty());
+    }
+
+    @Test
+    public void testReloadReplacesTheSnapshotAtomically() {
+        store.reload(List.of(), List.of(), null);
+
+        assertNull(store.getOrganizationDefinition("ORG1"));
+        assertNull(store.getIntegrationDefinition("INT-001"));
+        assertTrue(store.getIntegrationDefinitionOfConsumer("ORG2", "SYS2").isEmpty());
+        assertNull(store.getRecordTypeDefinition("anyType"));
+    }
+
+}

--- a/Integration/org.egovframe.rte.itl.integration/src/test/java/org/egovframe/rte/itl/integration/metadata/store/EgovJdbcIntegrationMetadataStoreTest.java
+++ b/Integration/org.egovframe.rte.itl.integration/src/test/java/org/egovframe/rte/itl/integration/metadata/store/EgovJdbcIntegrationMetadataStoreTest.java
@@ -1,0 +1,104 @@
+package org.egovframe.rte.itl.integration.metadata.store;
+
+import org.egovframe.rte.itl.integration.metadata.IntegrationDefinition;
+import org.egovframe.rte.itl.integration.metadata.ServiceDefinition;
+import org.hsqldb.jdbc.JDBCDataSource;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.sql.Connection;
+import java.sql.Statement;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * EgovJdbcIntegrationMetadataStore 의 표준 테이블 로딩, 그래프 연결, 재기동 없는 reload 를 HSQLDB 로 검증한다.
+ */
+public class EgovJdbcIntegrationMetadataStoreTest {
+
+    private static JDBCDataSource dataSource;
+
+    @BeforeAll
+    public static void setUpDatabase() throws Exception {
+        dataSource = new JDBCDataSource();
+        dataSource.setURL("jdbc:hsqldb:mem:egovitlmeta");
+        dataSource.setUser("sa");
+        try (Connection connection = dataSource.getConnection();
+                Statement statement = connection.createStatement()) {
+            statement.execute("DROP TABLE EGOV_ITL_INTEGRATION IF EXISTS");
+            statement.execute("DROP TABLE EGOV_ITL_SERVICE IF EXISTS");
+            statement.execute("DROP TABLE EGOV_ITL_SYSTEM IF EXISTS");
+            statement.execute("DROP TABLE EGOV_ITL_ORGANIZATION IF EXISTS");
+            statement.execute("CREATE TABLE EGOV_ITL_ORGANIZATION ("
+                    + "ORGANIZATION_ID VARCHAR(20) PRIMARY KEY, ORGANIZATION_NAME VARCHAR(100))");
+            statement.execute("CREATE TABLE EGOV_ITL_SYSTEM (SYSTEM_KEY VARCHAR(40) PRIMARY KEY,"
+                    + " ORGANIZATION_ID VARCHAR(20), SYSTEM_ID VARCHAR(20), SYSTEM_NAME VARCHAR(100),"
+                    + " STANDARD_YN CHAR(1))");
+            statement.execute("CREATE TABLE EGOV_ITL_SERVICE (SERVICE_KEY VARCHAR(40) PRIMARY KEY,"
+                    + " SYSTEM_KEY VARCHAR(40), SERVICE_ID VARCHAR(20), SERVICE_NAME VARCHAR(100),"
+                    + " REQUEST_MESSAGE_TYPE_ID VARCHAR(40), RESPONSE_MESSAGE_TYPE_ID VARCHAR(40),"
+                    + " SERVICE_PROVIDER_BEAN_ID VARCHAR(60), STANDARD_YN CHAR(1), USING_YN CHAR(1))");
+            statement.execute("CREATE TABLE EGOV_ITL_INTEGRATION (INTEGRATION_ID VARCHAR(20) PRIMARY KEY,"
+                    + " PROVIDER_SERVICE_KEY VARCHAR(40), CONSUMER_SYSTEM_KEY VARCHAR(40),"
+                    + " DEFAULT_TIMEOUT BIGINT, USING_YN CHAR(1), VALIDATE_FROM TIMESTAMP, VALIDATE_TO TIMESTAMP)");
+            statement.execute("INSERT INTO EGOV_ITL_ORGANIZATION VALUES ('ORG1', '행정안전부')");
+            statement.execute("INSERT INTO EGOV_ITL_ORGANIZATION VALUES ('ORG2', '국세청')");
+            statement.execute("INSERT INTO EGOV_ITL_SYSTEM VALUES ('SYS-KEY-1', 'ORG1', 'SYS1', '인사시스템', 'Y')");
+            statement.execute("INSERT INTO EGOV_ITL_SYSTEM VALUES ('SYS-KEY-2', 'ORG2', 'SYS2', '세정시스템', 'N')");
+            statement.execute("INSERT INTO EGOV_ITL_SERVICE VALUES ('SVC-KEY-1', 'SYS-KEY-1', 'SVC1',"
+                    + " '직원조회', 'reqType', 'resType', 'employeeServiceProvider', 'Y', 'Y')");
+            statement.execute("INSERT INTO EGOV_ITL_INTEGRATION VALUES ('INT-001', 'SVC-KEY-1', 'SYS-KEY-2',"
+                    + " 5000, 'Y', TIMESTAMP '2026-01-01 00:00:00', NULL)");
+        }
+    }
+
+    @Test
+    public void testLoadsDefinitionGraphFromStandardTables() {
+        EgovJdbcIntegrationMetadataStore store = new EgovJdbcIntegrationMetadataStore(dataSource);
+
+        ServiceDefinition service = store.getServiceDefinition("ORG1", "SYS1", "SVC1");
+        assertNotNull(service);
+        assertEquals("직원조회", service.getName());
+        assertEquals("employeeServiceProvider", service.getServiceProviderBeanId());
+        assertEquals("ORG1", service.getSystem().getOrganization().getId());
+        assertTrue(service.isStandard());
+
+        IntegrationDefinition integration = store.getIntegrationDefinition("INT-001");
+        assertNotNull(integration);
+        assertEquals(5000, integration.getDefaultTimeout());
+        assertTrue(integration.isUsing());
+        assertNotNull(integration.getValidateFrom());
+
+        List<IntegrationDefinition> ofConsumer = store.getIntegrationDefinitionOfConsumer("ORG2", "SYS2");
+        assertEquals(1, ofConsumer.size());
+        assertEquals(1, store.getIntegrationDefinitionOfProvider("ORG1", "SYS1").size());
+    }
+
+    @Test
+    public void testReloadReflectsChangedDefinitionsWithoutRestart() throws Exception {
+        EgovJdbcIntegrationMetadataStore store = new EgovJdbcIntegrationMetadataStore(dataSource);
+        assertEquals("직원조회", store.getServiceDefinition("SVC-KEY-1").getName());
+        try (Connection connection = dataSource.getConnection();
+                Statement statement = connection.createStatement()) {
+            statement.execute("UPDATE EGOV_ITL_SERVICE SET SERVICE_NAME = '직원조회v2' WHERE SERVICE_KEY = 'SVC-KEY-1'");
+        }
+
+        store.reload();
+
+        assertEquals("직원조회v2", store.getServiceDefinition("SVC-KEY-1").getName());
+        try (Connection connection = dataSource.getConnection();
+                Statement statement = connection.createStatement()) {
+            statement.execute("UPDATE EGOV_ITL_SERVICE SET SERVICE_NAME = '직원조회' WHERE SERVICE_KEY = 'SVC-KEY-1'");
+        }
+    }
+
+    @Test
+    public void testNullDataSourceIsRejected() {
+        assertThrows(IllegalArgumentException.class, () -> new EgovJdbcIntegrationMetadataStore(null));
+    }
+
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [ ] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [X] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

### 배경

연계 메타데이터 DAO 5종(기관·시스템·서비스·연계·레코드타입)의 구현은 Hibernate 매핑 기반 `dao.hibernate.*` 뿐입니다.
연계 정의를 설정·프로그램으로 등록하거나 ORM 없이 JDBC 로 읽으려는 애플리케이션은 DAO 계약 5개를 처음부터 다시 구현해야
합니다.

### 추가한 것

**1. `metadata/store/EgovInMemoryIntegrationMetadataStore`** — DAO 5종 계약을 한 클래스로 구현

| 항목 | 내용 |
|---|---|
| 구현 계약 | `OrganizationDefinitionDao`·`SystemDefinitionDao`·`ServiceDefinitionDao`·`IntegrationDefinitionDao`·`RecordTypeDefinitionDao` |
| `reload(organizations, integrations, recordTypes)` | 기관→시스템→서비스 그래프와 연계·레코드타입으로 조회 인덱스를 새로 조립해 **volatile 불변 스냅숏**으로 원자적으로 교체 |
| 조회 | 잠금 없이 현재 스냅숏에서 조회. 키 조회와 대체 키(기관 ID + 시스템 ID 등) 조회, 소비자·제공자 기준 연계 필터 |

**2. `metadata/store/EgovJdbcIntegrationMetadataStore`** — 표준 테이블에서 JDBC 로 로딩

`EgovInMemoryIntegrationMetadataStore` 를 상속해 `JdbcTemplate` 으로 정의 그래프를 읽고 스냅숏을 교체합니다. `reload()` 로
재기동 없이 변경을 반영합니다. 레코드타입은 이 저장소 범위 밖이며 필요하면 InMemory `reload` 로 따로 등록합니다.

```sql
EGOV_ITL_ORGANIZATION (ORGANIZATION_ID PK, ORGANIZATION_NAME)
EGOV_ITL_SYSTEM       (SYSTEM_KEY PK, ORGANIZATION_ID, SYSTEM_ID, SYSTEM_NAME, STANDARD_YN)
EGOV_ITL_SERVICE      (SERVICE_KEY PK, SYSTEM_KEY, SERVICE_ID, SERVICE_NAME, REQUEST_MESSAGE_TYPE_ID,
                       RESPONSE_MESSAGE_TYPE_ID, SERVICE_PROVIDER_BEAN_ID, STANDARD_YN, USING_YN)
EGOV_ITL_INTEGRATION  (INTEGRATION_ID PK, PROVIDER_SERVICE_KEY, CONSUMER_SYSTEM_KEY, DEFAULT_TIMEOUT, USING_YN,
                       VALIDATE_FROM, VALIDATE_TO)
```

```xml
<bean id="metadataStore" class="org.egovframe.rte.itl.integration.metadata.store.EgovJdbcIntegrationMetadataStore">
    <constructor-arg ref="dataSource"/>
</bean>
<!-- 기존 DAO 주입 지점(예: TypeLoaderUsingMetadata 의 recordTypeDefinitionDao 등)에 같은 빈을 넘긴다 -->
```

### 의존과 호환성

- **기존 클래스는 수정하지 않았습니다.** Hibernate DAO 는 그대로 두고 대체 구현을 더할 뿐입니다.
- 직접 쓰는 `spring-jdbc` 를 pom 에 **optional** 로 명시했습니다. `spring-orm` 을 통해 이미 전이되므로 소비자의 의존은
  바뀌지 않습니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

`EgovInMemoryIntegrationMetadataStoreTest` **3건** + `EgovJdbcIntegrationMetadataStoreTest` **3건**(HSQLDB 인메모리) 신규,
`itl.integration` 모듈 전건 통과.

| 환경 | 기본 로케일(Locale) | 모듈 실행 건수 | 결과 |
|---|---|---:|---|
| **Windows** | ko_KR | **89** | `Tests run: 89, Failures: 0, Errors: 0, Skipped: 0` |
| **Linux** (Ubuntu 22.04 / OpenJDK 17) | C.UTF-8 | **89** | `Tests run: 89, Failures: 0, Errors: 0, Skipped: 0` |

| 구분 | 건수 | 내용 |
|---|---:|---|
| InMemory 조회 | 1 | 기관·시스템(키/기관+ID)·서비스(키/시스템키+ID/기관+시스템+서비스 ID) 조회와 없는 키의 null |
| InMemory 연계 | 1 | 연계 ID 조회, 소비자·제공자 기준 필터 |
| InMemory reload | 1 | 빈 정의로 reload 하면 이전 스냅숏이 사라진다 |
| JDBC 로딩 | 1 | 표준 테이블 4개에서 그래프 로딩(서비스→시스템→기관 연결, 연계의 타임아웃·사용 여부·유효기간) |
| JDBC reload | 1 | DB 값 변경 후 `reload()` 로 재기동 없이 반영 |
| 인자 | 1 | null DataSource 는 `IllegalArgumentException` |

**수동 확인**: 현재 `main`(`cc2b332`) 위에서 `itl.integration` 모듈 빌드·테스트가 통과함을 Windows 와 Linux 에서 확인했습니다.

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

해당 없음 — 연계 라이브러리 클래스 추가입니다.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

해당 없음 — 위 JUnit 테스트 결과로 갈음합니다.

---

<sub>base: `eGovFramework:main` @ `cc2b332` (2026-09-10 fetch 기준, #366~#379 머지 후) · 단일 커밋</sub>
