### PR TITLE
fix(psl-dataaccess): 날짜 문자열 유효성 검사 강화

### DIFF
--- a/Persistence/org.egovframe.rte.psl.dataaccess/src/main/java/org/egovframe/rte/psl/dataaccess/typehandler/StringTimestampTypeHandler.java
+++ b/Persistence/org.egovframe.rte.psl.dataaccess/src/main/java/org/egovframe/rte/psl/dataaccess/typehandler/StringTimestampTypeHandler.java
@@ -22,8 +22,12 @@ import com.ibatis.sqlmap.client.extensions.TypeHandlerCallback;
 import java.sql.SQLException;
 import java.sql.Timestamp;
 import java.time.LocalDateTime;
+import java.time.chrono.IsoEra;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
 import java.time.format.DateTimeParseException;
+import java.time.format.ResolverStyle;
+import java.time.temporal.ChronoField;
 
 /**
  * String - Timestamp 변환을 지원하는 TypeHandler 확장 클래스
@@ -55,7 +59,11 @@ public class StringTimestampTypeHandler implements TypeHandlerCallback {
     /**
      * DateTimeFormatter - DATE_FORMAT 기반 포맷터
      */
-    private static final DateTimeFormatter DTF = DateTimeFormatter.ofPattern(DATE_FORMAT);
+    private static final DateTimeFormatter DTF = new DateTimeFormatterBuilder()
+            .appendPattern(DATE_FORMAT)
+            .parseDefaulting(ChronoField.ERA, IsoEra.CE.getValue())
+            .toFormatter()
+            .withResolverStyle(ResolverStyle.STRICT);
 
     /**
      * JDBC 의 Timestamp 로 조회된 값을 resultMap 처리 시 결과
@@ -80,6 +88,7 @@ public class StringTimestampTypeHandler implements TypeHandlerCallback {
      * 맞춰진)으로 세팅된 입력 객체(VO 또는 Map)의 특정 Attribute 로 부터
      * parameterMap(inline parameterMap) 처리 시 JDBC 의
      * Timestamp 로 처리한다.
+     * 존재하지 않는 날짜나 시각은 SQLException으로 처리한다.
      *
      * @param setter    - prepared statement 의 현재 바인드 변수에 대한 값 세팅을 지원하는(index 없이) ibatis 의 ParameterSetter
      * @param parameter - 입력 객체
@@ -93,7 +102,7 @@ public class StringTimestampTypeHandler implements TypeHandlerCallback {
                 Timestamp ts = Timestamp.valueOf(LocalDateTime.parse((String) parameter, DTF));
                 setter.setTimestamp(ts);
             } catch (DateTimeParseException e) {
-                throw new SQLException("Error parsing string to timestamp.  Cause: " + e.getMessage());
+                throw new SQLException("Error parsing string to timestamp.  Cause: " + e.getMessage(), e);
             }
         }
     }

--- a/Persistence/org.egovframe.rte.psl.dataaccess/src/test/java/org/egovframe/rte/psl/dataaccess/typehandler/StringTimestampTypeHandlerValidationTest.java
+++ b/Persistence/org.egovframe.rte.psl.dataaccess/src/test/java/org/egovframe/rte/psl/dataaccess/typehandler/StringTimestampTypeHandlerValidationTest.java
@@ -1,0 +1,108 @@
+package org.egovframe.rte.psl.dataaccess.typehandler;
+
+import com.ibatis.sqlmap.client.extensions.ParameterSetter;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Proxy;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.time.format.DateTimeParseException;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class StringTimestampTypeHandlerValidationTest {
+
+    @Test
+    void rejectsDatesThatDoNotExist() {
+        for (String input : new String[]{"20230229010203", "20240230010203", "20230431010203",
+                "19000229010203", "21000229010203"}) {
+            assertInvalidTimestamp(input);
+        }
+    }
+
+    @Test
+    void rejectsInvalidTimesWithoutRollingIntoNextDay() {
+        for (String input : new String[]{"20240101240000", "20240101250000", "20240101006000", "20240101000060"}) {
+            assertInvalidTimestamp(input);
+        }
+    }
+
+    @Test
+    void preservesParseCauseForMalformedInputs() {
+        for (String input : new String[]{"invalid", "", "20240101", "20241301000000", "00000101000000"}) {
+            assertInvalidTimestamp(input);
+        }
+    }
+
+    @Test
+    void acceptsValidLeapDaysAndMonthEnds() throws SQLException {
+        String[][] inputs = {
+                {"20000229010203", "2000-02-29 01:02:03"},
+                {"20240229010203", "2024-02-29 01:02:03"},
+                {"20230430235959", "2023-04-30 23:59:59"}
+        };
+        for (String[] input : inputs) {
+            AtomicReference<Timestamp> captured = new AtomicReference<>();
+            ParameterSetter setter = setter((method, args) -> {
+                assertEquals("setTimestamp", method);
+                captured.set((Timestamp) args[0]);
+            });
+
+            new StringTimestampTypeHandler().setParameter(setter, input[0]);
+
+            assertEquals(Timestamp.valueOf(input[1]), captured.get());
+        }
+    }
+
+    @Test
+    void nullInputStillBindsSqlNull() throws SQLException {
+        AtomicInteger nullCalls = new AtomicInteger();
+        ParameterSetter setter = setter((method, args) -> {
+            assertEquals("setNull", method);
+            nullCalls.incrementAndGet();
+        });
+
+        new StringTimestampTypeHandler().setParameter(setter, null);
+
+        assertEquals(1, nullCalls.get());
+    }
+
+    @Test
+    void preservesSqlExceptionFromParameterSetter() {
+        SQLException original = new SQLException("binding failed");
+        ParameterSetter setter = setter((method, args) -> { throw original; });
+
+        SQLException actual = assertThrows(SQLException.class,
+                () -> new StringTimestampTypeHandler().setParameter(setter, "20240102030405"));
+
+        assertSame(original, actual);
+    }
+
+    private void assertInvalidTimestamp(String input) {
+        AtomicInteger bindCalls = new AtomicInteger();
+        ParameterSetter setter = setter((method, args) -> bindCalls.incrementAndGet());
+
+        SQLException exception = assertThrows(SQLException.class,
+                () -> new StringTimestampTypeHandler().setParameter(setter, input), input);
+
+        assertInstanceOf(DateTimeParseException.class, exception.getCause(), input);
+        assertEquals(0, bindCalls.get(), input);
+    }
+
+    private ParameterSetter setter(Binding binding) {
+        return (ParameterSetter) Proxy.newProxyInstance(getClass().getClassLoader(),
+                new Class<?>[]{ParameterSetter.class}, (proxy, method, args) -> {
+                    binding.apply(method.getName(), args);
+                    return null;
+                });
+    }
+
+    private interface Binding {
+        void apply(String method, Object[] args) throws SQLException;
+    }
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [ ] 버그수정 Bug fixes
- [X] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

20230229010203처럼 존재하지 않는 날짜가 2023-02-28로 자동 보정되어 바인딩됐습니다. 잘못된 입력을 그대로 식별할 수 있도록 날짜·시각 검증을 강화합니다.

## 수정된 소스 내용 Modified source

기존 날짜 형식에 엄격한 검증을 적용하고, SQLException에 원인 예외를 보존합니다. 잘못된 날짜·시각은 자동 보정 대신 예외로 처리하므로 해당 보정에 의존하는 호출자는 입력 확인이 필요합니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

JDK 17에서 관련 테스트 9건이 통과했습니다. 동일 테스트를 수정 전 코드에 실행하여 실패·오류 3건으로 문제를 재현했습니다.
없는 날짜·윤년·세기 경계·월말·24시 등 잘못된 시각·형식 오류·null·예외 원인·바인딩 실패를 검증했습니다. 기존 정상 왕복 변환과 동시 호출 테스트도 통과했습니다.

저장소 루트에서 실행:

```sh
mvn -B -ntp -Dfile.encoding=UTF-8 -Duser.timezone=Asia/Seoul -pl Persistence/org.egovframe.rte.psl.dataaccess -am -Dtest=StringTimestampTypeHandlerValidationTest,StringTimestampTypeHandlerTest -Dsurefire.failIfNoSpecifiedTests=false test
```

JVM 단위 테스트이며 JDBC 바인딩은 대역으로 검증했습니다. 전체 저장소 테스트는 실행하지 않았습니다.

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

해당 없음.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

화면 캡처 대신 자동 테스트 실행 결과를 기재합니다.

```text
수정 전: Tests run: 9, Failures: 3, Errors: 0, Skipped: 0
수정 후: Tests run: 9, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS
```
