### PR TITLE
fix(ptl-mvc): 페이징 출력 오류 원인 보존

### DIFF
--- a/Presentation/org.egovframe.rte.ptl.mvc/src/main/java/org/egovframe/rte/ptl/mvc/tags/ui/PaginationTag.java
+++ b/Presentation/org.egovframe.rte.ptl.mvc/src/main/java/org/egovframe/rte/ptl/mvc/tags/ui/PaginationTag.java
@@ -80,7 +80,7 @@ public class PaginationTag extends TagSupport {
             out.println(contents);
             return EVAL_PAGE;
         } catch (IOException e) {
-            throw new JspException();
+            throw new JspException(e);
         }
     }
 

--- a/Presentation/org.egovframe.rte.ptl.mvc/src/test/java/org/egovframe/rte/ptl/mvc/tags/ui/PaginationTagExceptionTest.java
+++ b/Presentation/org.egovframe.rte.ptl.mvc/src/test/java/org/egovframe/rte/ptl/mvc/tags/ui/PaginationTagExceptionTest.java
@@ -1,0 +1,59 @@
+package org.egovframe.rte.ptl.mvc.tags.ui;
+
+import jakarta.servlet.jsp.JspException;
+import jakarta.servlet.jsp.JspWriter;
+import jakarta.servlet.jsp.PageContext;
+import jakarta.servlet.jsp.tagext.Tag;
+import org.egovframe.rte.ptl.mvc.tags.ui.pagination.PaginationInfo;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockJspWriter;
+import org.springframework.mock.web.MockPageContext;
+
+import java.io.IOException;
+import java.io.StringWriter;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class PaginationTagExceptionTest {
+
+    @Test
+    void rendersPaginationAndContinuesPage() throws JspException, IOException {
+        MockPageContext context = new MockPageContext();
+        assertEquals(Tag.EVAL_PAGE, newTag(context).doEndTag());
+        assertTrue(context.getContentAsString().contains("<strong>1</strong>"));
+        assertTrue(context.getContentAsString().contains("goPage(2)"));
+    }
+
+    @Test
+    void preservesOutputFailureAsCause() {
+        IOException failure = new IOException("Cannot write pagination output");
+        JspWriter writer = new MockJspWriter(new StringWriter()) {
+            @Override
+            public void println(String value) throws IOException {
+                throw failure;
+            }
+        };
+        MockPageContext context = new MockPageContext() {
+            @Override
+            public JspWriter getOut() {
+                return writer;
+            }
+        };
+
+        JspException exception = assertThrows(JspException.class, () -> newTag(context).doEndTag());
+        assertSame(failure, exception.getCause());
+    }
+
+    private PaginationTag newTag(PageContext context) {
+        PaginationInfo info = new PaginationInfo();
+        info.setCurrentPageNo(1);
+        info.setPageSize(5);
+        info.setRecordCountPerPage(10);
+        info.setTotalRecordCount(51);
+        PaginationTag tag = new PaginationTag();
+        tag.setPageContext(context);
+        tag.setPaginationInfo(info);
+        tag.setJsFunction("goPage");
+        return tag;
+    }
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

페이징 HTML 출력 중 IOException이 발생하면 원인 없는 JspException으로 바뀌어 실제 실패 원인을 확인하기 어려웠습니다.

## 수정된 소스 내용 Modified source

출력 오류를 JspException의 원인 예외로 전달합니다.
관련 단위 테스트를 추가했습니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

JDK 17에서 관련 JUnit 11건 통과했습니다. 동일 테스트의 수정 전 실행에서는 1건이 실패해 문제 재현을 확인했습니다.
검증 항목: 정상 페이징 HTML 출력과 페이지 처리 계속 진행, 출력 실패 시 원본 IOException 보존.

저장소 루트에서 실행:

```sh
mvn -B -ntp -pl Presentation/org.egovframe.rte.ptl.mvc -am -Dtest=PaginationTagExceptionTest,PaginationTest -Dsurefire.failIfNoSpecifiedTests=false test
```

관련 모듈과 의존 모듈을 컴파일하고 지정한 테스트를 실행했습니다. 전체 모듈 테스트 및 DB·브라우저 통합 테스트는 수행하지 않았습니다.

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

해당 없음: JVM 단위 테스트입니다.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

별도 화면 캡처 없이 자동 테스트 실행 결과를 첨부합니다.

```text
Tests run: 11, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS
```
