### PR TITLE
fix(fdl-string): 컨텍스트 클래스 로더가 없는 경우 처리

### DIFF
--- a/Foundation/org.egovframe.rte.fdl.string/src/main/java/org/egovframe/rte/fdl/string/EgovObjectUtil.java
+++ b/Foundation/org.egovframe.rte.fdl.string/src/main/java/org/egovframe/rte/fdl/string/EgovObjectUtil.java
@@ -79,11 +79,11 @@ public final class EgovObjectUtil {
         if (allowed != null && !allowed.contains(className)) {
             throw new SecurityException("class '" + className + "' is not in the allowed class list");
         }
-        Class<?> clazz = Thread.currentThread().getContextClassLoader().loadClass(className);
-        if (clazz == null) {
-            clazz = Class.forName(className);
+        ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+        if (classLoader == null) {
+            return Class.forName(className, false, EgovObjectUtil.class.getClassLoader());
         }
-        return clazz;
+        return classLoader.loadClass(className);
     }
 
     /**

--- a/Foundation/org.egovframe.rte.fdl.string/src/test/java/org/egovframe/rte/fdl/string/EgovObjectUtilClassLoaderTest.java
+++ b/Foundation/org.egovframe.rte.fdl.string/src/test/java/org/egovframe/rte/fdl/string/EgovObjectUtilClassLoaderTest.java
@@ -1,0 +1,97 @@
+package org.egovframe.rte.fdl.string;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Isolated;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@Isolated("Temporarily changes the class loading allowlist")
+class EgovObjectUtilClassLoaderTest {
+
+    private ClassLoader originalLoader;
+    private Set<String> originalAllowedClasses;
+
+    @BeforeEach
+    @SuppressWarnings("unchecked")
+    void saveClassLoadingConfiguration() {
+        originalLoader = Thread.currentThread().getContextClassLoader();
+        originalAllowedClasses = (Set<String>) ReflectionTestUtils.getField(EgovObjectUtil.class, "allowedClassNames");
+        EgovObjectUtil.setAllowedClassNames(null);
+    }
+
+    @AfterEach
+    void restoreClassLoadingConfiguration() {
+        Thread.currentThread().setContextClassLoader(originalLoader);
+        EgovObjectUtil.setAllowedClassNames(originalAllowedClasses);
+    }
+
+    @Test
+    void usesExistingContextClassLoader() throws ClassNotFoundException {
+        AtomicBoolean called = new AtomicBoolean();
+        Thread.currentThread().setContextClassLoader(new ClassLoader(originalLoader) {
+            @Override
+            public Class<?> loadClass(String name) throws ClassNotFoundException {
+                called.set(true);
+                return super.loadClass(name);
+            }
+        });
+        assertSame(String.class, EgovObjectUtil.loadClass("java.lang.String"));
+        assertTrue(called.get());
+    }
+
+    @Test
+    void loadsBootstrapClassWithoutContextClassLoader() throws ClassNotFoundException {
+        Thread.currentThread().setContextClassLoader(null);
+        assertSame(String.class, EgovObjectUtil.loadClass("java.lang.String"));
+    }
+
+    @Test
+    void loadsApplicationClassWithoutContextClassLoader() throws ClassNotFoundException {
+        Thread.currentThread().setContextClassLoader(null);
+        assertSame(EgovObjectUtil.class, EgovObjectUtil.loadClass(EgovObjectUtil.class.getName()));
+    }
+
+    @Test
+    void instantiatesWithoutContextClassLoader() {
+        Thread.currentThread().setContextClassLoader(null);
+        assertEquals("", EgovObjectUtil.instantiate("java.lang.String"));
+    }
+
+    @Test
+    void instantiatesWithArgumentsWithoutContextClassLoader() {
+        Thread.currentThread().setContextClassLoader(null);
+        Object value = EgovObjectUtil.instantiate("java.lang.StringBuilder", new String[]{"java.lang.String"}, new Object[]{"egov"});
+        assertEquals("egov", value.toString());
+    }
+
+    @Test
+    void reportsMissingClassWithoutContextClassLoader() {
+        Thread.currentThread().setContextClassLoader(null);
+        assertThrows(ClassNotFoundException.class, () -> EgovObjectUtil.loadClass("review.MissingClass"));
+    }
+
+    @Test
+    void doesNotBypassExistingContextClassLoader() {
+        Thread.currentThread().setContextClassLoader(new ClassLoader(originalLoader) {
+            @Override
+            public Class<?> loadClass(String name) throws ClassNotFoundException {
+                throw new ClassNotFoundException(name);
+            }
+        });
+        assertThrows(ClassNotFoundException.class, () -> EgovObjectUtil.loadClass("java.lang.String"));
+    }
+
+    @Test
+    void enforcesAllowlistWithoutContextClassLoader() throws ClassNotFoundException {
+        Thread.currentThread().setContextClassLoader(null);
+        EgovObjectUtil.setAllowedClassNames(Set.of("java.lang.String"));
+        assertSame(String.class, EgovObjectUtil.loadClass("java.lang.String"));
+        assertThrows(SecurityException.class, () -> EgovObjectUtil.loadClass("java.lang.StringBuilder"));
+    }
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

스레드의 컨텍스트 클래스 로더가 null이면 EgovObjectUtil.loadClass()에서 NullPointerException이 발생해 기본 클래스도 로딩하지 못했습니다.

## 수정된 소스 내용 Modified source

컨텍스트 클래스 로더가 없으면 유틸리티의 클래스 로더로 로딩합니다. 기존 클래스 로더와 허용 목록 검사는 유지합니다.
관련 단위 테스트를 추가했습니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

JDK 17에서 관련 JUnit 13건 통과했습니다. 동일 테스트의 수정 전 실행에서는 6건이 실패해 문제 재현을 확인했습니다.
검증 항목: 일반/null 클래스 로더, 기본·애플리케이션 클래스 로딩, 기본·인자 생성자 호출, 없는 클래스와 허용 목록 밖 클래스 거부.

저장소 루트에서 실행:

```sh
mvn -B -ntp -pl Foundation/org.egovframe.rte.fdl.string -am -Dtest=EgovObjectUtilClassLoaderTest,EgovObjectUtilTest -Dsurefire.failIfNoSpecifiedTests=false test
```

관련 모듈과 의존 모듈을 컴파일하고 지정한 테스트를 실행했습니다. 전체 모듈 테스트 및 DB·브라우저 통합 테스트는 수행하지 않았습니다.

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

해당 없음: JVM 단위 테스트입니다.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

별도 화면 캡처 없이 자동 테스트 실행 결과를 첨부합니다.

```text
Tests run: 13, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS
```
