### PR TITLE
fix(bat-core): 단일 열린 바이트 범위 처리 수정

### DIFF
--- a/Batch/org.egovframe.rte.bat.core/src/main/java/org/egovframe/rte/bat/core/item/file/transform/EgovFixedByteLengthTokenizer.java
+++ b/Batch/org.egovframe.rte.bat.core/src/main/java/org/egovframe/rte/bat/core/item/file/transform/EgovFixedByteLengthTokenizer.java
@@ -97,9 +97,7 @@ public class EgovFixedByteLengthTokenizer extends EgovAbstractLineTokenizer {
                 upperBound = ranges[i].getMax();
             } else {
                 upperBound = ranges[i].getMin();
-                if (upperBound > maxRange) {
-                    open = true;
-                }
+                open = true;
             }
             if (upperBound > maxRange) {
                 maxRange = upperBound;

--- a/Batch/org.egovframe.rte.bat.core/src/test/java/org/egovframe/rte/bat/core/item/file/transform/EgovFixedByteLengthTokenizerOpenRangeTest.java
+++ b/Batch/org.egovframe.rte.bat.core/src/test/java/org/egovframe/rte/bat/core/item/file/transform/EgovFixedByteLengthTokenizerOpenRangeTest.java
@@ -1,0 +1,58 @@
+package org.egovframe.rte.bat.core.item.file.transform;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.batch.item.file.transform.IncorrectLineLengthException;
+import org.springframework.batch.item.file.transform.Range;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class EgovFixedByteLengthTokenizerOpenRangeTest {
+
+    @Test
+    void readsEntireAsciiLineWithSingleOpenRange() throws Exception {
+        assertEquals(List.of("ABCDE"), tokenizer(1).tokenize("ABCDE", "UTF-8"));
+    }
+
+    @Test
+    void readsEntireUtf8LineWithSingleOpenRange() throws Exception {
+        EgovFixedByteLengthTokenizer tokenizer = tokenizer(1);
+        tokenizer.setByteEncoding("UTF-8");
+        assertEquals(List.of("가나다"), tokenizer.tokenize("가나다"));
+    }
+
+    @Test
+    void readsEntireEucKrLineWithSingleOpenRange() throws Exception {
+        assertEquals(List.of("가나다"), tokenizer(1).tokenize("가나다", "EUC-KR"));
+    }
+
+    @Test
+    void readsRemainderStartingAtByteOffset() throws Exception {
+        assertEquals(List.of("나다"), tokenizer(4).tokenize("가나다", "UTF-8"));
+    }
+
+    @Test
+    void preservesMinimumLengthValidation() throws Exception {
+        EgovFixedByteLengthTokenizer tokenizer = tokenizer(3);
+        assertEquals(List.of("C"), tokenizer.tokenize("ABC", "UTF-8"));
+        assertThrows(IncorrectLineLengthException.class, () -> tokenizer.tokenize("AB", "UTF-8"));
+    }
+
+    @Test
+    void resetsOpenRangeStateWhenColumnsChange() throws Exception {
+        EgovFixedByteLengthTokenizer tokenizer = tokenizer(1);
+        assertEquals(List.of("ABCDE"), tokenizer.tokenize("ABCDE", "UTF-8"));
+        tokenizer.setColumns(new Range[]{new Range(1, 3)});
+        assertEquals(List.of("ABC"), tokenizer.tokenize("ABC", "UTF-8"));
+        assertThrows(IncorrectLineLengthException.class, () -> tokenizer.tokenize("ABCDE", "UTF-8"));
+        tokenizer.setColumns(new Range[]{new Range(1)});
+        assertEquals(List.of("ABCDE"), tokenizer.tokenize("ABCDE", "UTF-8"));
+    }
+
+    private EgovFixedByteLengthTokenizer tokenizer(int firstByte) {
+        EgovFixedByteLengthTokenizer tokenizer = new EgovFixedByteLengthTokenizer();
+        tokenizer.setColumns(new Range[]{new Range(firstByte)});
+        return tokenizer;
+    }
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

EgovFixedByteLengthTokenizer에 끝 위치가 없는 Range(1) 하나를 지정하면 열린 범위로 인식하지 못해, ABCDE처럼 한 바이트를 넘는 정상 입력을 길이 오류로 거부했습니다.

## 수정된 소스 내용 Modified source

끝 위치가 없는 범위를 최대 길이 계산과 별도로 판정합니다.
관련 단위 테스트를 추가했습니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

JDK 17에서 관련 JUnit 14건 통과했습니다. 동일 테스트의 수정 전 실행에서는 5건이 실패해 문제 재현을 확인했습니다.
검증 항목: 단일 열린 범위의 ASCII·UTF-8·EUC-KR 입력, 시작 바이트 지정, 최소 길이 검증, 범위 재설정 및 기존 닫힌 범위 검사.

저장소 루트에서 실행:

```sh
mvn -B -ntp -pl Batch/org.egovframe.rte.bat.core -am -Dtest=EgovFixedByteLengthTokenizerOpenRangeTest,EgovFixedByteLengthTokenizerTest -Dsurefire.failIfNoSpecifiedTests=false test
```

관련 모듈과 의존 모듈을 컴파일하고 지정한 테스트를 실행했습니다. 전체 모듈 테스트 및 DB·브라우저 통합 테스트는 수행하지 않았습니다.

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

해당 없음: JVM 단위 테스트입니다.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

별도 화면 캡처 없이 자동 테스트 실행 결과를 첨부합니다.

```text
Tests run: 14, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS
```
