### PR TITLE
fix(bat-core): 인코딩 지정 시 문자열 분리 결과 반환

### DIFF
--- a/Batch/org.egovframe.rte.bat.core/src/main/java/org/egovframe/rte/bat/core/item/file/transform/EgovAbstractLineTokenizer.java
+++ b/Batch/org.egovframe.rte.bat.core/src/main/java/org/egovframe/rte/bat/core/item/file/transform/EgovAbstractLineTokenizer.java
@@ -67,12 +67,13 @@ public abstract class EgovAbstractLineTokenizer implements EgovLineTokenizer<Obj
 
     /**
      * Encoding Type에 따른 Token 목록을 생성한다.
-     * 실제 구현은 Token을 만드는 방식에 따라 하위 클래스에서 이루어진다.
+     * 문자 단위 분리는 기본 분리 방식을 사용한다.
+     * 인코딩이 필요한 바이트 단위 분리는 하위 클래스에서 재정의한다.
      *
      * @return List String: token 목록
      */
     protected List<String> doTokenize(String line, String encoding) throws Exception {
-        return null;
+        return doTokenize(line);
     }
 
 }

--- a/Batch/org.egovframe.rte.bat.core/src/test/java/org/egovframe/rte/bat/core/item/file/transform/EgovLineTokenizerEncodingTest.java
+++ b/Batch/org.egovframe.rte.bat.core/src/test/java/org/egovframe/rte/bat/core/item/file/transform/EgovLineTokenizerEncodingTest.java
@@ -1,0 +1,79 @@
+package org.egovframe.rte.bat.core.item.file.transform;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.batch.item.file.transform.IncorrectLineLengthException;
+import org.springframework.batch.item.file.transform.Range;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class EgovLineTokenizerEncodingTest {
+
+    @Test
+    void delimitedTokenizerReturnsTokensWithExplicitEncoding() throws Exception {
+        EgovDelimitedLineTokenizer tokenizer = new EgovDelimitedLineTokenizer();
+
+        assertEquals(List.of("A", "B", ""), tokenizer.tokenize("A,B,", "UTF-8"));
+        assertEquals(List.of("가", "나"), tokenizer.tokenize("가,나", "EUC-KR"));
+    }
+
+    @Test
+    void escapableTokenizerPreservesQuotedDelimiter() throws Exception {
+        EgovEscapableDelimitedLineTokenizer tokenizer = new EgovEscapableDelimitedLineTokenizer();
+
+        assertEquals(List.of("\"A,B\"", "C"), tokenizer.tokenize("\"A,B\",C", "UTF-8"));
+    }
+
+    @Test
+    void fixedLengthTokenizerUsesCharacterRanges() throws Exception {
+        EgovFixedLengthTokenizer tokenizer = fixedLengthTokenizer();
+
+        assertEquals(List.of("가나", "AB"), tokenizer.tokenize("가나AB", "UTF-8"));
+        assertEquals(List.of("가나", "AB"), tokenizer.tokenize("가나AB", "EUC-KR"));
+    }
+
+    @Test
+    void emptyAndNullDelimitedLinesKeepSingleArgumentBehavior() throws Exception {
+        EgovAbstractLineTokenizer[] tokenizers = {
+                new EgovDelimitedLineTokenizer(), new EgovEscapableDelimitedLineTokenizer()
+        };
+        for (EgovAbstractLineTokenizer tokenizer : tokenizers) {
+            assertEquals(tokenizer.tokenize(""), tokenizer.tokenize("", "UTF-8"));
+            assertEquals(tokenizer.tokenize(null), tokenizer.tokenize(null, "UTF-8"));
+        }
+    }
+
+    @Test
+    void fixedLengthTokenizerStillRejectsIncorrectLengths() {
+        EgovFixedLengthTokenizer tokenizer = fixedLengthTokenizer();
+        for (String line : new String[]{null, "", "ABC", "ABCDE"}) {
+            assertThrows(IncorrectLineLengthException.class, () -> tokenizer.tokenize(line, "UTF-8"));
+        }
+    }
+
+    @Test
+    void byteTokenizerStillUsesExplicitUtf8Encoding() throws Exception {
+        EgovFixedByteLengthTokenizer tokenizer = new EgovFixedByteLengthTokenizer();
+        tokenizer.setByteEncoding("EUC-KR");
+        tokenizer.setColumns(new Range[]{new Range(1, 3), new Range(4, 6)});
+
+        assertEquals(List.of("가", "나"), tokenizer.tokenize("가나", "UTF-8"));
+    }
+
+    @Test
+    void byteTokenizerStillUsesExplicitEucKrEncoding() throws Exception {
+        EgovFixedByteLengthTokenizer tokenizer = new EgovFixedByteLengthTokenizer();
+        tokenizer.setByteEncoding("UTF-8");
+        tokenizer.setColumns(new Range[]{new Range(1, 2), new Range(3, 4)});
+
+        assertEquals(List.of("가", "나"), tokenizer.tokenize("가나", "EUC-KR"));
+    }
+
+    private EgovFixedLengthTokenizer fixedLengthTokenizer() {
+        EgovFixedLengthTokenizer tokenizer = new EgovFixedLengthTokenizer();
+        tokenizer.setColumns(new Range[]{new Range(1, 2), new Range(3, 4)});
+        return tokenizer;
+    }
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

문자열 tokenizer에서 tokenize(line, encoding)을 호출하면 정상 입력에도 토큰 목록 대신 null을 반환했습니다. 부모 클래스의 인코딩 경로가 기본 분리 로직을 호출하지 않았습니다.

## 수정된 소스 내용 Modified source

문자 단위 tokenizer의 인코딩 경로를 기존 분리 로직에 연결하고, 관련 테스트를 추가했습니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

JDK 17에서 관련 테스트 30건이 통과했습니다. 동일 테스트를 수정 전 코드에 실행하여 실패·오류 5건으로 문제를 재현했습니다.
구분자·따옴표·고정 길이 분리, 빈 값·null·잘못된 길이, 한글 입력을 확인했습니다. 바이트 단위 tokenizer의 UTF-8/EUC-KR 처리도 유지됩니다.

저장소 루트에서 실행:

```sh
mvn -B -ntp -Dfile.encoding=UTF-8 -Duser.timezone=Asia/Seoul -pl Batch/org.egovframe.rte.bat.core -am -Dtest=EgovLineTokenizerEncodingTest,EgovDelimitedLineTokenizerTest,EgovEscapableDelimitedLineTokenizerTest,EgovEscapableDelimitedLineTokenizerEmptyColumnTest,EgovFixedLengthTokenizerTest,EgovFixedByteLengthTokenizerTest -Dsurefire.failIfNoSpecifiedTests=false test
```

JVM 단위 테스트입니다. 여러 글자 구분자 및 열린 바이트 범위의 별도 PR 변경은 포함하지 않습니다. 전체 저장소 테스트는 실행하지 않았습니다.

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

해당 없음.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

화면 캡처 대신 자동 테스트 실행 결과를 기재합니다.

```text
수정 전: Tests run: 30, Failures: 5, Errors: 0, Skipped: 0
수정 후: Tests run: 30, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS
```
