### PR TITLE
fix(fdl-property): DB 설정 재조회 시 삭제 항목 반영

### DIFF
--- a/Foundation/org.egovframe.rte.fdl.property/src/main/java/org/egovframe/rte/fdl/property/db/DbPropertySourceDelegate.java
+++ b/Foundation/org.egovframe.rte.fdl.property/src/main/java/org/egovframe/rte/fdl/property/db/DbPropertySourceDelegate.java
@@ -21,6 +21,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.jdbc.core.JdbcTemplate;
 
 import javax.sql.DataSource;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -37,7 +38,7 @@ public class DbPropertySourceDelegate {
     public static final String PROPERTY_SOURCE_KEY = "PKEY";
     public static final String PROPERTY_SOURCE_VALUE = "PVALUE";
 
-    private final Map<String, Object> properties = new HashMap<>();
+    private volatile Map<String, Object> properties = Collections.emptyMap();
 
     private final JdbcTemplate jdbcTemplate;
 
@@ -51,6 +52,7 @@ public class DbPropertySourceDelegate {
 
     public void initProperties() {
         List<Map<String, Object>> result = jdbcTemplate.queryForList(sql);
+        Map<String, Object> loadedProperties = new HashMap<>();
         if (ObjectUtils.isNotEmpty(result)) {
             int skippedRowCount = 0;
             Set<String> skippedColumnLabels = null;
@@ -72,7 +74,7 @@ public class DbPropertySourceDelegate {
                         skippedColumnLabels = property.keySet();
                         continue;
                     }
-                    properties.put(pKey, pValue);
+                    loadedProperties.put(pKey, pValue);
                 }
             }
             if (skippedRowCount > 0) {
@@ -80,6 +82,8 @@ public class DbPropertySourceDelegate {
                         skippedRowCount, PROPERTY_SOURCE_KEY, skippedColumnLabels);
             }
         }
+        // 조회와 변환이 모두 끝난 설정을 반영해 실패 시 기존 값을 보존한다.
+        properties = Collections.unmodifiableMap(loadedProperties);
     }
 
     public Object getProperty(String key) {

--- a/Foundation/org.egovframe.rte.fdl.property/src/test/java/org/egovframe/rte/fdl/property/db/DbPropertySourceDelegateReloadTest.java
+++ b/Foundation/org.egovframe.rte.fdl.property/src/test/java/org/egovframe/rte/fdl/property/db/DbPropertySourceDelegateReloadTest.java
@@ -1,0 +1,103 @@
+package org.egovframe.rte.fdl.property.db;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.dao.DataAccessException;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.datasource.embedded.EmbeddedDatabase;
+import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseBuilder;
+import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseType;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class DbPropertySourceDelegateReloadTest {
+
+    private EmbeddedDatabase database;
+    private JdbcTemplate jdbc;
+    private DbPropertySourceDelegate delegate;
+
+    @BeforeEach
+    void setUp() {
+        database = new EmbeddedDatabaseBuilder().generateUniqueName(true)
+                .setType(EmbeddedDatabaseType.HSQL).build();
+        jdbc = new JdbcTemplate(database);
+        createTable("VARCHAR(40)");
+        jdbc.update("INSERT INTO REVIEW_PROPERTY VALUES (?, ?)", "remaining", "before");
+        jdbc.update("INSERT INTO REVIEW_PROPERTY VALUES (?, ?)", "removed", "old");
+        delegate = new DbPropertySourceDelegate(database, "SELECT PKEY, PVALUE FROM REVIEW_PROPERTY");
+    }
+
+    @AfterEach
+    void tearDown() {
+        database.shutdown();
+    }
+
+    @Test
+    void reloadReflectsDeletedUpdatedAndAddedProperties() {
+        jdbc.update("DELETE FROM REVIEW_PROPERTY WHERE PKEY = ?", "removed");
+        jdbc.update("UPDATE REVIEW_PROPERTY SET PVALUE = ? WHERE PKEY = ?", "after", "remaining");
+        jdbc.update("INSERT INTO REVIEW_PROPERTY VALUES (?, ?)", "added", "new");
+
+        delegate.initProperties();
+
+        assertNull(delegate.getProperty("removed"));
+        assertEquals("after", delegate.getProperty("remaining"));
+        assertEquals("new", delegate.getProperty("added"));
+    }
+
+    @Test
+    void emptyQueryResultClearsAllProperties() {
+        jdbc.update("DELETE FROM REVIEW_PROPERTY");
+
+        delegate.initProperties();
+
+        assertNull(delegate.getProperty("remaining"));
+        assertNull(delegate.getProperty("removed"));
+    }
+
+    @Test
+    void queryFailurePreservesPreviousValuesAndAllowsLaterReload() {
+        jdbc.execute("DROP TABLE REVIEW_PROPERTY");
+
+        assertThrows(DataAccessException.class, delegate::initProperties);
+        assertEquals("before", delegate.getProperty("remaining"));
+        assertEquals("old", delegate.getProperty("removed"));
+
+        createTable("VARCHAR(40)");
+        jdbc.update("INSERT INTO REVIEW_PROPERTY VALUES (?, ?)", "recovered", "new");
+        delegate.initProperties();
+
+        assertNull(delegate.getProperty("remaining"));
+        assertNull(delegate.getProperty("removed"));
+        assertEquals("new", delegate.getProperty("recovered"));
+    }
+
+    @Test
+    void invalidColumnTypePreservesPreviousValues() {
+        jdbc.execute("DROP TABLE REVIEW_PROPERTY");
+        createTable("INTEGER");
+        jdbc.update("INSERT INTO REVIEW_PROPERTY VALUES (?, ?)", "remaining", 123);
+
+        assertThrows(ClassCastException.class, delegate::initProperties);
+
+        assertEquals("before", delegate.getProperty("remaining"));
+        assertEquals("old", delegate.getProperty("removed"));
+    }
+
+    @Test
+    void reloadStillAllowsNullPropertyValues() {
+        jdbc.update("UPDATE REVIEW_PROPERTY SET PVALUE = NULL WHERE PKEY = ?", "remaining");
+
+        delegate.initProperties();
+
+        assertNull(delegate.getProperty("remaining"));
+        assertEquals("old", delegate.getProperty("removed"));
+    }
+
+    private void createTable(String valueType) {
+        jdbc.execute("CREATE TABLE REVIEW_PROPERTY (PKEY VARCHAR(40), PVALUE " + valueType + ")");
+    }
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

DB에서 설정을 삭제한 뒤 initProperties()를 다시 호출해도 이전 값이 남았습니다. 조회 결과가 비어도 기존 설정을 비우지 않았습니다.

## 수정된 소스 내용 Modified source

조회·변환이 완료된 설정으로 전체 값을 교체합니다. 실패 시 기존 값을 보존하고, 재조회 테스트를 추가했습니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

JDK 17에서 관련 테스트 9건이 통과했습니다. 동일 테스트를 수정 전 코드에 실행하여 실패·오류 3건으로 문제를 재현했습니다.
HSQLDB에서 삭제·추가·변경·빈 결과·조회 실패 후 복구·잘못된 컬럼 타입·null 값을 검증했습니다. 기존 컬럼명 처리 테스트도 통과했습니다.

저장소 루트에서 실행:

```sh
mvn -B -ntp -Dfile.encoding=UTF-8 -Duser.timezone=Asia/Seoul -pl Foundation/org.egovframe.rte.fdl.property -am -Dtest=DbPropertySourceDelegateReloadTest,DbPropertySourceDelegateTest -Dsurefire.failIfNoSpecifiedTests=false test
```

메모리 HSQLDB와 실제 JdbcTemplate을 사용했습니다. 주기적 갱신 기능은 추가하지 않았습니다. 전체 저장소 테스트는 실행하지 않았습니다.

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

해당 없음.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

화면 캡처 대신 자동 테스트 실행 결과를 기재합니다.

```text
수정 전: Tests run: 9, Failures: 3, Errors: 0, Skipped: 0
수정 후: Tests run: 9, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS
```
