### PR TITLE
fix(bat-core): 배치 변수에 기본 설정 반영

### DIFF
--- a/Batch/org.egovframe.rte.bat.core/src/main/java/org/egovframe/rte/bat/support/EgovResourceVariable.java
+++ b/Batch/org.egovframe.rte.bat.core/src/main/java/org/egovframe/rte/bat/support/EgovResourceVariable.java
@@ -18,7 +18,6 @@ package org.egovframe.rte.bat.support;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
@@ -59,13 +58,10 @@ public class EgovResourceVariable {
 
     public void setPros(Properties pros) {
         LOGGER.debug("### EgovResourceVariable setPros run. ");
-        String key = "";
         synchronized (this.map) {
             map.clear();
             this.pros = pros;
-            Enumeration<Object> keys = this.pros.keys();
-            while (keys.hasMoreElements()) {
-                key = (String) keys.nextElement();
+            for (String key : pros.stringPropertyNames()) {
                 this.map.put(key, pros.getProperty(key));
             }
         }

--- a/Batch/org.egovframe.rte.bat.core/src/test/java/org/egovframe/rte/bat/support/EgovResourceVariablePropertiesTest.java
+++ b/Batch/org.egovframe.rte.bat.core/src/test/java/org/egovframe/rte/bat/support/EgovResourceVariablePropertiesTest.java
@@ -1,0 +1,73 @@
+package org.egovframe.rte.bat.support;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Properties;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class EgovResourceVariablePropertiesTest {
+
+    @Test
+    void includesInheritedDefaultResources() {
+        EgovResourceVariable variable = new EgovResourceVariable();
+        variable.setPros(new Properties(properties("input.resource", "input.csv")));
+
+        assertEquals("input.csv", variable.getVariable("input.resource"));
+        assertEquals("input.csv", variable.getVariableString("input.resource"));
+        assertEquals("input.csv", variable.getVariableMap().get("input.resource"));
+    }
+
+    @Test
+    void explicitValuesOverrideDefaults() {
+        Properties properties = new Properties(properties("input.resource", "default.csv"));
+        properties.setProperty("input.resource", "custom.csv");
+        EgovResourceVariable variable = new EgovResourceVariable();
+        variable.setPros(properties);
+
+        assertEquals("custom.csv", variable.getVariableString("input.resource"));
+    }
+
+    @Test
+    void resolvesMultipleLevelsOfDefaults() {
+        Properties defaults = properties("input.resource", "input.csv");
+        Properties parent = new Properties(defaults);
+        parent.setProperty("output.resource", "output.csv");
+        EgovResourceVariable variable = new EgovResourceVariable();
+        variable.setPros(new Properties(parent));
+
+        assertEquals("input.csv", variable.getVariableString("input.resource"));
+        assertEquals("output.csv", variable.getVariableString("output.resource"));
+    }
+
+    @Test
+    void replacingPropertiesDropsPreviousValuesAndLoadsNewDefaults() {
+        EgovResourceVariable variable = new EgovResourceVariable();
+        variable.setPros(properties("old.resource", "old.csv"));
+        variable.setVariable("temporary", "value");
+
+        variable.setPros(new Properties(properties("input.resource", "new.csv")));
+
+        assertNull(variable.getVariable("old.resource"));
+        assertNull(variable.getVariable("temporary"));
+        assertEquals("new.csv", variable.getVariableString("input.resource"));
+    }
+
+    @Test
+    void emptyPropertiesClearExistingValues() {
+        EgovResourceVariable variable = new EgovResourceVariable();
+        variable.setPros(properties("input.resource", "input.csv"));
+
+        variable.setPros(new Properties());
+
+        assertTrue(variable.getVariableMap().isEmpty());
+    }
+
+    private Properties properties(String key, String value) {
+        Properties properties = new Properties();
+        properties.setProperty(key, value);
+        return properties;
+    }
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

Properties의 defaults에 입력 경로 같은 공통 설정을 두면 getProperty()에서는 읽히지만 배치 변수에서는 누락됐습니다. setPros()가 직접 등록한 키만 순회하고 있었습니다.

## 수정된 소스 내용 Modified source

기본값을 포함한 문자열 키를 읽도록 변경하고, 상속·덮어쓰기·설정 교체 테스트를 추가했습니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

JDK 17에서 관련 테스트 8건이 통과했습니다. 동일 테스트를 수정 전 코드에 실행하여 실패·오류 3건으로 문제를 재현했습니다.
기본값 상속·다단계 상속·명시 값 우선순위·재설정·초기화와 기존 동기화 테스트를 확인했습니다. 기존 Spring Batch 작업 실행 테스트도 통과했습니다.

저장소 루트에서 실행:

```sh
mvn -B -ntp -Dfile.encoding=UTF-8 -Duser.timezone=Asia/Seoul -pl Batch/org.egovframe.rte.bat.core -am -Dtest=EgovResourceVariablePropertiesTest,EgovResourceVariableConcurrencyTest,EgovResourceVariableTest -Dsurefire.failIfNoSpecifiedTests=false test
```

JVM 단위 테스트와 기존 로컬 배치 작업 테스트를 실행했습니다. 브라우저 테스트는 해당하지 않습니다. 전체 저장소 테스트는 실행하지 않았습니다.

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

해당 없음.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

화면 캡처 대신 자동 테스트 실행 결과를 기재합니다.

```text
수정 전: Tests run: 8, Failures: 3, Errors: 0, Skipped: 0
수정 후: Tests run: 8, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS
```
