### PR TITLE
fix(bat-core): boolean getter 추출 지원

### DIFF
--- a/Batch/org.egovframe.rte.bat.core/src/main/java/org/egovframe/rte/bat/core/reflection/EgovReflectionSupport.java
+++ b/Batch/org.egovframe.rte.bat.core/src/main/java/org/egovframe/rte/bat/core/reflection/EgovReflectionSupport.java
@@ -82,6 +82,15 @@ public class EgovReflectionSupport<T> {
         return method;
     }
 
+    private Method retrieveGetterMethod(Method[] methods, String methodName) {
+        for (Method method : methods) {
+            if (method.getName().equals(methodName) && method.getParameterCount() == 0) {
+                return method;
+            }
+        }
+        return null;
+    }
+
     /**
      * VO 타입의 instance 생성
      *
@@ -168,10 +177,17 @@ public class EgovReflectionSupport<T> {
             try {
                 if (ArrayUtils.isNotEmpty(names) && names.length > 0) {
                     for (int i = 0; i < names.length; i++) {
-                        String strMethod;
                         if (names[i].length() > 0) {
-                            strMethod = "get" + (names[i].substring(0, 1)).toUpperCase(Locale.ROOT) + names[i].substring(1);
-                            localMap.put(names[i], retrieveMethod(localMethods, strMethod));
+                            String suffix = names[i].substring(0, 1).toUpperCase(Locale.ROOT) + names[i].substring(1);
+                            // 기존 getXxx 선택을 유지하고, 없으면 boolean isXxx를 사용한다.
+                            Method getter = retrieveGetterMethod(localMethods, "get" + suffix);
+                            if (getter == null) {
+                                Method booleanGetter = retrieveGetterMethod(localMethods, "is" + suffix);
+                                if (booleanGetter != null && booleanGetter.getReturnType() == boolean.class) {
+                                    getter = booleanGetter;
+                                }
+                            }
+                            localMap.put(names[i], getter);
                         }
                     }
                 }

--- a/Batch/org.egovframe.rte.bat.core/src/test/java/org/egovframe/rte/bat/core/item/file/transform/EgovFieldExtractorBooleanTest.java
+++ b/Batch/org.egovframe.rte.bat.core/src/test/java/org/egovframe/rte/bat/core/item/file/transform/EgovFieldExtractorBooleanTest.java
@@ -1,0 +1,110 @@
+package org.egovframe.rte.bat.core.item.file.transform;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class EgovFieldExtractorBooleanTest {
+
+    @Test
+    void extractsTrueAndFalseFromBooleanGetter() {
+        EgovFieldExtractor<Object> extractor = extractor("enabled");
+
+        assertArrayEquals(new Object[]{true}, extractor.extract(new Flag(true)));
+        assertArrayEquals(new Object[]{false}, extractor.extract(new Flag(false)));
+    }
+
+    @Test
+    void extractsBooleanAndOtherFieldsInConfiguredOrder() {
+        assertArrayEquals(new Object[]{"sample", true},
+                extractor("name", "enabled").extract(new Flag(true)));
+    }
+
+    @Test
+    void keepsExistingGetGetterWhenBothFormsExist() {
+        assertArrayEquals(new Object[]{false}, extractor("enabled").extract(new BothGetters()));
+    }
+
+    @Test
+    void keepsBoxedBooleanGetGetterIncludingNull() {
+        EgovFieldExtractor<Object> extractor = extractor("enabled");
+
+        assertArrayEquals(new Object[]{true}, extractor.extract(new BoxedFlag(true)));
+        assertArrayEquals(new Object[]{false}, extractor.extract(new BoxedFlag(false)));
+        assertArrayEquals(new Object[]{null}, extractor.extract(new BoxedFlag(null)));
+    }
+
+    @Test
+    void supportsInheritedBooleanGetter() {
+        assertArrayEquals(new Object[]{true}, extractor("enabled").extract(new InheritedFlag()));
+    }
+
+    @Test
+    void choosesNoArgumentGetterWhenMethodsAreOverloaded() {
+        assertArrayEquals(new Object[]{true}, extractor("enabled").extract(new OverloadedFlag()));
+    }
+
+    @Test
+    void doesNotUseIsGetterWithBoxedReturnType() {
+        assertThrows(RuntimeException.class, () -> extractor("enabled").extract(new BoxedIsFlag()));
+    }
+
+    @Test
+    void doesNotUseIsGetterWithNonBooleanReturnType() {
+        assertThrows(RuntimeException.class, () -> extractor("enabled").extract(new StringIsFlag()));
+    }
+
+    @Test
+    void doesNotUseIsGetterRequiringAnArgument() {
+        assertThrows(RuntimeException.class, () -> extractor("enabled").extract(new ArgumentIsFlag()));
+    }
+
+    private EgovFieldExtractor<Object> extractor(String... names) {
+        EgovFieldExtractor<Object> extractor = new EgovFieldExtractor<>();
+        extractor.setNames(names);
+        extractor.afterPropertiesSet();
+        return extractor;
+    }
+
+    public static class Flag {
+        private final boolean enabled;
+
+        public Flag(boolean enabled) { this.enabled = enabled; }
+        public boolean isEnabled() { return enabled; }
+        public String getName() { return "sample"; }
+    }
+
+    public static class BothGetters {
+        public boolean getEnabled() { return false; }
+        public boolean isEnabled() { return true; }
+    }
+
+    public static class BoxedFlag {
+        private final Boolean enabled;
+
+        public BoxedFlag(Boolean enabled) { this.enabled = enabled; }
+        public Boolean getEnabled() { return enabled; }
+    }
+
+    public static class InheritedFlag extends Flag {
+        public InheritedFlag() { super(true); }
+    }
+
+    public static class OverloadedFlag {
+        public boolean getEnabled(String ignored) { return false; }
+        public boolean getEnabled() { return true; }
+    }
+
+    public static class BoxedIsFlag {
+        public Boolean isEnabled() { return true; }
+    }
+
+    public static class StringIsFlag {
+        public String isEnabled() { return "true"; }
+    }
+
+    public static class ArgumentIsFlag {
+        public boolean isEnabled(String ignored) { return true; }
+    }
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

boolean 속성에 isEnabled() 형태의 getter만 있으면 필드 추출 시 NullPointerException이 발생했습니다. getter 검색이 getXxx()만 처리하고 있었습니다.

## 수정된 소스 내용 Modified source

인수가 없는 boolean isXxx()를 지원하고, 기존 getXxx()가 있으면 우선 사용합니다. 관련 필드 추출 테스트를 추가했습니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

JDK 17에서 관련 테스트 20건이 통과했습니다. 동일 테스트를 수정 전 코드에 실행하여 실패·오류 3건으로 문제를 재현했습니다.
true/false·상속된 getter·혼합 필드·기존 getXxx()·부적절한 isXxx()를 확인했습니다. 기존 getter 캐시 동시성·로케일·JDBC writer 테스트도 통과했습니다.

저장소 루트에서 실행:

```sh
mvn -B -ntp -Dfile.encoding=UTF-8 -Duser.timezone=Asia/Seoul -pl Batch/org.egovframe.rte.bat.core -am -Dtest=EgovFieldExtractorBooleanTest,EgovFieldExtractorTest,EgovReflectionSupportConcurrencyTest,EgovReflectionSupportLocaleTest,EgovJdbcBatchWriteReflectionTest -Dsurefire.failIfNoSpecifiedTests=false test
```

JVM 단위 테스트이며 JDBC writer의 바인딩은 대역으로 검증했습니다. 전체 저장소 테스트는 실행하지 않았습니다.

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

해당 없음.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

화면 캡처 대신 자동 테스트 실행 결과를 기재합니다.

```text
수정 전: Tests run: 20, Failures: 0, Errors: 3, Skipped: 0
수정 후: Tests run: 20, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS
```
