### PR TITLE
fix(bat-core): 여러 글자 구분자의 파일 분리 수정

### DIFF
--- a/Batch/org.egovframe.rte.bat.core/src/main/java/org/egovframe/rte/bat/core/item/file/transform/EgovDelimitedLineTokenizer.java
+++ b/Batch/org.egovframe.rte.bat.core/src/main/java/org/egovframe/rte/bat/core/item/file/transform/EgovDelimitedLineTokenizer.java
@@ -71,6 +71,7 @@ public class EgovDelimitedLineTokenizer extends EgovAbstractLineTokenizer {
      * @param delimiter : delimiter로 사용 할 문자열
      */
     public EgovDelimitedLineTokenizer(String delimiter) {
+        Assert.hasLength(delimiter, "Delimiter must not be null or empty");
         Assert.state(!delimiter.equals(DEFAULT_QUOTE_CHARACTER), DEFAULT_QUOTE_CHARACTER + " is not allowed as delimiter for tokenizers.");
         this.delimiter = delimiter;
         setQuoteCharacter(DEFAULT_QUOTE_CHARACTER);
@@ -82,6 +83,7 @@ public class EgovDelimitedLineTokenizer extends EgovAbstractLineTokenizer {
      * @param delimiter : delimiter로 사용 할 문자열
      */
     public void setDelimiter(String delimiter) {
+        Assert.hasLength(delimiter, "Delimiter must not be null or empty");
         this.delimiter = delimiter;
     }
 
@@ -117,7 +119,7 @@ public class EgovDelimitedLineTokenizer extends EgovAbstractLineTokenizer {
             if (quoteIndex == -1) {
                 lastCut = (delimiterIndex != -1 ? delimiterIndex : length);
                 tokens.add(line.substring(beginIndex, lastCut));
-                beginIndex = lastCut + 1;
+                beginIndex = lastCut + delimiter.length();
             } else {
                 if (quoteIndex < delimiterIndex) {
                     // delimiter보다 앞에 있는 quotation을 발견했을 경우, 이는 첫 quotation(여는 quotation)이므로 다음 quotation(닫는 quotation)을 찾는다.
@@ -128,7 +130,7 @@ public class EgovDelimitedLineTokenizer extends EgovAbstractLineTokenizer {
                         // 마지막 token 인지 체크하여 마지막 token 이라면 끝내고, 아니라면 마지막 자른 위치를 닫는 quotation 문자열 다음 식별자로 한다.
                         if (line.indexOf(quoteCharacter, endQuoteIndex) != -1) {
                             lastCut = line.indexOf(delimiter, endQuoteIndex);
-                            beginIndex = lastCut + 1;
+                            beginIndex = lastCut + delimiter.length();
                         }
                     } else {
                         // 닫는 quotation이 없다면 모든 token 을 하나로 처리한다.
@@ -139,7 +141,7 @@ public class EgovDelimitedLineTokenizer extends EgovAbstractLineTokenizer {
                     // quotation이 delimiter보다 뒤에 있으면 해당 delimiter를 기준으로 자른다.
                     lastCut = (delimiterIndex != -1 ? delimiterIndex : length);
                     tokens.add(line.substring(beginIndex, lastCut));
-                    beginIndex = lastCut + 1;
+                    beginIndex = lastCut + delimiter.length();
                 }
                 quoteIndex = line.indexOf(quoteCharacter, beginIndex);
             }

--- a/Batch/org.egovframe.rte.bat.core/src/test/java/org/egovframe/rte/bat/core/item/file/transform/EgovDelimitedLineTokenizerMultiDelimiterTest.java
+++ b/Batch/org.egovframe.rte.bat.core/src/test/java/org/egovframe/rte/bat/core/item/file/transform/EgovDelimitedLineTokenizerMultiDelimiterTest.java
@@ -1,0 +1,82 @@
+package org.egovframe.rte.bat.core.item.file.transform;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class EgovDelimitedLineTokenizerMultiDelimiterTest {
+
+    @Test
+    void splitsMultiCharacterDelimiterFromConstructor() throws Exception {
+        assertEquals(List.of("A", "B", "C"), new EgovDelimitedLineTokenizer("||").tokenize("A||B||C"));
+    }
+
+    @Test
+    void splitsLongerDelimiterFromSetter() throws Exception {
+        EgovDelimitedLineTokenizer tokenizer = new EgovDelimitedLineTokenizer();
+        tokenizer.setDelimiter("<->");
+        assertEquals(List.of("가", "나", "다"), tokenizer.tokenize("가<->나<->다"));
+    }
+
+    @Test
+    void preservesConsecutiveEmptyFields() throws Exception {
+        assertEquals(List.of("A", "", "B"), new EgovDelimitedLineTokenizer("||").tokenize("A||||B"));
+    }
+
+    @Test
+    void preservesLeadingAndTrailingEmptyFields() throws Exception {
+        assertEquals(List.of("", "A", ""), new EgovDelimitedLineTokenizer("||").tokenize("||A||"));
+    }
+
+    @Test
+    void splitsDelimiterOnlyLine() throws Exception {
+        assertEquals(List.of("", ""), new EgovDelimitedLineTokenizer("||").tokenize("||"));
+    }
+
+    @Test
+    void advancesPastDelimiterAfterQuotedField() throws Exception {
+        assertEquals(List.of("A||B", "C"), new EgovDelimitedLineTokenizer("||").tokenize("\"A||B\"||C"));
+    }
+
+    @Test
+    void advancesPastDelimiterBeforeQuotedField() throws Exception {
+        assertEquals(List.of("A", "B||C", "D"), new EgovDelimitedLineTokenizer("||").tokenize("A||\"B||C\"||D"));
+    }
+
+    @Test
+    void endsAfterQuotedFieldContainingDelimiter() throws Exception {
+        assertEquals(List.of("A", "B||C"), new EgovDelimitedLineTokenizer("||").tokenize("A||\"B||C\""));
+    }
+
+    @Test
+    void preservesLineWithoutDelimiter() throws Exception {
+        assertEquals(List.of("ABC"), new EgovDelimitedLineTokenizer("||").tokenize("ABC"));
+    }
+
+    @Test
+    void preservesSingleCharacterDelimiter() throws Exception {
+        assertEquals(List.of("", "A", "", "B", ""), new EgovDelimitedLineTokenizer(",").tokenize(",A,,B,"));
+    }
+
+    @Test
+    void handlesEmptyAndNullLines() throws Exception {
+        EgovDelimitedLineTokenizer tokenizer = new EgovDelimitedLineTokenizer("||");
+        assertEquals(List.of(), tokenizer.tokenize(""));
+        assertEquals(List.of(), tokenizer.tokenize(null));
+    }
+
+    @Test
+    void rejectsEmptyOrNullDelimiterInConstructor() {
+        assertThrows(IllegalArgumentException.class, () -> new EgovDelimitedLineTokenizer(""));
+        assertThrows(IllegalArgumentException.class, () -> new EgovDelimitedLineTokenizer(null));
+    }
+
+    @Test
+    void rejectsEmptyOrNullDelimiterInSetter() {
+        EgovDelimitedLineTokenizer tokenizer = new EgovDelimitedLineTokenizer();
+        assertThrows(IllegalArgumentException.class, () -> tokenizer.setDelimiter(""));
+        assertThrows(IllegalArgumentException.class, () -> tokenizer.setDelimiter(null));
+    }
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

EgovDelimitedLineTokenizer가 다음 필드 시작 위치를 한 글자만 이동해, 구분자 ||로 A||B||C를 분리하면 A, |B, |C로 처리되었습니다.

## 수정된 소스 내용 Modified source

실제 구분자 길이만큼 이동하도록 수정하고, 처리 위치가 진행되지 않는 빈 구분자와 null 구분자는 설정 단계에서 거부합니다.
관련 단위 테스트를 추가했습니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

JDK 17에서 관련 JUnit 15건 통과했습니다. 동일 테스트의 수정 전 실행에서는 9건이 실패해 문제 재현을 확인했습니다.
검증 항목: 생성자/setter의 여러 글자 구분자, 연속·앞뒤 빈 필드, 따옴표 포함 필드, 한 글자 구분자, 빈 입력 및 잘못된 구분자.

저장소 루트에서 실행:

```sh
mvn -B -ntp -pl Batch/org.egovframe.rte.bat.core -am -Dtest=EgovDelimitedLineTokenizerMultiDelimiterTest,EgovDelimitedLineTokenizerTest -Dsurefire.failIfNoSpecifiedTests=false test
```

관련 모듈과 의존 모듈을 컴파일하고 지정한 테스트를 실행했습니다. 전체 모듈 테스트 및 DB·브라우저 통합 테스트는 수행하지 않았습니다.

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

해당 없음: JVM 단위 테스트입니다.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

별도 화면 캡처 없이 자동 테스트 실행 결과를 첨부합니다.

```text
Tests run: 15, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS
```
